### PR TITLE
Progress bars

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
@@ -108,6 +108,7 @@ def cacheMaxMerge(self, item):
     if "IndexRange" not in metadata or "IndexStride" not in metadata:
         raise Exception("Specified item is not multi-frame")
     sample = ts.getSingleTile()
+    jobs = []
     for axis in ["Z", "T", "ZT"]:
         if axis != "ZT":
             stride = metadata["IndexStride"].get(f"Index{axis}", 1)
@@ -180,6 +181,7 @@ def cacheMaxMerge(self, item):
                 localJob=True,
                 tileSize=max(ts.tileWidth, ts.tileHeight),
             )
+            jobs.append(str(job["_id"]))
             subs = {}
             for idx, frame in enumerate(multi["sources"][0]["frames"]):
                 framelist = [
@@ -195,6 +197,7 @@ def cacheMaxMerge(self, item):
                 "user": user["_id"],
                 "merge_substitutes": subs,
             }
+    return {"scheduledJobs": jobs}
 
 
 def _updateJob(event):

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -67,16 +67,6 @@
       @cornersChange="setCorners"
     />
     <v-alert
-      v-model="showOptimizedAlert"
-      class="viewer-alert"
-      type="success"
-      dense
-      dismissible
-      transition="slide-x-transition"
-    >
-      Dataset fully loaded and optimized
-    </v-alert>
-    <v-alert
       v-model="showSamToolHelpAlert"
       class="viewer-alert"
       type="info"
@@ -89,30 +79,6 @@
       Shift + click + drag to add box
     </v-alert>
     <div class="bottom-right-container">
-      <div
-        class="progress"
-        v-for="(cacheObj, cacheIdx) in progresses"
-        :key="'cache-' + cacheIdx"
-      >
-        <v-progress-linear
-          :indeterminate="cacheObj.total === 0"
-          :value="
-            cacheObj.total ? (100 * cacheObj.progress) / cacheObj.total : 0
-          "
-          color="#CCC"
-          background-color="blue-grey"
-          style="height: 100%; z-index: inherit"
-        >
-          <strong class="text-center ma-1">
-            {{ cacheObj.title }}
-            <template v-if="cacheObj.total !== 0">
-              {{ ((100 * cacheObj.progress) / cacheObj.total).toFixed(1) }}% ({{
-                cacheObj.progress
-              }}&nbsp;/&nbsp;{{ cacheObj.total }})
-            </template>
-          </strong>
-        </v-progress-linear>
-      </div>
       <v-btn
         v-if="submitPendingAnnotation"
         @click.capture.stop="
@@ -366,8 +332,6 @@ export default class ImageViewer extends Vue {
 
   mapSynchronizationCallbacks: Map<IGeoJSMap, () => void> = new Map();
 
-  histogramCaches: number = 0;
-  cacheProgresses: { progress: number; total: number }[] = [];
   scaleWidget: IGeoJSScaleWidget | null = null;
   scalePixelWidget: IGeoJSScaleWidget | null = null;
 
@@ -388,28 +352,22 @@ export default class ImageViewer extends Vue {
     }
   }
 
-  // Logic to show an alert when the dataset is optimized
+  // // Logic to show an alert when the dataset is optimized
+  // showOptimizedAlert = false;
 
-  showOptimizedAlert = false;
+  // get loadedAndOptimized() {
+  //   return this.cacheProgresses.length === 0 && this.histogramCaches <= 0;
+  // }
 
-  get loadedAndOptimized() {
-    return (
-      this.cacheProgresses.length === 0 &&
-      this.annotationStore.progresses.length === 0 &&
-      this.histogramCaches <= 0
-    );
-  }
+  // @Watch("loadedAndOptimized")
+  // onOptimizedChanged() {
+  //   this.showOptimizedAlert = this.loadedAndOptimized;
+  //   if (this.showOptimizedAlert) {
+  //     setTimeout(() => (this.showOptimizedAlert = false), 3000);
+  //   }
+  // }
 
-  @Watch("loadedAndOptimized")
-  onOptimizedChanged() {
-    this.showOptimizedAlert = this.loadedAndOptimized;
-    if (this.showOptimizedAlert) {
-      setTimeout(() => (this.showOptimizedAlert = false), 3000);
-    }
-  }
-
-  // Logic to show the progress bars
-
+  // Logic to show the layer progress bars
   @Watch("readyLayersCount")
   @Watch("readyLayersTotal")
   onReadyLayersChange() {
@@ -419,49 +377,6 @@ export default class ImageViewer extends Vue {
       total: this.readyLayersTotal,
       title: "Preparing layers",
     });
-  }
-
-  get progresses() {
-    // Merge caching and downloading of annotations and connections
-    const progresses: {
-      progress: number;
-      total: number;
-      title: string;
-    }[] = [];
-    if (!this.layersReady) {
-      progresses.push({
-        progress: this.readyLayersCount,
-        total: this.readyLayersTotal,
-        title: "Preparing layers",
-      });
-    }
-    if (this.histogramCaches > 0) {
-      progresses.push({
-        progress: 0,
-        total: 0,
-        title: "Computing histograms",
-      });
-    }
-    for (const progress of this.cacheProgresses) {
-      progresses.push({ ...progress, title: "Optimizing performance" });
-    }
-    for (const progress of this.annotationStore.progresses) {
-      if (!progress.annotationDone) {
-        progresses.push({
-          progress: progress.annotationProgress,
-          total: progress.annotationTotal,
-          title: "Downloading annotations",
-        });
-      }
-      if (!progress.connectionDone) {
-        progresses.push({
-          progress: progress.connectionProgress,
-          total: progress.connectionTotal,
-          title: "Downloading connections",
-        });
-      }
-    }
-    return progresses;
   }
 
   get readyLayersCount() {
@@ -589,50 +504,15 @@ export default class ImageViewer extends Vue {
     return llist;
   }
 
+  // TODO: This currently does nothing. However, this used to be where the
+  // histogram cachine was reloaded based on the running jobs. We could implement
+  // something like that again if we want to show the progress bars for the
+  // various caching processes (histograms, annotations, quad frames, etc.).
   async datasetReset() {
-    // Get histogram progresses
-    this.histogramCaches = 0;
     const datasetId = this.dataset?.id;
     if (!datasetId) {
       return;
     }
-    const girderJobs = await this.store.api.findJobs(
-      "large_image_cache_histograms",
-      [jobStates.inactive, jobStates.queued, jobStates.running],
-    );
-    const validityPromises = girderJobs.map(async (girderJob: any) => {
-      const largeImageId = girderJob?.kwargs?.itemId;
-      if (!largeImageId) {
-        return false;
-      }
-      const largeImageItem = await this.girderResources.getItem(largeImageId);
-      return !!largeImageItem && datasetId === largeImageItem.folderId;
-    });
-    const validityArray = await Promise.all(validityPromises);
-    const filteredJobs = girderJobs.filter((_, i) => validityArray[i]);
-    filteredJobs.forEach((girderJob: any) => {
-      const jobId = girderJob._id;
-      let cacheIncreased = false;
-      // Increase number of caching histograms when running
-      const eventCallback = (jobInfo: any) => {
-        const newStatus = jobInfo.status;
-        if (
-          !cacheIncreased &&
-          typeof newStatus === "number" &&
-          newStatus === jobStates.running
-        ) {
-          ++this.histogramCaches;
-          cacheIncreased = true;
-        }
-      };
-      eventCallback(girderJob);
-      jobs.addJob({ jobId, datasetId, eventCallback }).then(() => {
-        // Decrease number of caching histograms if it has been increased
-        if (cacheIncreased) {
-          --this.histogramCaches;
-        }
-      });
-    });
   }
 
   mouseState: IMouseState | null = null;
@@ -1218,16 +1098,10 @@ export default class ImageViewer extends Vue {
           } else {
             if (!fullLayer.setFrameQuad) {
               const progessObject = { progress: 0, total: 0 };
-              this.cacheProgresses.push(progessObject);
               setFrameQuad(someImage.tileinfo, fullLayer, baseQuadOptions, {
                 progress: (status: ISetQuadStatus) => {
                   progessObject.progress = status.loadedCount;
                   progessObject.total = status.totalToLoad;
-                  if (progessObject.progress >= progessObject.total) {
-                    this.cacheProgresses = this.cacheProgresses.filter(
-                      (obj) => obj !== progessObject,
-                    );
-                  }
                 },
               });
             }

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="image" v-mousetrap="mousetrapAnnotations">
+    <progress-bar-group />
     <v-dialog v-model="scaleDialog">
       <v-card>
         <v-card-title> Scale settings </v-card-title>
@@ -165,6 +166,7 @@
 //  $('.geojs-map').data('data-geojs-map')
 import { Vue, Component, Watch } from "vue-property-decorator";
 import annotationStore from "@/store/annotation";
+import progressStore from "@/store/progress";
 import store from "@/store";
 import girderResources from "@/store/girderResources";
 import geojs from "geojs";
@@ -182,12 +184,14 @@ import {
   IMouseState,
   SamAnnotationToolStateSymbol,
   IGeoJSMap,
+  ProgressType,
 } from "../store/model";
 import setFrameQuad, { ISetQuadStatus } from "@/utils/setFrameQuad";
 
 import AnnotationViewer from "@/components/AnnotationViewer.vue";
 import ImageOverview from "@/components/ImageOverview.vue";
 import ScaleSettings from "@/components/ScaleSettings.vue";
+import ProgressBarGroup from "@/components/ProgressBarGroup.vue";
 import LayerInfoGrid from "./LayerInfoGrid.vue";
 import { ITileHistogram } from "@/store/images";
 import { convertLength } from "@/utils/conversion";
@@ -254,7 +258,13 @@ function isMouseStartEvent(evt: MouseEvent): boolean {
 }
 
 @Component({
-  components: { AnnotationViewer, ImageOverview, ScaleSettings, LayerInfoGrid },
+  components: {
+    AnnotationViewer,
+    ImageOverview,
+    ScaleSettings,
+    LayerInfoGrid,
+    ProgressBarGroup,
+  },
 })
 export default class ImageViewer extends Vue {
   readonly store = store;

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -161,7 +161,6 @@ import ProgressBarGroup from "@/components/ProgressBarGroup.vue";
 import LayerInfoGrid from "./LayerInfoGrid.vue";
 import { ITileHistogram } from "@/store/images";
 import { convertLength } from "@/utils/conversion";
-import jobs, { jobStates } from "@/store/jobs";
 import { IHotkey } from "@/utils/v-mousetrap";
 import { NoOutput } from "@/pipelines/computePipeline";
 import { logWarning } from "@/utils/log";

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -410,6 +410,17 @@ export default class ImageViewer extends Vue {
 
   // Logic to show the progress bars
 
+  @Watch("readyLayersCount")
+  @Watch("readyLayersTotal")
+  onReadyLayersChange() {
+    progressStore.updateReactiveProgress({
+      type: ProgressType.LAYER_CACHE,
+      progress: this.readyLayersCount,
+      total: this.readyLayersTotal,
+      title: "Preparing layers",
+    });
+  }
+
   get progresses() {
     // Merge caching and downloading of annotations and connections
     const progresses: {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -351,21 +351,6 @@ export default class ImageViewer extends Vue {
     }
   }
 
-  // // Logic to show an alert when the dataset is optimized
-  // showOptimizedAlert = false;
-
-  // get loadedAndOptimized() {
-  //   return this.cacheProgresses.length === 0 && this.histogramCaches <= 0;
-  // }
-
-  // @Watch("loadedAndOptimized")
-  // onOptimizedChanged() {
-  //   this.showOptimizedAlert = this.loadedAndOptimized;
-  //   if (this.showOptimizedAlert) {
-  //     setTimeout(() => (this.showOptimizedAlert = false), 3000);
-  //   }
-  // }
-
   // Logic to show the layer progress bars
   @Watch("readyLayersCount")
   @Watch("readyLayersTotal")

--- a/src/components/ProgressBarGroup.vue
+++ b/src/components/ProgressBarGroup.vue
@@ -84,16 +84,20 @@ export default class ProgressBarGroup extends Vue {
       // Single progress case
       if (items.length === 1) {
         const progress = items[0];
+        const isIndeterminate = progress.total === 0;
         return {
           type,
           display: "single",
           title: progress.title,
-          progress: progress.progress,
-          total: progress.total,
-          value: progress.total
-            ? (100 * progress.progress) / progress.total
-            : 0,
-          indeterminate: progress.total === 0,
+          indeterminate: isIndeterminate,
+          // Only set total and progress if we actually have a total.
+          ...(isIndeterminate
+            ? {}
+            : {
+                progress: progress.progress,
+                total: progress.total,
+                value: (100 * progress.progress) / progress.total,
+              }),
           count: 1,
           items,
         };

--- a/src/components/ProgressBarGroup.vue
+++ b/src/components/ProgressBarGroup.vue
@@ -11,7 +11,7 @@
           :indeterminate="group.indeterminate"
           :value="group.value"
           color="primary"
-          height="20"
+          height="16"
         >
           <strong>
             {{ group.title }}
@@ -36,7 +36,7 @@
               progress.total ? (100 * progress.progress) / progress.total : 0
             "
             color="primary"
-            height="12"
+            height="10"
             class="mb-1"
           >
             <strong class="caption">
@@ -141,7 +141,8 @@ export default class ProgressBarGroup extends Vue {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-width: 300px;
+  min-width: 250px;
+  max-width: 250px;
 }
 
 .progress-group {
@@ -157,11 +158,11 @@ export default class ProgressBarGroup extends Vue {
   gap: 2px;
 
   :deep(.v-progress-linear) {
-    font-size: 0.75rem;
+    font-size: 0.7rem;
   }
 }
 
 :deep(.v-progress-linear) {
-  font-size: 0.85rem;
+  font-size: 0.75rem;
 }
 </style>

--- a/src/components/ProgressBarGroup.vue
+++ b/src/components/ProgressBarGroup.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="progress-container" v-if="hasActiveProgresses">
+    <div
+      v-for="group in progressGroups"
+      :key="group.type"
+      class="progress-group"
+    >
+      <!-- Single progress or multiple indeterminate with same title -->
+      <template v-if="group.display === 'single'">
+        <v-progress-linear
+          :indeterminate="group.indeterminate"
+          :value="group.value"
+          color="primary"
+          height="20"
+        >
+          <strong>
+            {{ group.title }}
+            <template v-if="group.total !== undefined">
+              ({{ group.progress }}/{{ group.total }})
+            </template>
+            <template v-if="group.count > 1">
+              ({{ group.count }} remaining)
+            </template>
+          </strong>
+        </v-progress-linear>
+      </template>
+
+      <!-- Multiple progresses that need individual display -->
+      <template v-else>
+        <div class="stacked-progress">
+          <v-progress-linear
+            v-for="progress in group.items"
+            :key="progress.id"
+            :indeterminate="progress.total === 0"
+            :value="
+              progress.total ? (100 * progress.progress) / progress.total : 0
+            "
+            color="primary"
+            height="12"
+            class="mb-1"
+          >
+            <strong class="caption">
+              {{ progress.title }}
+              <template v-if="progress.total > 0">
+                ({{ progress.progress }}/{{ progress.total }})
+              </template>
+            </strong>
+          </v-progress-linear>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from "vue-property-decorator";
+import progressStore from "@/store/progress";
+import { ProgressType, IProgress, IProgressGroup } from "@/store/model";
+
+@Component({})
+export default class ProgressBarGroup extends Vue {
+  readonly progressStore = progressStore;
+
+  get activeProgresses() {
+    return this.progressStore.activeProgresses;
+  }
+
+  get hasActiveProgresses() {
+    return this.progressStore.hasActiveProgresses;
+  }
+
+  get progressGroups(): IProgressGroup[] {
+    // Group progresses by type
+    const groupedByType = new Map<ProgressType, IProgress[]>();
+
+    for (const progress of this.activeProgresses) {
+      if (!groupedByType.has(progress.type)) {
+        groupedByType.set(progress.type, []);
+      }
+      groupedByType.get(progress.type)!.push(progress);
+    }
+
+    return Array.from(groupedByType.entries()).map(([type, items]) => {
+      // Single progress case
+      if (items.length === 1) {
+        const progress = items[0];
+        return {
+          type,
+          display: "single",
+          title: progress.title,
+          progress: progress.progress,
+          total: progress.total,
+          value: progress.total
+            ? (100 * progress.progress) / progress.total
+            : 0,
+          indeterminate: progress.total === 0,
+          count: 1,
+          items,
+        };
+      }
+
+      // Check if all items are indeterminate and have the same title
+      const allIndeterminate = items.every((p) => p.total === 0);
+      const allSameTitle = items.every((p) => p.title === items[0].title);
+
+      if (allIndeterminate && allSameTitle) {
+        return {
+          type,
+          display: "single",
+          title: items[0].title,
+          indeterminate: true,
+          count: items.length,
+          items,
+        };
+      }
+
+      // Multiple different progresses case
+      return {
+        type,
+        display: "stacked",
+        title: "", // Not used in stacked display
+        indeterminate: false,
+        count: items.length,
+        items,
+      };
+    });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.progress-container {
+  position: absolute;
+  bottom: 40px;
+  left: 20px;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 300px;
+}
+
+.progress-group {
+  background: rgba(0, 0, 0, 0.7);
+  padding: 4px;
+  border-radius: 4px;
+  color: white;
+}
+
+.stacked-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  :deep(.v-progress-linear) {
+    font-size: 0.75rem;
+  }
+}
+
+:deep(.v-progress-linear) {
+  font-size: 0.85rem;
+}
+</style>

--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -1,5 +1,4 @@
 import { RestClientInstance } from "@/girder";
-import progressStore from "@/store/progress";
 import {
   IAnnotation,
   IAnnotationConnection,
@@ -11,7 +10,6 @@ import {
   IDisplayLayer,
   IScales,
   IDataset,
-  ProgressType,
 } from "./model";
 
 import { logError } from "@/utils/log";

--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -1,4 +1,5 @@
 import { RestClientInstance } from "@/girder";
+import progressStore from "@/store/progress";
 import {
   IAnnotation,
   IAnnotationConnection,
@@ -10,6 +11,7 @@ import {
   IDisplayLayer,
   IScales,
   IDataset,
+  ProgressType,
 } from "./model";
 
 import { logError } from "@/utils/log";

--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -83,10 +83,7 @@ export default class AnnotationsAPI {
       });
   }
 
-  async getAnnotationsForDatasetId(
-    datasetId: string,
-    progressCallback?: (fetched: number, total: number) => void,
-  ): Promise<IAnnotation[]> {
+  async getAnnotationsForDatasetId(datasetId: string): Promise<IAnnotation[]> {
     const annotations: IAnnotation[] = [];
     const pages = await fetchAllPages(
       this.client,
@@ -95,7 +92,6 @@ export default class AnnotationsAPI {
         params: { datasetId, sort: "_id" },
       },
       undefined,
-      progressCallback,
     );
     for (const page of pages) {
       const newAnnotations = page.map(this.toAnnotation);
@@ -190,7 +186,6 @@ export default class AnnotationsAPI {
 
   async getConnectionsForDatasetId(
     datasetId: string,
-    progressCallback?: (fetched: number, total: number) => void,
   ): Promise<IAnnotationConnection[]> {
     const connections: IAnnotationConnection[] = [];
     const pages = await fetchAllPages(
@@ -200,7 +195,6 @@ export default class AnnotationsAPI {
         params: { datasetId, sort: "_id" },
       },
       undefined,
-      progressCallback,
     );
     for (const page of pages) {
       const newConnections = page.map(this.toConnection);

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -610,13 +610,6 @@ export default class GirderAPI {
     const largeImageItems = await this.getImages(datasetId);
     const responses = [];
 
-    // TODO: Decide whether we want to track this progress.
-    // This is just for scheduling the histogram jobs, so it's not
-    // very heavy, computationally. Might be better as a toast.
-    const progressId = await progressStore.create({
-      type: ProgressType.HISTOGRAM_SCHEDULE,
-    });
-
     try {
       // Don't use a Promise.all to avoid flooding the backend with requests
       // Only send one cache request at a time
@@ -634,11 +627,10 @@ export default class GirderAPI {
     } catch (error) {
       return null;
     }
-    await progressStore.complete(progressId);
 
     // TODO: It may be important to run this over all responses, but it's
-    // probably not necessary, since if we have multiple large images, we'll
-    // have multiple jobs.
+    // probably not necessary for now, since if we have multiple large images
+    // we'll have multiple jobs.
     const jobId = responses[0].data.scheduledJob;
     await progressStore.trackHistogramJob(jobId);
     return responses;

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -26,7 +26,6 @@ import {
   newLayer,
   TJobType,
   IDatasetConfigurationCompatibility,
-  ProgressType,
 } from "@/store/model";
 import {
   toStyle,

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -20,6 +20,7 @@ export interface IFrameInfo {
   IndexZ?: number;
   IndexC?: number;
   IndexT?: number;
+  Channel?: string;
 }
 
 export interface IImage {
@@ -197,8 +198,11 @@ export enum ProgressType {
   CONNECTION_DELETE = "CONNECTION_DELETE",
   VIEW_FETCH = "VIEW_FETCH",
   LAYER_CACHE = "LAYER_CACHE",
+  QUADTILE_CACHE = "QUADTILE_CACHE",
   HISTOGRAM_CACHE = "HISTOGRAM_CACHE",
   HISTOGRAM_SCHEDULE = "HISTOGRAM_SCHEDULE",
+  MAXMERGE_CACHE = "MAXMERGE_CACHE",
+  MAXMERGE_SCHEDULE = "MAXMERGE_SCHEDULE",
   GENERIC = "GENERIC",
 }
 

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -193,18 +193,41 @@ export enum ProgressType {
   ANNOTATION_SAVE = "ANNOTATION_SAVE",
   ANNOTATION_DELETE = "ANNOTATION_DELETE",
   ANNOTATION_COMPUTE = "ANNOTATION_COMPUTE",
+  PROPERTY_FETCH = "PROPERTY_FETCH",
+  PROPERTY_COMPUTE = "PROPERTY_COMPUTE",
   CONNECTION_FETCH = "CONNECTION_FETCH",
   CONNECTION_SAVE = "CONNECTION_SAVE",
   CONNECTION_DELETE = "CONNECTION_DELETE",
   VIEW_FETCH = "VIEW_FETCH",
   LAYER_CACHE = "LAYER_CACHE",
   QUADTILE_CACHE = "QUADTILE_CACHE",
-  HISTOGRAM_CACHE = "HISTOGRAM_CACHE",
-  HISTOGRAM_SCHEDULE = "HISTOGRAM_SCHEDULE",
-  MAXMERGE_CACHE = "MAXMERGE_CACHE",
   MAXMERGE_SCHEDULE = "MAXMERGE_SCHEDULE",
+  MAXMERGE_CACHE = "MAXMERGE_CACHE",
+  HISTOGRAM_SCHEDULE = "HISTOGRAM_SCHEDULE",
+  HISTOGRAM_CACHE = "HISTOGRAM_CACHE",
   GENERIC = "GENERIC",
 }
+
+export const PROGRESS_TYPE_ORDER = new Map<ProgressType, number>([
+  [ProgressType.ANNOTATION_FETCH, 0],
+  [ProgressType.ANNOTATION_SAVE, 1],
+  [ProgressType.ANNOTATION_DELETE, 2],
+  [ProgressType.ANNOTATION_COMPUTE, 3],
+  [ProgressType.PROPERTY_FETCH, 4],
+  [ProgressType.PROPERTY_COMPUTE, 5],
+  [ProgressType.CONNECTION_FETCH, 6],
+  [ProgressType.CONNECTION_SAVE, 7],
+  [ProgressType.CONNECTION_DELETE, 8],
+  [ProgressType.VIEW_FETCH, 9],
+  [ProgressType.LAYER_CACHE, 10],
+  [ProgressType.QUADTILE_CACHE, 11],
+  [ProgressType.MAXMERGE_SCHEDULE, 12],
+  [ProgressType.MAXMERGE_CACHE, 13],
+  [ProgressType.HISTOGRAM_SCHEDULE, 14],
+  [ProgressType.HISTOGRAM_CACHE, 15],
+  [ProgressType.GENERIC, 16],
+]);
+
 
 export interface IProgress {
   id: string;
@@ -213,6 +236,7 @@ export interface IProgress {
   total: number;
   title: string;
   metadata: Record<string, any>;
+  isReactive?: boolean;
 }
 
 export interface IProgressGroup {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -228,7 +228,6 @@ export const PROGRESS_TYPE_ORDER = new Map<ProgressType, number>([
   [ProgressType.GENERIC, 16],
 ]);
 
-
 export interface IProgress {
   id: string;
   type: ProgressType;

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -187,6 +187,42 @@ export interface IActiveTool<T extends TToolType = TToolType> {
   state: TToolState<T>;
 }
 
+export enum ProgressType {
+  ANNOTATION_FETCH = "ANNOTATION_FETCH",
+  ANNOTATION_SAVE = "ANNOTATION_SAVE",
+  ANNOTATION_DELETE = "ANNOTATION_DELETE",
+  ANNOTATION_COMPUTE = "ANNOTATION_COMPUTE",
+  CONNECTION_FETCH = "CONNECTION_FETCH",
+  CONNECTION_SAVE = "CONNECTION_SAVE",
+  CONNECTION_DELETE = "CONNECTION_DELETE",
+  VIEW_FETCH = "VIEW_FETCH",
+  LAYER_CACHE = "LAYER_CACHE",
+  HISTOGRAM_CACHE = "HISTOGRAM_CACHE",
+  HISTOGRAM_SCHEDULE = "HISTOGRAM_SCHEDULE",
+  GENERIC = "GENERIC",
+}
+
+export interface IProgress {
+  id: string;
+  type: ProgressType;
+  progress: number;
+  total: number;
+  title: string;
+  metadata: Record<string, any>;
+}
+
+export interface IProgressGroup {
+  type: ProgressType;
+  display: "single" | "stacked";
+  title: string;
+  progress?: number;
+  total?: number;
+  value?: number;
+  indeterminate: boolean;
+  count: number;
+  items: IProgress[];
+}
+
 export interface IRestrictTagsAndLayer {
   tags: string[];
   tagsInclusive: boolean;

--- a/src/store/progress.ts
+++ b/src/store/progress.ts
@@ -1,0 +1,196 @@
+import {
+  VuexModule,
+  Module,
+  Mutation,
+  Action,
+  getModule,
+} from "vuex-module-decorators";
+import store from "./root";
+import main from "./index";
+import jobs from "./jobs";
+import { ProgressType, IProgress } from "./model";
+import { jobStates } from "./jobs";
+import { v4 as uuidv4 } from "uuid";
+
+// These are the endpoints that are sent to the fetchAllJobs call. We can capture them to
+// create appropriate progress items for them.
+const ENDPOINT_MAPPINGS: Record<string, { type: ProgressType; title: string }> =
+  {
+    upenn_annotation: {
+      type: ProgressType.ANNOTATION_FETCH,
+      title: "Fetching Annotations", // TODO: If we decide that this will always be the same for all progresses of this type, we can remove this title and just use the default
+    },
+    annotation_connection: {
+      type: ProgressType.CONNECTION_FETCH,
+      title: "Fetching Connections",
+    },
+    dataset_view: {
+      type: ProgressType.VIEW_FETCH,
+      title: "Fetching Dataset View",
+    },
+    // Can add other endpoint mappings as needed
+  };
+
+@Module({ dynamic: true, store, name: "progress" })
+class Progress extends VuexModule {
+  items: IProgress[] = [];
+
+  @Mutation
+  private ADD_PROGRESS(progress: IProgress) {
+    this.items.push(progress);
+  }
+
+  @Mutation
+  private UPDATE_PROGRESS({
+    id,
+    progress,
+    total,
+  }: {
+    id: string;
+    progress: number;
+    total: number;
+  }) {
+    const item = this.items.find((p) => p.id === id);
+    if (item) {
+      item.progress = progress;
+      item.total = total;
+    }
+  }
+
+  @Mutation
+  private REMOVE_PROGRESS(id: string) {
+    this.items = this.items.filter((p) => p.id !== id);
+  }
+
+  @Action
+  create(payload: {
+    type?: ProgressType;
+    endpoint?: string;
+    title?: string;
+    metadata?: Record<string, any>;
+  }) {
+    const id = uuidv4();
+    let type: ProgressType;
+    let title: string;
+
+    if (payload.title) {
+      // If title is provided, use it directly with a default type
+      type = payload.type || ProgressType.GENERIC;
+      title = payload.title;
+    } else if (payload.endpoint) {
+      // If endpoint is provided, look up the mapping
+      const mapping = ENDPOINT_MAPPINGS[payload.endpoint];
+      if (!mapping) {
+        type = ProgressType.GENERIC;
+        title = `Fetching ${payload.endpoint}`;
+      } else {
+        type = mapping.type;
+        title = mapping.title;
+      }
+    } else if (payload.type) {
+      // If only type is provided, use a default title for that type
+      type = payload.type;
+      switch (type) {
+        case ProgressType.ANNOTATION_FETCH:
+          title = "Fetching Annotations";
+          break;
+        case ProgressType.CONNECTION_FETCH:
+          title = "Fetching Connections";
+          break;
+        case ProgressType.VIEW_FETCH:
+          title = "Fetching Dataset View";
+          break;
+        case ProgressType.HISTOGRAM_CACHE:
+          title = "Computing Histograms";
+          break;
+        case ProgressType.HISTOGRAM_SCHEDULE:
+          title = "Scheduling Histogram Cache";
+          break;
+        default:
+          title = "Operation in Progress";
+      }
+    } else {
+      // Fallback
+      type = ProgressType.GENERIC;
+      title = "Operation in Progress";
+    }
+
+    this.ADD_PROGRESS({
+      id,
+      type,
+      progress: 0,
+      total: 0,
+      title,
+      metadata: payload.metadata || {},
+    });
+    return id;
+  }
+
+  @Action
+  async trackHistogramJob(jobId: string) {
+    const progressId = await this.create({
+      type: ProgressType.HISTOGRAM_CACHE,
+      title: "Computing histograms",
+    });
+
+    const datasetId = main.dataset?.id;
+    if (!datasetId) {
+      return;
+    }
+
+    const totalFrames = main.dataset
+      ? main.dataset.z.length *
+        main.dataset.time.length *
+        main.dataset.xy.length *
+        main.dataset.channels.length
+      : 0;
+
+    await jobs.addJob({
+      jobId,
+      datasetId,
+      eventCallback: (jobInfo) => {
+        // Check for completion first
+        if (
+          [jobStates.success, jobStates.error].includes(jobInfo.status || 0)
+        ) {
+          this.complete(progressId);
+          return;
+        }
+
+        // If we have text with a frame number, treat it as progress
+        // Note that the jobStates.running only comes on the first "running"
+        // progress update, so we can't just use that to determine if we're
+        // still running.
+        const frameMatch = jobInfo.text?.match(/{'frame': (\d+)/);
+        if (frameMatch) {
+          const currentFrame = parseInt(frameMatch[1]);
+          this.update({
+            id: progressId,
+            progress: currentFrame + 1,
+            total: totalFrames,
+          });
+        }
+      },
+    });
+  }
+
+  @Action
+  update(payload: { id: string; progress: number; total: number }) {
+    this.UPDATE_PROGRESS(payload);
+  }
+
+  @Action
+  complete(id: string) {
+    this.REMOVE_PROGRESS(id);
+  }
+
+  get activeProgresses() {
+    return this.items;
+  }
+
+  get hasActiveProgresses() {
+    return this.items.length > 0;
+  }
+}
+
+export default getModule(Progress);

--- a/src/store/progress.ts
+++ b/src/store/progress.ts
@@ -18,15 +18,15 @@ const ENDPOINT_MAPPINGS: Record<string, { type: ProgressType; title: string }> =
   {
     upenn_annotation: {
       type: ProgressType.ANNOTATION_FETCH,
-      title: "Fetching Annotations", // TODO: If we decide that this will always be the same for all progresses of this type, we can remove this title and just use the default
+      title: "Fetching annotations", // TODO: If we decide that this will always be the same for all progresses of this type, we can remove this title and just use the default
     },
     annotation_connection: {
       type: ProgressType.CONNECTION_FETCH,
-      title: "Fetching Connections",
+      title: "Fetching connections",
     },
     annotation_property_values: {
       type: ProgressType.PROPERTY_FETCH,
-      title: "Fetching Property Values",
+      title: "Fetching property values",
     },
     // Can add other endpoint mappings as needed
   };
@@ -127,33 +127,33 @@ class Progress extends VuexModule {
       type = payload.type;
       switch (type) {
         case ProgressType.ANNOTATION_FETCH:
-          title = "Fetching Annotations";
+          title = "Fetching annotations";
           break;
         case ProgressType.CONNECTION_FETCH:
-          title = "Fetching Connections";
+          title = "Fetching connections";
           break;
         case ProgressType.PROPERTY_FETCH:
-          title = "Fetching Properties";
+          title = "Fetching properties";
           break;
         case ProgressType.VIEW_FETCH:
-          title = "Fetching Dataset View";
+          title = "Fetching dataset view";
           break;
         case ProgressType.HISTOGRAM_CACHE:
-          title = "Computing Histograms";
+          title = "Computing histograms";
           break;
         case ProgressType.HISTOGRAM_SCHEDULE:
-          title = "Scheduling Histogram Cache";
+          title = "Scheduling histogram cache";
           break;
         case ProgressType.MAXMERGE_CACHE:
-          title = "Caching Max-Merge";
+          title = "Caching max-merge";
           break;
         default:
-          title = "Operation in Progress";
+          title = "Operation in progress";
       }
     } else {
       // Fallback
       type = ProgressType.GENERIC;
-      title = "Operation in Progress";
+      title = "Operation in progress";
     }
 
     this.ADD_PROGRESS({
@@ -181,7 +181,7 @@ class Progress extends VuexModule {
   async trackHistogramJob(jobId: string) {
     const progressId = await this.create({
       type: ProgressType.HISTOGRAM_CACHE,
-      title: "Waiting for Histogram precomputation",
+      title: "Waiting for histogram precomputation",
     });
 
     const datasetId = main.dataset?.id;
@@ -219,7 +219,7 @@ class Progress extends VuexModule {
             id: progressId,
             progress: currentFrame + 1,
             total: totalFrames,
-            title: "Precomputing Histograms",
+            title: "Precomputing histograms",
           });
         }
       },
@@ -230,7 +230,7 @@ class Progress extends VuexModule {
   async trackMaxMergeJob(jobId: string) {
     const progressId = await this.create({
       type: ProgressType.MAXMERGE_CACHE,
-      title: "Waiting for Max-Merge precomputation",
+      title: "Waiting for max-merge precomputation",
     });
 
     const datasetId = main.dataset?.id;

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -8,7 +8,6 @@ export async function fetchAllPages(
   endpoint: string,
   baseFormData?: AxiosRequestConfig,
   firstPage?: number,
-  progressCallback?: (fetched: number, total: number) => void,
 ) {
   // Only capture progress for these endpoints
   const PROGRESS_ENDPOINTS = [
@@ -47,7 +46,6 @@ export async function fetchAllPages(
       totalCount = Number(res.headers["girder-total-count"]);
       pages.push(res.data);
       downloaded += res.data.length;
-      progressCallback?.(downloaded, totalCount);
     } catch (err) {
       logError(`Could not get all ${endpoint} pages:\n${err}`);
       throw err;

--- a/src/utils/setFrameQuad.ts
+++ b/src/utils/setFrameQuad.ts
@@ -1,5 +1,11 @@
 import { ITileMeta } from "@/store/GirderAPI";
-import { IGeoJSOsmLayer, IGeoJSQuad, IQuadInformation } from "@/store/model";
+import {
+  IGeoJSOsmLayer,
+  IGeoJSQuad,
+  IQuadInformation,
+  ProgressType,
+} from "@/store/model";
+import progressStore from "@/store/progress";
 
 export interface ISetQuadStatusOptions {
   progress: (status: ISetQuadStatus) => void;
@@ -110,7 +116,7 @@ async function loadImages(
   layer: IGeoJSOsmLayer,
 ) {
   // Helper arrow function to call the progress callback
-  const safeProgress = () => {
+  const safeProgress = async () => {
     try {
       options.progress(status);
     } catch {}
@@ -127,6 +133,18 @@ async function loadImages(
   status.framesToIdx = data.framesToIdx;
   status.totalToLoad = data.src.length;
   safeProgress();
+
+  let progressId: string | null = null;
+  const channel = status.tileinfo.frames[status.frames[0]].Channel ?? "channel";
+  progressId = await progressStore.create({
+    type: ProgressType.QUADTILE_CACHE,
+    title: `Optimizing ${channel}`,
+  });
+  await progressStore.update({
+    id: progressId,
+    progress: 0,
+    total: data.src.length,
+  });
 
   // Create an Image element for each src in the quad info
   for (let idx = 0; idx < data.src.length; idx++) {
@@ -166,12 +184,20 @@ async function loadImages(
       img.onerror = voidResolve;
     });
     status.loadedCount += 1;
+    await progressStore.update({
+      id: progressId,
+      progress: status.loadedCount,
+      total: data.src.length,
+    });
     safeProgress();
   }
 
   // Done loading all images
   status.loaded = true;
   safeProgress();
+  if (progressId) {
+    await progressStore.complete(progressId);
+  }
 
   // Adjust min level of the layer
   if (

--- a/src/utils/setFrameQuad.ts
+++ b/src/utils/setFrameQuad.ts
@@ -115,13 +115,6 @@ async function loadImages(
   status: ISetQuadStatus,
   layer: IGeoJSOsmLayer,
 ) {
-  // Helper arrow function to call the progress callback
-  const safeProgress = async () => {
-    try {
-      options.progress(status);
-    } catch {}
-  };
-
   // Get quad info and update status
   const data = await quadInformation.restRequest({
     type: "GET",
@@ -132,7 +125,6 @@ async function loadImages(
   status.frames = data.frames;
   status.framesToIdx = data.framesToIdx;
   status.totalToLoad = data.src.length;
-  safeProgress();
 
   let progressId: string | null = null;
   const channel = status.tileinfo.frames[status.frames[0]].Channel ?? "channel";
@@ -189,12 +181,10 @@ async function loadImages(
       progress: status.loadedCount,
       total: data.src.length,
     });
-    safeProgress();
   }
 
   // Done loading all images
   status.loaded = true;
-  safeProgress();
   if (progressId) {
     await progressStore.complete(progressId);
   }


### PR DESCRIPTION
Added a new ProgressBarGroup component and progress store to help manage progress bars across the application.
Converted all existing progress bars to use new framework.
Updated max-merges so that their progress is captured (before it was not, leading to a gap).
Created both ID-tracked progresses for longer computations and reactive progresses for quick updates.

Next steps could be to duplicate annotation worker progresses and other deletion/drawing/import/export updates that can be slow.