### PR TITLE
Decrease Girder log level

### DIFF
--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/__init__.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/__init__.py
@@ -8,7 +8,7 @@ from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
 
 # Set up logging
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This line used to set Girder log level to DEBUG, which floods the log pretty quickly.
Switch it back to INFO