### PR TITLE
Added a simple user tour

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "reflect-metadata": "^0.1.13",
     "register-service-worker": "^1.6.2",
     "roboto-fontface": "*",
-    "shepherd.js": "8.3.1",
+    "shepherd.js": "^8.3.1",
     "sortablejs": "^1.15.2",
     "uuid": "^3.4.0",
     "vue": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "fs-extra": "^10.0.0",
     "html2canvas": "^1.4.1",
     "itk-wasm": "^1.0.0-b.166",
+    "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "marked": "^14.1.1",
     "mousetrap": "^1.6.4",
@@ -71,6 +72,7 @@
     "reflect-metadata": "^0.1.13",
     "register-service-worker": "^1.6.2",
     "roboto-fontface": "*",
+    "shepherd.js": "8.3.1",
     "sortablejs": "^1.15.2",
     "uuid": "^3.4.0",
     "vue": "^2.7.1",
@@ -86,6 +88,8 @@
     "vuex-module-decorators": "^0.11.0"
   },
   "devDependencies": {
+    "@rollup/plugin-yaml": "^4.1.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^18.19.0",
     "@types/papaparse": "^5.3.8",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
@@ -113,6 +117,7 @@
     "vue-tsc": "^1.8.27",
     "vuetify-loader": "^1.4.2",
     "worker-loader": "^3.0.8",
-    "yaml-front-matter": "^4.0.0"
+    "yaml-front-matter": "^4.0.0",
+    "yaml-loader": "^0.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       itk-wasm:
         specifier: ^1.0.0-b.166
         version: 1.0.0-b.166
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -142,6 +145,9 @@ importers:
       roboto-fontface:
         specifier: '*'
         version: 0.10.0
+      shepherd.js:
+        specifier: 8.3.1
+        version: 8.3.1
       sortablejs:
         specifier: ^1.15.2
         version: 1.15.2
@@ -182,6 +188,12 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(vue@2.7.16)(vuex@3.6.2(vue@2.7.16))
     devDependencies:
+      '@rollup/plugin-yaml':
+        specifier: ^4.1.2
+        version: 4.1.2(rollup@4.9.5)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^18.19.0
         version: 18.19.7
@@ -266,6 +278,9 @@ importers:
       yaml-front-matter:
         specifier: ^4.0.0
         version: 4.1.1
+      yaml-loader:
+        specifier: ^0.8.1
+        version: 0.8.1
 
 packages:
 
@@ -1135,6 +1150,9 @@ packages:
     resolution: {integrity: sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1164,6 +1182,15 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rollup/plugin-yaml@4.1.2':
+    resolution: {integrity: sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -1298,6 +1325,9 @@ packages:
 
   '@types/jquery@3.5.29':
     resolution: {integrity: sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2102,6 +2132,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   define-data-property@1.1.1:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
     engines: {node: '>= 0.4'}
@@ -2716,6 +2750,9 @@ packages:
   itk-wasm@1.0.0-b.166:
     resolution: {integrity: sha512-BZZvgUyTT+4DpiLkS7Hahbt+CpR63ckTgyE8li3d6gg3ljqBXfHDavWLiuUIaTA7RXuPUnpIl23jB9z6v77ymA==}
     hasBin: true
+
+  javascript-stringify@2.1.0:
+    resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -3483,6 +3520,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  shepherd.js@8.3.1:
+    resolution: {integrity: sha512-IhxZNhnK2m/pNTXudNfYrcwvcZNWkeYngQbQee8nC3xJ2GjeIatGqivhdZAMZ+LeogZvKMakB931d/V534uhrw==}
+    engines: {node: 10.* || >= 12}
+
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
 
@@ -3509,6 +3550,9 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  smoothscroll-polyfill@0.4.4:
+    resolution: {integrity: sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==}
 
   sortablejs@1.10.2:
     resolution: {integrity: sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==}
@@ -3670,6 +3714,10 @@ packages:
 
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
+
+  tosource@2.0.0-alpha.3:
+    resolution: {integrity: sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==}
+    engines: {node: '>=10'}
 
   tough-cookie@4.1.3:
     resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
@@ -4102,6 +4150,10 @@ packages:
   yaml-front-matter@4.1.1:
     resolution: {integrity: sha512-ULGbghCLsN8Hs8vfExlqrJIe8Hl2TUjD7/zsIGMP8U+dgRXEsDXk4yydxeZJgdGiimP1XB7zhmhOB4/HyfqOyQ==}
     hasBin: true
+
+  yaml-loader@0.8.1:
+    resolution: {integrity: sha512-BCEndnUoi3BaZmePkwGGe93txRxLgMhBa/gE725v1/GHnura8QvNs7c4+4C1yyhhKoj3Dg63M7IqhA++15j6ww==}
+    engines: {node: '>= 14'}
 
   yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
@@ -5220,6 +5272,8 @@ snapshots:
 
   '@pkgr/core@0.1.0': {}
 
+  '@popperjs/core@2.11.8': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -5242,6 +5296,14 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@rollup/plugin-yaml@4.1.2(rollup@4.9.5)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.5)
+      js-yaml: 4.1.0
+      tosource: 2.0.0-alpha.3
+    optionalDependencies:
+      rollup: 4.9.5
 
   '@rollup/pluginutils@5.1.0(rollup@4.9.5)':
     dependencies:
@@ -5349,6 +5411,8 @@ snapshots:
   '@types/jquery@3.5.29':
     dependencies:
       '@types/sizzle': 2.3.8
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -6313,6 +6377,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   define-data-property@1.1.1:
     dependencies:
       get-intrinsic: 1.2.2
@@ -7030,6 +7096,8 @@ snapshots:
       wasm-feature-detect: 1.6.1
     transitivePeerDependencies:
       - debug
+
+  javascript-stringify@2.1.0: {}
 
   jest-worker@27.5.1:
     dependencies:
@@ -7836,6 +7904,12 @@ snapshots:
       rechoir: 0.6.2
     optional: true
 
+  shepherd.js@8.3.1:
+    dependencies:
+      '@popperjs/core': 2.11.8
+      deepmerge: 4.3.1
+      smoothscroll-polyfill: 0.4.4
+
   side-channel@1.0.4:
     dependencies:
       call-bind: 1.0.5
@@ -7859,6 +7933,8 @@ snapshots:
   slash@2.0.0: {}
 
   slash@3.0.0: {}
+
+  smoothscroll-polyfill@0.4.4: {}
 
   sortablejs@1.10.2: {}
 
@@ -8008,6 +8084,8 @@ snapshots:
       is-number: 7.0.0
 
   token-stream@1.0.0: {}
+
+  tosource@2.0.0-alpha.3: {}
 
   tough-cookie@4.1.3:
     dependencies:
@@ -8464,6 +8542,12 @@ snapshots:
     dependencies:
       commander: 6.2.1
       js-yaml: 3.14.1
+
+  yaml-loader@0.8.1:
+    dependencies:
+      javascript-stringify: 2.1.0
+      loader-utils: 2.0.4
+      yaml: 2.3.4
 
   yaml@2.3.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         specifier: '*'
         version: 0.10.0
       shepherd.js:
-        specifier: 8.3.1
+        specifier: ^8.3.1
         version: 8.3.1
       sortablejs:
         specifier: ^1.15.2

--- a/src/App.vue
+++ b/src/App.vue
@@ -232,6 +232,7 @@ import { logError } from "@/utils/log";
 import { IHotkey } from "@/utils/v-mousetrap";
 import ChatComponent from "@/components/ChatComponent.vue";
 import { IGirderFolder } from "@/girder";
+import { ITourMetadata } from "./store/model";
 
 @Component({
   components: {
@@ -260,7 +261,7 @@ export default class App extends Vue {
   };
 
   tourSearch = "";
-  availableTours: Record<string, any> = {};
+  availableTours: Record<string, ITourMetadata> = {};
 
   snapshotPanel = false;
   snapshotPanelFull = false;
@@ -388,9 +389,9 @@ export default class App extends Vue {
     }
   }
 
-  get filteredToursByCategory() {
+  get filteredToursByCategory(): Record<string, Record<string, ITourMetadata>> {
     const tours = this.availableTours;
-    const filtered = Object.entries(tours).filter(([_, tour]) => {
+    const filtered = Object.entries(tours).filter(([, tour]) => {
       // First filter by search term
       const matchesSearch = tour.name
         .toLowerCase()
@@ -408,14 +409,17 @@ export default class App extends Vue {
     });
 
     // Group by category
-    const grouped = filtered.reduce((acc, [id, tour]) => {
-      const category = tour.category || "General";
-      if (!acc[category]) {
-        acc[category] = {};
-      }
-      acc[category][id] = tour;
-      return acc;
-    }, {});
+    const grouped = filtered.reduce(
+      (acc: Record<string, Record<string, ITourMetadata>>, [id, tour]) => {
+        const category = tour.category || "General";
+        if (!acc[category]) {
+          acc[category] = {};
+        }
+        acc[category][id] = tour;
+        return acc;
+      },
+      {},
+    );
 
     return grouped;
   }

--- a/src/components/DisplayLayers.vue
+++ b/src/components/DisplayLayers.vue
@@ -1,5 +1,6 @@
 <template>
   <v-expansion-panels
+    id="layer-controls-tourstep"
     class="d-block mt-2"
     multiple
     accordion

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -114,6 +114,7 @@
     <v-menu offset-y top :close-on-content-click="false">
       <template #activator="{ on }">
         <v-btn
+          id="layer-info-tourstep"
           icon
           v-on="on"
           class="layer-info-btn"
@@ -126,6 +127,7 @@
       <layer-info-grid :layers="store.layers" />
     </v-menu>
     <v-btn
+      id="lock-view-tourstep"
       icon
       class="lock-view-btn"
       :color="isViewLocked ? 'error' : 'primary'"
@@ -141,6 +143,7 @@
       }}</v-icon>
     </v-btn>
     <v-btn
+      id="reset-rotation-tourstep"
       icon
       class="reset-rotation-btn"
       color="primary"

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <div style="overflow-y: auto; scrollbar-width: none">
-    <div v-mousetrap="mousetrapSliders">
+    <div v-mousetrap="mousetrapSliders" id="viewer-toolbar-tourstep">
       <v-layout>
         <value-slider
           v-model="xy"
@@ -51,7 +51,7 @@
       </v-layout>
       <v-layout v-if="maxTime > 0 && !unrollT">
         <v-checkbox
-          id="timelapse-mode"
+          id="timelapse-mode-tourstep"
           v-tour-trigger="'timelapse-mode-tourtrigger'"
           class="ml-3 my-checkbox"
           v-model="timelapseMode"
@@ -69,7 +69,7 @@
       </v-layout>
       <v-layout v-if="timelapseMode">
         <tag-picker
-          id="timelapse-tags"
+          id="timelapse-tags-tourstep"
           class="ml-3"
           v-model="timelapseTags"
           style="max-width: 300px"
@@ -77,7 +77,7 @@
       </v-layout>
       <v-layout v-if="timelapseMode">
         <v-checkbox
-          id="timelapse-labels"
+          id="timelapse-labels-tourstep"
           class="ml-3 my-checkbox"
           v-model="showTimelapseLabels"
           label="Show labels"

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -51,11 +51,14 @@
       </v-layout>
       <v-layout v-if="maxTime > 0 && !unrollT">
         <v-checkbox
+          id="timelapse-mode"
+          v-tour-trigger="'timelapse-mode-tourtrigger'"
           class="ml-3 my-checkbox"
           v-model="timelapseMode"
           label="Time lapse mode"
         />
         <value-slider
+          id="timelapse-window"
           v-if="timelapseMode"
           v-model="timelapseModeWindow"
           label="Track window"
@@ -66,6 +69,7 @@
       </v-layout>
       <v-layout v-if="timelapseMode">
         <tag-picker
+          id="timelapse-tags"
           class="ml-3"
           v-model="timelapseTags"
           style="max-width: 300px"
@@ -73,6 +77,7 @@
       </v-layout>
       <v-layout v-if="timelapseMode">
         <v-checkbox
+          id="timelapse-labels"
           class="ml-3 my-checkbox"
           v-model="showTimelapseLabels"
           label="Show labels"

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,8 @@ import vDescription from "@/utils/v-description";
 import chat from "./store/chat";
 import VueTooltipDirective from "vue-tooltip-directive";
 import NimbusTooltip from "@/components/NimbusTooltip.vue";
+import { installTour } from "./plugins/tour";
+import "./plugins/tour-trigger.directive";
 
 Vue.config.productionTip = false;
 
@@ -37,13 +39,18 @@ main.initialize();
 main.setupWatchers();
 chat.initializeChatDatabase();
 
+const router = new VueRouter({
+  routes,
+});
+
+// Install tour plugin before creating Vue instance
+export const tourManager = installTour(router);
+
 const app = new Vue({
   provide: {
     girderRest: main.girderRestProxy,
   },
-  router: new VueRouter({
-    routes,
-  }),
+  router,
   store,
   vuetify,
   render: (h: any) => h(App),

--- a/src/plugins/tour-trigger.directive.ts
+++ b/src/plugins/tour-trigger.directive.ts
@@ -1,0 +1,22 @@
+import Vue from "vue";
+import { DirectiveBinding } from "vue/types/options";
+import { tourBus } from "./tourBus";
+
+Vue.directive("tour-trigger", {
+  bind(el: HTMLElement, binding: DirectiveBinding) {
+    const handler = () => {
+      tourBus.$emit(binding.value);
+    };
+    el.addEventListener("click", handler);
+    // Store the handler function on the element so we can remove it later
+    (el as any)._tourTriggerHandler = handler;
+  },
+
+  unbind(el: HTMLElement) {
+    // Remove the event listener using the stored handler
+    if ((el as any)._tourTriggerHandler) {
+      el.removeEventListener("click", (el as any)._tourTriggerHandler);
+      delete (el as any)._tourTriggerHandler;
+    }
+  },
+});

--- a/src/plugins/tour.scss
+++ b/src/plugins/tour.scss
@@ -1,0 +1,90 @@
+.shepherd-theme-custom {
+  // Modern, clean background
+  background: #1E1E1E !important;  // Darker background
+  border-radius: 6px;
+  border: 2px solid #f0f0f0;
+  color: #FFFFFF;
+  max-width: 320px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+  overflow: visible;
+
+  // Clean header without separate background
+  .shepherd-header {
+    padding: 16px 16px 0;
+    background: #1E1E1E !important;  // Explicitly match the container background
+    border-radius: 4px 4px 0 0;  // Match the top corners
+    display: flex;
+    
+    .shepherd-title {
+      font-family: Roboto, sans-serif;
+      font-size: 20px;
+      font-weight: 400;
+      margin: 0;
+      color: #FFFFFF !important;
+      background: #1E1E1E !important;
+      flex: 1;  // Allow title to take up available space
+      word-wrap: break-word;  // Enable word wrapping
+      padding-right: 16px;    // Space between text and close button
+      line-height: 1.3;       // Better spacing for wrapped text
+    }
+
+    .shepherd-cancel-icon {
+      color: rgba(255, 255, 255, 0.7);
+      padding: 4px;
+      margin: -4px;
+      font-size: 18px;
+      
+      &:hover {
+        color: #FFFFFF;
+      }
+    }
+  }
+
+  // Content area
+  .shepherd-text {
+    padding: 16px;
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.87);
+    background: #1E1E1E !important;
+  }
+
+  // Footer with clean button and progress indicator
+  .shepherd-footer {
+    padding: 8px 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    background: #1E1E1E !important;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .v-btn {
+      font-family: Roboto, sans-serif;
+      text-transform: none;
+      letter-spacing: 0.25px;
+      font-weight: 400;
+      font-size: 14px;
+    }
+
+    // New progress indicator styles
+    .shepherd-progress {
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.7);
+      font-family: Roboto, sans-serif;
+      margin-right: 16px;  // Space between progress and button
+    }
+  }
+}
+
+// Darker overlay
+.shepherd-modal-overlay-container {
+  background: rgba(255, 255, 255, 0.15); /* a pale overlay that dims but doesn't black out the UI */
+}
+
+.shepherd-target {
+  /* Example highlight ring */
+  box-shadow: 0 0 0 2px #fff;
+  border-radius: 3px;
+  z-index: 999999;
+}

--- a/src/plugins/tour.ts
+++ b/src/plugins/tour.ts
@@ -1,0 +1,384 @@
+import Vue from "vue";
+import Shepherd from "shepherd.js";
+import Router from "vue-router";
+import "shepherd.js/dist/css/shepherd.css";
+import "./tour.scss";
+import { tourBus } from "./tourBus";
+import { logError } from "@/utils/log";
+import {
+  ITourConfig,
+  ITourMetadata,
+  IExtendedShepherdStep,
+} from "@/store/model";
+
+export class TourManager {
+  private shepherd!: Shepherd.Tour;
+  private currentStepIndex = 0;
+  private isActive = false;
+  private tours: Record<string, ITourMetadata> = {};
+
+  constructor(private router: Router) {
+    Vue.prototype.$startTour = this.startTour.bind(this);
+    Vue.prototype.$nextStep = this.nextStep.bind(this);
+    Vue.prototype.$loadAllTours = this.loadAllTours.bind(this);
+
+    // Watch for route changes
+    this.router.afterEach(() => {
+      if (this.shepherd && this.isActive) {
+        this.checkCurrentStep();
+      }
+    });
+  }
+
+  private async checkCurrentStep() {
+    if (!this.isActive) {
+      return;
+    }
+
+    if (
+      !this.shepherd ||
+      !this.shepherd.steps ||
+      this.shepherd.steps.length === 0
+    ) {
+      return;
+    }
+
+    if (this.currentStepIndex >= this.shepherd.steps.length) {
+      this.isActive = false;
+      this.shepherd.complete();
+      return;
+    }
+
+    const currentStep = this.shepherd.steps[
+      this.currentStepIndex
+    ] as IExtendedShepherdStep;
+    const currentRoute = this.router.currentRoute.name;
+    const expectedRoute = currentStep.options.route;
+
+    if (currentRoute === expectedRoute) {
+      try {
+        // Execute beforeShow hook if it exists
+        if (currentStep.options.beforeShow) {
+          try {
+            await currentStep.options.beforeShow();
+          } catch (error) {
+            logError(`[Tour] Error in beforeShow hook:`, error);
+          }
+        }
+
+        // Wait for element to be available
+        if (currentStep.options.attachTo?.element) {
+          await this.waitForElement(
+            currentStep.options.attachTo.element.toString(),
+            currentStep.options.waitForElement,
+          );
+        }
+
+        this.shepherd.show(currentStep.id);
+      } catch (error) {
+        logError(`[Tour] Error showing step:`, error);
+        // Optionally advance to next step on error
+        this.currentStepIndex++;
+        this.checkCurrentStep();
+      }
+    }
+    // No else block - let route changes trigger new checks
+  }
+
+  private waitForElement(
+    selector: string,
+    timeout: number = 1000,
+  ): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      if (document.querySelector(selector)) {
+        return resolve(document.querySelector(selector)!);
+      }
+
+      const observer = new MutationObserver(() => {
+        if (document.querySelector(selector)) {
+          observer.disconnect();
+          resolve(document.querySelector(selector)!);
+        }
+      });
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+
+      // Use configurable timeout
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element ${selector} not found after ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  async startTour(tourName: string) {
+    const tour = await this.loadTourConfig(tourName);
+    if (!tour) {
+      return;
+    }
+
+    this.currentStepIndex = 0;
+    this.isActive = true;
+
+    this.shepherd = new Shepherd.Tour({
+      useModalOverlay: true,
+      defaultStepOptions: {
+        classes: "shepherd-theme-custom",
+        scrollTo: true,
+        cancelIcon: {
+          enabled: true,
+        },
+        buttons: [
+          {
+            text: "Next",
+            classes: "v-btn v-btn--elevated primary",
+            action: () => {
+              const currentStep = this.shepherd.steps[
+                this.currentStepIndex
+              ] as IExtendedShepherdStep;
+              // Execute onNext hook if it exists
+              if (currentStep.options.onNext) {
+                try {
+                  // Convert string to function if necessary
+                  const onNext =
+                    typeof currentStep.options.onNext === "string"
+                      ? new Function(currentStep.options.onNext)
+                      : currentStep.options.onNext;
+                  onNext();
+                } catch (error) {
+                  logError("[Tour] Error executing onNext hook:", error);
+                }
+              }
+              this.currentStepIndex++;
+              this.shepherd.hide();
+              // Immediately check for the next step
+              this.checkCurrentStep();
+            },
+          },
+        ],
+      },
+    });
+
+    // Add a show event handler
+    this.shepherd.on("show", (event) => {
+      const step = event.step;
+      const overlay = document.querySelector(
+        ".shepherd-modal-overlay-container",
+      );
+      if (overlay) {
+        (overlay as HTMLElement).style.display = step.options.hasModalOverlay
+          ? "block"
+          : "none";
+      }
+    });
+
+    // Add steps
+    this.shepherd.addSteps(
+      tour.steps.map((step, index: number) => {
+        const isLastStep = index === tour.steps.length - 1;
+
+        // Convert hook strings to functions
+        const beforeShow = step.beforeShow
+          ? new Function(step.beforeShow)
+          : undefined;
+        const onNext = step.onNext ? new Function(step.onNext) : undefined;
+
+        // Define buttons based on showNextButton option
+        const buttons =
+          step.showNextButton !== false
+            ? [
+                {
+                  text: isLastStep ? "Done" : "Next",
+                  classes: "v-btn v-btn--elevated primary",
+                  action: () => {
+                    const currentStep = this.shepherd.steps[
+                      this.currentStepIndex
+                    ] as IExtendedShepherdStep;
+                    // Execute onNext hook if it exists
+                    if (currentStep.options.onNext) {
+                      try {
+                        const onNext =
+                          typeof currentStep.options.onNext === "string"
+                            ? new Function(currentStep.options.onNext)
+                            : currentStep.options.onNext;
+                        onNext();
+                      } catch (error) {
+                        logError("[Tour] Error executing onNext hook:", error);
+                      }
+                    }
+                    this.currentStepIndex++;
+                    this.shepherd.hide();
+                    this.checkCurrentStep();
+                  },
+                },
+              ]
+            : [];
+
+        return {
+          id: step.id,
+          attachTo: step.element
+            ? {
+                element: step.element,
+                on: step.position || "bottom",
+              }
+            : undefined,
+          popperOptions: {
+            modifiers: [
+              {
+                name: "offset",
+                options: {
+                  offset: [0, 15],
+                },
+              },
+            ],
+          },
+          title: step.title,
+          text: step.text,
+          classes: "shepherd-theme-custom",
+          arrow: true,
+          route: step.route,
+          waitForElement: step.waitForElement,
+          beforeShow,
+          onNext,
+          hasModalOverlay: step.modalOverlay ?? true,
+          onTriggerEvent: step.onTriggerEvent,
+          buttons, // Use our conditional buttons array
+          when: {
+            show: () => {
+              // First call the existing step listeners
+              this.setupStepListeners(step);
+
+              // Then add progress indicator
+              const currentStep = this.shepherd.getCurrentStep();
+              const currentStepElement = currentStep?.getElement();
+              const footer =
+                currentStepElement?.querySelector(".shepherd-footer");
+              const progress = document.createElement("span");
+              progress.className = "shepherd-progress";
+              progress.innerText = `${this.currentStepIndex + 1} of ${this.shepherd.steps.length}`;
+              if (currentStepElement) {
+                if (footer) {
+                  // If there already is a button, insert the progress before it
+                  footer.insertBefore(
+                    progress,
+                    currentStepElement.querySelector(
+                      ".shepherd-button:last-child",
+                    ),
+                  );
+                } else {
+                  // make a footer and add the progress to it
+                  const footer = document.createElement("div");
+                  footer.className = "shepherd-footer";
+                  footer.appendChild(progress);
+                  currentStepElement.appendChild(footer);
+                }
+              }
+            },
+
+            hide: () => {
+              return this.removeStepListeners(step);
+            },
+          },
+        };
+      }),
+    );
+
+    // Start by checking if we can show the first step
+    this.checkCurrentStep();
+  }
+
+  async loadTourConfig(tourName: string): Promise<ITourConfig> {
+    const tour = await import(`@/tours/${tourName}.yaml`);
+    return tour.default;
+  }
+
+  stopTour() {
+    if (this.shepherd) {
+      this.isActive = false;
+      this.shepherd.complete();
+    }
+  }
+
+  async nextStep(targetElementId?: string) {
+    if (!this.shepherd || !this.isActive) {
+      return;
+    }
+
+    if (targetElementId) {
+      // Find the index of the step with the matching element
+      const targetIndex = this.shepherd.steps.findIndex(
+        (step: any) => step.options.attachTo.element === `#${targetElementId}`,
+      );
+
+      if (targetIndex !== -1) {
+        this.currentStepIndex = targetIndex;
+      } else {
+        // If target not found, just go to next step
+        this.currentStepIndex++;
+      }
+    } else {
+      // Normal next step behavior
+      this.currentStepIndex++;
+    }
+
+    this.shepherd.hide();
+    await this.checkCurrentStep();
+  }
+
+  async loadAllTours(): Promise<Record<string, ITourMetadata>> {
+    if (Object.keys(this.tours).length > 0) {
+      return this.tours;
+    }
+
+    // Get all tour YAML files from the tours directory
+    const tourModules = import.meta.glob("@/tours/*.yaml");
+
+    for (const path in tourModules) {
+      const tourName = path.split("/").pop()?.replace(".yaml", "");
+      if (tourName) {
+        const tour = await import(`@/tours/${tourName}.yaml`);
+        this.tours[tourName] = {
+          name: tour.default.name,
+          entryPoint: tour.default.entryPoint,
+          popular: tour.default.popular,
+          category: tour.default.category || "General",
+        };
+      }
+    }
+
+    return this.tours;
+  }
+
+  private setupStepListeners = (step: any) => {
+    if (step.onTriggerEvent) {
+      tourBus.$on(step.onTriggerEvent, this.handleNextStep);
+    }
+  };
+
+  private removeStepListeners = (step: any) => {
+    if (step.onTriggerEvent) {
+      tourBus.$off(step.onTriggerEvent, this.handleNextStep);
+    }
+  };
+
+  private handleNextStep = () => {
+    this.currentStepIndex++;
+    this.shepherd.hide();
+    this.checkCurrentStep();
+  };
+}
+
+declare module "vue/types/vue" {
+  interface Vue {
+    $startTour: (tourName: string) => Promise<void>;
+    $nextStep: (targetElementId?: string) => Promise<void>;
+    $loadAllTours: () => Promise<Record<string, ITourMetadata>>;
+  }
+}
+
+export function installTour(router: Router) {
+  return new TourManager(router);
+}

--- a/src/plugins/tour.ts
+++ b/src/plugins/tour.ts
@@ -11,6 +11,10 @@ import {
   IExtendedShepherdStep,
 } from "@/store/model";
 
+interface ShepherdShowEvent {
+  step: IExtendedShepherdStep;
+}
+
 export class TourManager {
   private shepherd!: Shepherd.Tour;
   private currentStepIndex = 0;
@@ -163,7 +167,7 @@ export class TourManager {
     });
 
     // Add a show event handler
-    this.shepherd.on("show", (event) => {
+    this.shepherd.on("show", (event: ShepherdShowEvent) => {
       const step = event.step;
       const overlay = document.querySelector(
         ".shepherd-modal-overlay-container",

--- a/src/plugins/tourBus.ts
+++ b/src/plugins/tourBus.ts
@@ -1,0 +1,2 @@
+import Vue from "vue";
+export const tourBus = new Vue();

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1,5 +1,6 @@
 import { IGirderItem } from "@/girder";
 import { ITileHistogram } from "./images";
+import Shepherd from "shepherd.js";
 
 interface IObject<Values = any> {
   [key: string]: Values;
@@ -1361,6 +1362,55 @@ export interface IDatasetLocation {
   xy: number;
   z: number;
   time: number;
+}
+
+// Tour System Types
+export interface ITourStep {
+  id: string;
+  route: string;
+  element?: string;
+  title: string;
+  text: string;
+  position?: "top" | "bottom" | "left" | "right";
+  waitForElement?: number;
+  modalOverlay?: boolean;
+  beforeShow?: string;
+  onNext?: string;
+  showNextButton?: boolean;
+  onTriggerEvent?: string;
+}
+
+export interface IExtendedShepherdStep extends Shepherd.Step {
+  options: Shepherd.Step.StepOptions & {
+    route?: string;
+    beforeShow?: () => void;
+    onNext?: () => void;
+    hasModalOverlay?: boolean;
+    waitForElement?: number;
+    onTriggerEvent?: string;
+  };
+}
+
+export interface ITourMetadata {
+  name: string;
+  entryPoint: string;
+  popular?: boolean;
+  category?: string;
+}
+
+export interface ITourConfig extends ITourMetadata {
+  steps: ITourStep[];
+  options?: {
+    modalOverlay?: boolean;
+  };
+}
+
+declare module "vue/types/vue" {
+  interface Vue {
+    $startTour: (tourName: string) => Promise<void>;
+    $nextStep: (targetElementId?: string) => Promise<void>;
+    $loadAllTours: () => Promise<Record<string, ITourMetadata>>;
+  }
 }
 
 // https://opengeoscience.github.io/geojs/apidocs/geo.util.html#.pixelCoordinateParams

--- a/src/tours/AdvancedUploadTour.yaml
+++ b/src/tours/AdvancedUploadTour.yaml
@@ -1,0 +1,100 @@
+name: Advanced upload dataset
+entryPoint: root
+popular: true
+category: Upload
+options:
+  modalOverlay: true
+steps:
+  - id: Welcome
+    route: root
+    title: "Welcome to the Advanced Upload Tour"
+    text: "This tour will guide you through the advanced upload process. Let's get started!"
+    position: "bottom"
+    waitForElement: 1000  # 1 second timeout
+  - id: quick-upload
+    route: root
+    element: "#quick-upload-tab-tourstep"
+    title: "Quick Upload"
+    text: "If you want to accept all default options and go straight to the image viewer, use quick upload"
+    position: "bottom"
+    waitForElement: 1000
+  - id: advanced-upload
+    route: root
+    element: "#advanced-upload-tab-tourstep"
+    title: "Advanced Upload"
+    text: "Use advanced upload to assign variables to files, composite tiles, and configure additional options. Click the 'Advanced Upload' tab and then drag and drop a file into the dropzone. I'll meet you on the other side."
+    position: "bottom"
+    waitForElement: 1000
+    showNextButton: false
+    onTriggerEvent: "advanced-upload-tab-tourtrigger"
+  - id: dataset-name
+    route: newdataset
+    element: "#dataset-name-input-tourstep"
+    title: "Name Your Dataset"
+    text: "Give your dataset a descriptive name. This will help you identify it later. This name needs to be unique."
+    position: "top"
+    waitForElement: 1000
+  - id: dataset-description
+    route: newdataset
+    element: "#dataset-description-input-tourstep"
+    title: "Describe Your Dataset"
+    text: "Optionally, you can provide a brief description of your dataset. This metadata can be useful later."
+    position: "bottom"
+    waitForElement: 1000
+  - id: upload-button
+    route: newdataset
+    element: "#upload-button-tourstep"
+    title: "Upload Your Dataset"
+    text: "Click the 'Upload' button to upload your dataset. I'll meet you on the other side."
+    position: "bottom"
+    waitForElement: 1000
+    showNextButton: false
+    onTriggerEvent: "upload-button-tourtrigger"
+  - id: variables
+    route: multi
+    element: "#variables-tourstep"
+    title: "Variables"
+    text: "Variables are automatically detected from your files and filenames. NimbusImage will make the best guess as to what the filenames mean."
+    position: "bottom"
+    modalOverlay: false
+    waitForElement: 1000
+  - id: assignments
+    route: multi
+    element: "#assignments-tourstep"
+    title: "Assignments"
+    text: "If you want to override automatic assignments (like, assign Z to Time), you can do so here. Click Clear to remove a variable assignment and then use the dropdown to reassign it."
+    position: "bottom"
+    modalOverlay: false
+    waitForElement: 1000
+  - id: transcode
+    route: multi
+    element: "#transcode-checkbox-tourstep"
+    title: "Transcode"
+    text: "If you want to transcode the files, check this box. This will convert the files to a more optimized format. Most files will benefit from this, but not Nikon ND2 files, which are already pretty good."
+    position: "bottom"
+    waitForElement: 1000
+  - id: submit-button
+    route: multi
+    element: "#submit-button-tourstep"
+    title: "Submit"
+    text: "Click the 'Submit' button to submit your dataset. I'll meet you on the other side."
+    position: "bottom"
+    waitForElement: 1000
+    showNextButton: false
+    onTriggerEvent: "submit-button-tourtrigger"
+  - id: view-dataset
+    route: dataset
+    element: "#view-dataset-button-tourstep"
+    title: "View Dataset"
+    text: "Click the 'View Dataset' button to view your dataset in the image viewer. I'll meet you on the other side."
+    position: "bottom"
+    waitForElement: 1000
+    showNextButton: false
+    onTriggerEvent: "view-dataset-button-tourtrigger"
+  - id: view-dataset-button
+    route: datasetview
+    title: "Made it!"
+    text: "You've made it to the end of the tour. You can now view your dataset."
+    position: "bottom"
+    waitForElement: 2000
+    showNextButton: true

--- a/src/tours/IntroViewerTour.yaml
+++ b/src/tours/IntroViewerTour.yaml
@@ -1,0 +1,87 @@
+name: "Introduction to NimbusImage Viewer"
+entryPoint: datasetview
+popular: true
+category: Introduction
+steps:
+  - id: welcome-tourstep
+    route: datasetview
+    title: "Welcome to the NimbusImage Viewer"
+    text: "This is the NimbusImage Viewer. It allows you to navigate through and view your datasets."
+    position: "bottom"
+    waitForElement: 1000
+    modalOverlay: true
+    showNextButton: true
+
+  - id: navigation-toolbar-tourstep
+    route: datasetview
+    element: "#viewer-toolbar-tourstep"
+    title: "Multi-dimensional navigation"
+    text: "Here you can navigate through your dataset using the sliders. Use hotkeys (w/r for XY, d/e for Z, s/f for Time) for quick navigation."
+    position: "right"
+    waitForElement: 1000
+
+  - id: layer-controls-tourstep
+    route: datasetview
+    element: "#layer-controls-tourstep"
+    title: "Layer Controls"
+    text: "You can toggle layers on and off using the checkboxes here. Quick tip: Use number keys 1-9 to quickly toggle individual layers!"
+    position: "right"
+    modalOverlay: false
+    waitForElement: 1000
+
+  - id: pan-instruction-tourstep
+    route: datasetview
+    title: "Panning the Image"
+    text: "Click and drag anywhere on the image to pan around."
+    position: "left"
+    modalOverlay: false
+    waitForElement: 1000
+
+  - id: zoom-instruction-tourstep
+    route: datasetview
+    title: "Zooming"
+    text: "Use your mouse wheel or trackpad to zoom in and out of the image."
+    position: "left"
+    modalOverlay: false
+
+  - id: rotation-instruction-tourstep
+    route: datasetview
+    title: "Rotation"
+    text: "Use a two-finger pinch gesture on your trackpad to rotate the image."
+    position: "left"
+    modalOverlay: false
+
+  - id: reset-rotation-tourstep
+    route: datasetview
+    element: "#reset-rotation-tourstep"
+    title: "Reset Rotation"
+    text: "Click here to reset the image rotation back to 0 degrees."
+    position: "top"
+    waitForElement: 5000
+    modalOverlay: false
+
+  - id: lock-view-tourstep
+    route: datasetview
+    element: "#lock-view-tourstep"
+    title: "Lock View"
+    text: "Click here to lock/unlock the view. When locked, you cannot pan, zoom, or rotate."
+    position: "top"
+    modalOverlay: false
+    waitForElement: 1000
+
+  - id: contrast-palette-tourstep
+    route: datasetview
+    element: "#layer-info-tourstep"
+    title: "Layer Controls"
+    text: "Click here to adjust contrast settings for each layer."
+    position: "left"
+    modalOverlay: false
+    waitForElement: 1000
+
+  - id: tour-complete-tourstep
+    route: datasetview
+    title: "Tour Complete!"
+    text: "You now know the basics of navigation! Try the advanced navigation tour to learn more features."
+    position: "bottom"
+    modalOverlay: true
+    showNextButton: true

--- a/src/tours/TOURS.md
+++ b/src/tours/TOURS.md
@@ -1,0 +1,166 @@
+# Tour System Documentation
+
+## Overview
+The tour system provides a declarative way to create guided tours through the application's interface. It uses YAML configuration files to define tours, making them easy to maintain and modify without changing application code.
+
+Relevant files include:
+- `src/plugins/tour.ts` - Tour plugin
+- `src/plugins/tour.scss` - Tour styles
+- `src/plugins/tour-trigger.directive.ts` - Tour trigger directive
+- `src/plugins/tourBus.ts` - Tour event bus
+- `src/main.ts` - Tour initialization; added to router
+- `src/tours/TOURS.md` - This file
+- `src/tours/testTourUpload.yaml` - Example tour
+
+## Philosophy
+The tour system follows a declarative approach, where:
+- Tours are defined in YAML files rather than code
+- Components remain unaware of the tour system
+- User interactions are handled through directives rather than explicit event handling
+- Tour logic stays centralized in the tour configuration
+
+## Creating a Tour
+Tours are defined in YAML files in the `src/tours` directory. Each tour consists of metadata and a series of steps.
+
+In your component template, you can set elements for the tour to stop at using `id="mytourstop-tourstep"`:
+
+```vue
+<v-checkbox
+id="mytourstop-tourstep"
+/>
+``` 
+
+To use interactions to advance the tour, use the `v-tour-trigger` directive:
+```vue
+<v-checkbox
+v-tour-trigger="'tour-checkbox-clicked-tourtrigger'"
+v-model="someValue"
+/>
+```
+
+The `-tourstep` and `-tourtrigger` suffixes are used to make the IDs easier to find in the code.
+
+### Basic Structure
+
+```yaml
+name: My Tour # Display name of the tour
+entryPoint: root # Starting route
+popular: true # (Optional) Show in popular tours
+category: Analysis # (Optional) Group tours by category
+steps:
+  - id: step1-tourstep # Unique identifier for the step
+    route: root # Route where this step should appear
+    element: "#my-button-tourstep" # CSS selector for the target element
+    title: "Step Title" # Title shown in the popup
+    text: "Description" # Content shown in the popup
+    position: "bottom" # Popup position (top, bottom, left, right)
+```
+
+### Step Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `id` | string | Unique identifier for the step |
+| `route` | string | Route name where the step should be shown |
+| `element` | string | CSS selector for the target element |
+| `title` | string | Step title |
+| `text` | string | Step description |
+| `position` | string | Popup position (top, bottom, left, right) |
+| `waitForElement` | number | Timeout (ms) to wait for element to appear |
+| `modalOverlay` | boolean | Whether to show a modal overlay (default: true) |
+| `beforeShow` | string | JavaScript code to execute before showing step |
+| `onNext` | string | JavaScript code to execute before advancing |
+| `onTriggerEvent` | string | Event name to wait for before advancing |
+| `showNextButton` | boolean | Whether to show the Next button (default: true) |
+
+### Modal vs Non-Modal Steps
+Steps can be modal (with overlay) or non-modal:
+```yaml
+steps:
+id: modal-step-tourstep
+modalOverlay: true # Shows dark overlay, focuses attention
+# ... other options
+id: non-modal-step-tourstep
+modalOverlay: false # No overlay, allows interaction with UI
+# ... other options
+```
+
+### Event-Driven Steps
+Some steps may require user interaction before advancing. These use the `onTriggerEvent` option:
+
+```yaml
+steps:
+id: interactive-step
+element: "#some-checkbox-tourstep"
+onTriggerEvent: "tour-checkbox-clicked-tourtrigger"
+showNextButton: false # Hide the Next button, require interaction
+# ... other options
+```
+
+In your component template, use the `v-tour-trigger` directive:
+```vue
+<v-checkbox
+v-tour-trigger="'tour-checkbox-clicked-tourtrigger'"
+v-model="someValue"
+/>
+```
+
+## Example Tour
+Here's a complete example of a timelapse analysis tour:
+
+```yaml
+name: Time lapse analysis
+entryPoint: datasetview
+popular: true
+category: Analysis
+steps:
+  - id: timelapse-mode-tourstep
+    route: datasetview
+    element: "#timelapse-mode-tourstep"
+    title: "Timelapse Mode"
+    text: "Enable timelapse mode to view the dataset as a timelapse"
+    position: "bottom"
+    waitForElement: 5000
+    modalOverlay: true
+    beforeShow: "return console.log('About to show timelapse mode step')"
+    onTriggerEvent: "tour-timelapse-mode-clicked-tourtrigger"
+  - id: timelapse-labels-tourstep
+    route: datasetview
+    element: "#timelapse-labels-tourstep"
+    title: "Timelapse Labels"
+    text: "Enable labels for the timelapse"
+    position: "right"
+    waitForElement: 5000
+    modalOverlay: false # Allow interaction with UI
+    onTriggerEvent: "timelapse-labels-tourtrigger"
+```
+
+This tour:
+1. Starts at the dataset view
+2. Shows a modal step highlighting the timelapse mode toggle
+3. Waits for user to click the toggle
+4. Shows a non-modal step about labels
+5. Waits for user to interact with labels before completing
+
+## Best Practices
+1. Use meaningful step IDs; end with "-tourstep" to make them easier to find
+2. Keep text concise and clear
+3. Use modal overlays for important steps
+4. Use non-modal steps when users need to interact with UI
+5. Set reasonable `waitForElement` timeouts
+6. Use `beforeShow` and `onNext` hooks sparingly
+7. Prefer declarative `onTriggerEvent` over imperative hooks
+8. End trigger event names with "-tourtrigger" to make them easier to find
+9. Group related tours in the same category
+10. Test tours with both fast and slow loading conditions
+
+## Technical Details
+The tour system uses:
+- Shepherd.js for the tour UI
+- Vue directives for event handling
+- Vue Router for navigation
+- Event bus for decoupled communication
+
+Tours are loaded dynamically and can be started using:
+```typescript
+this.$startTour('tourName');
+```

--- a/src/tours/testTimelapseTour.yaml
+++ b/src/tours/testTimelapseTour.yaml
@@ -5,7 +5,7 @@ category: Analysis
 steps:
   - id: timelapse-mode
     route: datasetview
-    element: "#timelapse-mode"
+    element: "#timelapse-mode-tourstep"
     title: "Click for Timelapse Mode"
     text: "Enable timelapse mode to allow timelapse analysis. This mode allows you to edit tracks over time."
     position: "bottom"
@@ -17,7 +17,7 @@ steps:
     onTriggerEvent: "timelapse-mode-tourtrigger"
   - id: timelapse-labels
     route: datasetview
-    element: "#timelapse-labels"
+    element: "#timelapse-labels-tourstep"
     title: "Timelapse Labels"
     text: "Enable labels for the timelapse"
     position: "right"
@@ -27,7 +27,7 @@ steps:
     onNext: "return console.log('Next is timelapse window')"
   - id: timelapse-tags
     route: datasetview
-    element: "#timelapse-tags"
+    element: "#timelapse-tags-tourstep"
     title: "Timelapse Tags"
     text: "Select the tags to include in the timelapse"
     position: "top"

--- a/src/tours/testTimelapseTour.yaml
+++ b/src/tours/testTimelapseTour.yaml
@@ -1,0 +1,37 @@
+name: Time lapse analysis
+entryPoint: datasetview
+popular: true
+category: Analysis
+steps:
+  - id: timelapse-mode
+    route: datasetview
+    element: "#timelapse-mode"
+    title: "Click for Timelapse Mode"
+    text: "Enable timelapse mode to allow timelapse analysis. This mode allows you to edit tracks over time."
+    position: "bottom"
+    waitForElement: 1000
+    modalOverlay: true
+    beforeShow: "return console.log('About to show timelapse mode step')"
+    onNext: "return console.log('Next is timelapse window')"
+    showNextButton: false
+    onTriggerEvent: "timelapse-mode-tourtrigger"
+  - id: timelapse-labels
+    route: datasetview
+    element: "#timelapse-labels"
+    title: "Timelapse Labels"
+    text: "Enable labels for the timelapse"
+    position: "right"
+    waitForElement: 1000
+    modalOverlay: false
+    beforeShow: "return console.log('About to show timelapse labels step')"
+    onNext: "return console.log('Next is timelapse window')"
+  - id: timelapse-tags
+    route: datasetview
+    element: "#timelapse-tags"
+    title: "Timelapse Tags"
+    text: "Select the tags to include in the timelapse"
+    position: "top"
+    waitForElement: 1000
+    modalOverlay: true
+    beforeShow: "return console.log('About to show timelapse tags step')"
+    onNext: "return console.log('Completed tour')"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -10,6 +10,7 @@
               <v-card>
                 <v-tabs v-model="uploadTab">
                   <span
+                    id="quick-upload-tab-tourstep"
                     v-tooltip="
                       'Directly upload a file using all default options and then go straight to the image viewer'
                     "
@@ -18,12 +19,15 @@
                     <v-tab> Quick upload/view </v-tab>
                   </span>
                   <span
+                    id="advanced-upload-tab-tourstep"
                     v-tooltip="
                       'Upload a dataset with the option to assign variables to files, composite tiles, and more'
                     "
                     style="display: flex"
                   >
-                    <v-tab> Advanced upload </v-tab>
+                    <v-tab v-tour-trigger="'advanced-upload-tab-tourtrigger'">
+                      Advanced upload
+                    </v-tab>
                   </span>
                 </v-tabs>
               </v-card>

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -44,6 +44,8 @@
                   <v-tooltip top max-width="50vh">
                     <template v-slot:activator="{ on, attrs }">
                       <v-btn
+                        id="view-dataset-button-tourstep"
+                        v-tour-trigger="'view-dataset-button-tourtrigger'"
                         v-on="on"
                         v-bind="attrs"
                         class="ma-1"

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -1,7 +1,9 @@
 <template>
   <v-container>
     <v-card class="pa-4 my-4">
-      <v-subheader class="headline">Variables</v-subheader>
+      <v-subheader id="variables-tourstep" class="headline"
+        >Variables</v-subheader
+      >
       <v-divider class="my-2" />
       <v-data-table :headers="headers" :items="items" item-key="key" />
     </v-card>
@@ -13,7 +15,9 @@
     </v-card>
     <v-card class="pa-4 my-4" v-else>
       <div class="d-flex">
-        <v-subheader class="headline">Assignments</v-subheader>
+        <v-subheader id="assignments-tourstep" class="headline"
+          >Assignments</v-subheader
+        >
         <v-spacer />
         <v-btn
           @click="resetDimensionsToDefault"
@@ -76,6 +80,7 @@
     <v-row>
       <v-col class="d-flex justify-end">
         <v-checkbox
+          id="transcode-checkbox-tourstep"
           dense
           hide-details
           class="mr-8"
@@ -83,6 +88,8 @@
           label="Transcode into optimized TIFF file"
         />
         <v-btn
+          id="submit-button-tourstep"
+          v-tour-trigger="'submit-button-tourtrigger'"
           @click="submit"
           color="green"
           :disabled="!submitEnabled() || isUploading"

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -51,6 +51,7 @@
       </file-dropzone>
 
       <v-text-field
+        id="dataset-name-input-tourstep"
         v-model="name"
         label="Name"
         required
@@ -59,6 +60,7 @@
       />
 
       <v-textarea
+        id="dataset-description-input-tourstep"
         v-model="description"
         label="Description"
         :readonly="pageTwo"
@@ -83,6 +85,8 @@
 
       <div class="button-bar" v-if="!quickupload || pipelineError">
         <v-btn
+          id="upload-button-tourstep"
+          v-tour-trigger="'upload-button-tourtrigger'"
           :disabled="!valid || !filesSelected || uploading || fileSizeExceeded"
           color="success"
           class="mr-4"

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ import vue from "@vitejs/plugin-vue2";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { visualizer } from "rollup-plugin-visualizer";
 import path from "node:path";
+import yaml from "@rollup/plugin-yaml";
 
 // Shouldn't be needed after moving to Vue 3
 import { VuetifyResolver } from "unplugin-vue-components/resolvers";
@@ -38,8 +39,12 @@ const overriddenComponentsToNodeModules = Object.fromEntries(
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    "process.env": {},
+  },
   plugins: [
     vue(),
+    yaml(),
     visualizer(),
     Components({
       resolvers: [VuetifyResolver()],

--- a/vite.config.js
+++ b/vite.config.js
@@ -39,9 +39,6 @@ const overriddenComponentsToNodeModules = Object.fromEntries(
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  define: {
-    "process.env": {},
-  },
   plugins: [
     vue(),
     yaml(),


### PR DESCRIPTION
Check TOURS.md for a description.

Adds a declarative tour manager. You can specify a tour with a clear, easy-to-generate YAML file that simply declares the steps. You then just tag the relevant parts of the template as described in TOURS.md. The tour manager then turns that into a Shepherd tour—no need to edit any script. This should make it relatively easy to make new tours and maintain existing tours, especially using LLMs.