### PR TITLE
Speed selection and creation

### DIFF
--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -215,6 +215,9 @@ export default class AnnotationViewer extends Vue {
   readonly timelapseTextLayer!: IGeoJSFeatureLayer;
 
   @Prop()
+  readonly interactionLayer!: IGeoJSAnnotationLayer;
+
+  @Prop()
   readonly unrollH!: number;
 
   @Prop()
@@ -455,7 +458,7 @@ export default class AnnotationViewer extends Vue {
 
   previewMouseState(mouseState: IMouseState | null) {
     if (this.selectionAnnotation) {
-      this.annotationLayer.removeAnnotation(this.selectionAnnotation);
+      this.interactionLayer.removeAnnotation(this.selectionAnnotation);
     }
 
     const baseStyle = {
@@ -497,13 +500,13 @@ export default class AnnotationViewer extends Vue {
 
     if (this.selectionAnnotation) {
       this.selectionAnnotation.options("specialAnnotation", true);
-      this.annotationLayer.addAnnotation(this.selectionAnnotation);
+      this.interactionLayer.addAnnotation(this.selectionAnnotation);
     }
   }
 
   consumeMouseState(mouseState: IMouseState) {
     if (this.selectionAnnotation) {
-      this.annotationLayer.removeAnnotation(this.selectionAnnotation);
+      this.interactionLayer.removeAnnotation(this.selectionAnnotation);
       this.selectionAnnotation = null;
     }
     const mousePath = mouseState.path;

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -356,7 +356,7 @@ export default class AnnotationViewer extends Vue {
   @Watch("pendingStoreAnnotation")
   pendingAnnotationChanged() {
     if (this.pendingAnnotation) {
-      this.annotationLayer.removeAnnotation(this.pendingAnnotation);
+      this.interactionLayer.removeAnnotation(this.pendingAnnotation);
       this.pendingAnnotation = null;
     }
     if (this.pendingStoreAnnotation) {
@@ -366,7 +366,7 @@ export default class AnnotationViewer extends Vue {
     }
     if (this.pendingAnnotation) {
       this.pendingAnnotation.options("specialAnnotation", true);
-      this.annotationLayer.addAnnotation(this.pendingAnnotation);
+      this.interactionLayer.addAnnotation(this.pendingAnnotation);
     }
   }
 

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -757,11 +757,7 @@ export default class AnnotationViewer extends Vue {
 
   drawTooltips = throttle(this.drawTooltipsNoThrottle, THROTTLE).bind(this);
   drawTooltipsNoThrottle() {
-    // TODO: AR: I should be able to replace the below with the single call to features([]) below. However, when I do so, it doesn't seem to get rid of the text features. Hmm...
-    // this.timelapseTextLayer.features([]);
-    this.textLayer.features().forEach((feature: IGeoJSFeature) => {
-      this.textLayer.deleteFeature(feature);
-    });
+    this.textLayer.clear();
 
     if (this.showTooltips) {
       // One text feature per line as in https://opengeoscience.github.io/geojs/tutorials/text/

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -29,6 +29,7 @@
       :timelapseLayer="mapentry.timelapseLayer"
       :timelapseTextLayer="mapentry.timelapseTextLayer"
       :workerPreviewFeature="mapentry.workerPreviewFeature"
+      :interactionLayer="mapentry.interactionLayer"
       :maps="maps"
       :unrollH="unrollH"
       :unrollW="unrollW"
@@ -859,12 +860,19 @@ export default class ImageViewer extends Vue {
       const timelapseTextLayer = map.createLayer("feature", {
         features: ["text"],
       });
+      const interactionLayer = map.createLayer("annotation", {
+        annotations: [],
+        autoshareRenderer: false,
+        continuousCloseProximity: true,
+        showLabels: false,
+      });
 
       annotationLayer.node().css({ "mix-blend-mode": "unset" });
       workerPreviewLayer.node().css({ "mix-blend-mode": "unset" });
       textLayer.node().css({ "mix-blend-mode": "unset" });
       timelapseLayer.node().css({ "mix-blend-mode": "unset" });
       timelapseTextLayer.node().css({ "mix-blend-mode": "unset" });
+      interactionLayer.node().css({ "mix-blend-mode": "unset" });
 
       const mapentry: IMapEntry = {
         map,
@@ -877,6 +885,7 @@ export default class ImageViewer extends Vue {
         timelapseLayer,
         timelapseTextLayer,
         workerPreviewFeature,
+        interactionLayer,
       };
       Vue.set(this.maps, mllidx, mapentry);
     } else {
@@ -1304,13 +1313,15 @@ export default class ImageViewer extends Vue {
         mapentry.textLayer.zIndex() !== mll.length * 2 + 2 ||
         mapentry.timelapseLayer.zIndex() !== mll.length * 2 + 3 ||
         mapentry.timelapseTextLayer.zIndex() !== mll.length * 2 + 4 ||
-        (mapentry.uiLayer && mapentry.uiLayer.zIndex() !== mll.length * 2 + 5)
+        mapentry.interactionLayer.zIndex() !== mll.length * 2 + 5 ||
+        (mapentry.uiLayer && mapentry.uiLayer.zIndex() !== mll.length * 2 + 6)
       ) {
         mapentry.workerPreviewLayer.moveToTop();
         mapentry.annotationLayer.moveToTop();
         mapentry.textLayer.moveToTop();
         mapentry.timelapseLayer.moveToTop();
         mapentry.timelapseTextLayer.moveToTop();
+        mapentry.interactionLayer.moveToTop();
         if (mapentry.uiLayer) {
           mapentry.uiLayer.moveToTop();
         }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -726,6 +726,7 @@ export interface IGeoJSFeatureLayer extends IGeoJSLayer {
     arg?: IObject,
   ) => T extends "text" ? IGeoJSTextFeature : IGeoJSFeature;
   deleteFeature: (feature: IGeoJSFeature) => IGeoJSFeatureLayer;
+  clear: () => IGeoJSFeatureLayer;
   geoOn: (event: string, handler: Function) => IGeoJSFeatureLayer;
   geoOff: (
     event?: string | string[],

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1306,6 +1306,7 @@ export interface IMapEntry {
   textLayer: IGeoJSFeatureLayer;
   timelapseLayer: IGeoJSAnnotationLayer;
   timelapseTextLayer: IGeoJSFeatureLayer;
+  interactionLayer: IGeoJSAnnotationLayer;
   uiLayer?: IGeoJSUiLayer;
   lowestLayer?: number;
 }


### PR DESCRIPTION
Annotation selection and creation was very slow with large numbers of annotations because interaction annotations were on the same layer as the main annotations. I created a separate interactionLayer to capture all the interactions, making all these interactions much faster.