### PR TITLE
Refactored the object panel UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,30 +30,11 @@
       <template v-if="store.dataset && routeName === 'datasetview'">
         <span
           v-tooltip="
-            'Measure properties of your objects, like \'area\' or \'number of spots\''
-          "
-        >
-          <v-btn class="ml-4" @click.stop="toggleRightPanel('analyzePanel')">
-            <v-badge dot color="red" :value="hasUncomputedProperties">
-              Measure objects
-            </v-badge>
-          </v-btn>
-        </span>
-        <span
-          v-tooltip="
             'List of all objects in the dataset, including their properties, and various actions on them'
           "
         >
-          <v-btn
-            class="ml-4"
-            @click.stop="
-              toggleRightPanel('annotationPanel');
-              annotationPanelBadge = false;
-            "
-          >
-            <v-badge dot color="green" :value="annotationPanelBadge">
-              Object list
-            </v-badge>
+          <v-btn class="ml-4" @click.stop="toggleRightPanel('annotationPanel')">
+            Object list
           </v-btn>
         </span>
         <v-divider class="ml-4" vertical />
@@ -265,14 +246,6 @@ export default class App extends Vue {
   @Watch("annotationPanel")
   annotationPanelChanged() {
     this.store.setIsAnnotationPanelOpen(this.annotationPanel);
-  }
-
-  get annotationPanelBadge() {
-    return this.store.annotationPanelBadge;
-  }
-
-  set annotationPanelBadge(value) {
-    this.store.setAnnotationPanelBadge(value);
   }
 
   get routeName() {

--- a/src/components/AnalyzePanel.vue
+++ b/src/components/AnalyzePanel.vue
@@ -1,11 +1,14 @@
 <template>
-  <v-card class="ma-1">
-    <v-card-title> Measure objects </v-card-title>
-    <v-card-text>
-      <property-creation />
-      <property-list />
-    </v-card-text>
-  </v-card>
+  <div class="analyze-panel">
+    <div class="property-container">
+      <property-creation class="property-creation" />
+      <v-card class="property-list-container">
+        <div class="property-list-scroll">
+          <property-list />
+        </div>
+      </v-card>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -21,3 +24,48 @@ import PropertyCreation from "@/components/AnnotationBrowser/AnnotationPropertie
 })
 export default class AnalyzeAnnotations extends Vue {}
 </script>
+
+<style scoped>
+.analyze-panel {
+  width: 100%;
+  max-width: 1200px; /* Ensures dialog will be wide enough */
+}
+
+.property-container {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  min-height: 500px; /* Ensures consistent height */
+}
+
+.property-creation {
+  flex: 0 1 500px; /* Fixed width, can shrink if needed */
+}
+
+.property-list-container {
+  flex: 0 0 400px; /* Fixed width, won't grow or shrink */
+  height: 600px; /* Fixed height */
+  display: flex;
+  flex-direction: column;
+}
+
+.property-list-scroll {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 0;
+}
+
+/* Ensure scrollbar appears nicely in webkit browsers */
+.property-list-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.property-list-scroll::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.property-list-scroll::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 4px;
+}
+</style>

--- a/src/components/AnnotationBrowser/AnnotationBrowser.vue
+++ b/src/components/AnnotationBrowser/AnnotationBrowser.vue
@@ -5,7 +5,9 @@
       <v-expansion-panels hover multiple v-model="expanded">
         <annotation-filters></annotation-filters>
         <annotation-actions></annotation-actions>
-        <annotation-properties></annotation-properties>
+        <annotation-properties
+          @expand="expandProperties"
+        ></annotation-properties>
         <annotation-list @clickedTag="clickedTag"></annotation-list>
       </v-expansion-panels>
     </v-card-text>
@@ -35,6 +37,12 @@ export default class AnnotationBrowser extends Vue {
 
   clickedTag(tag: string) {
     this.filterStore.addTagToTagFilter(tag);
+  }
+
+  expandProperties() {
+    if (!this.expanded.includes(1)) {
+      this.expanded.push(1);
+    }
   }
 }
 </script>

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -6,26 +6,41 @@
       <v-container style="width: auto">
         <v-row>
           <v-col class="pa-0 mx-1">
-            <v-btn block small @click.stop="deleteSelected">
+            <v-btn color="error" small outlined @click.stop="deleteSelected">
               Delete Selected
             </v-btn>
           </v-col>
           <v-col class="pa-0 mx-1">
-            <v-btn block small @click.stop="deleteUnselected">
-              Delete Unselected
-            </v-btn>
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col class="pa-0 mx-1">
-            <v-btn block small @click.stop="showTagDialog = true">
-              Tag Selected
-            </v-btn>
-          </v-col>
-          <v-col class="pa-0 mx-1">
-            <v-btn block small @click.stop="showColorDialog = true">
-              Color Selected
-            </v-btn>
+            <v-menu offset-y>
+              <template v-slot:activator="{ on, attrs }">
+                <v-btn small v-bind="attrs" v-on="on">
+                  More Actions
+                  <v-icon small right>mdi-chevron-down</v-icon>
+                </v-btn>
+              </template>
+              <v-list>
+                <v-list-item @click="deleteUnselected">
+                  <v-list-item-icon>
+                    <v-icon>mdi-delete-outline</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-title>Delete Unselected</v-list-item-title>
+                </v-list-item>
+
+                <v-list-item @click="showTagDialog = true">
+                  <v-list-item-icon>
+                    <v-icon>mdi-tag</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-title>Tag Selected</v-list-item-title>
+                </v-list-item>
+
+                <v-list-item @click="showColorDialog = true">
+                  <v-list-item-icon>
+                    <v-icon>mdi-palette</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-title>Color Selected</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
           </v-col>
         </v-row>
       </v-container>

--- a/src/components/AnnotationBrowser/AnnotationProperties.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties.vue
@@ -1,6 +1,37 @@
 <template>
   <v-expansion-panel>
-    <v-expansion-panel-header>Properties</v-expansion-panel-header>
+    <v-expansion-panel-header>
+      Properties
+      <v-spacer />
+      <v-btn
+        color="primary"
+        dark
+        small
+        dense
+        @click.stop="showAnalyzeDialog = true"
+      >
+        Measure objects
+      </v-btn>
+    </v-expansion-panel-header>
+
+    <v-dialog
+      v-model="showAnalyzeDialog"
+      min-width="900px"
+      max-width="1000px"
+      @input="onDialogClose"
+    >
+      <v-card>
+        <v-card-title>Measure objects</v-card-title>
+        <v-card-text>
+          <analyze-panel />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="onDialogClose(false)">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <v-expansion-panel-content>
       <v-text-field
         v-model="propFilter"
@@ -53,6 +84,7 @@ import { Vue, Component } from "vue-property-decorator";
 import propertyStore from "@/store/properties";
 import filterStore from "@/store/filters";
 import { findIndexOfPath } from "@/utils/paths";
+import AnalyzePanel from "@/components/AnalyzePanel.vue";
 
 interface PropertyItem {
   name: string;
@@ -74,7 +106,11 @@ const tabs = [
 
 type TTabKey = (typeof tabs)[number]["key"];
 
-@Component
+@Component({
+  components: {
+    AnalyzePanel,
+  },
+})
 export default class AnnotationProperties extends Vue {
   readonly propertyStore = propertyStore;
   readonly filterStore = filterStore;
@@ -84,6 +120,7 @@ export default class AnnotationProperties extends Vue {
   propFilter: string | null = null;
   selectedPath: string[] = [];
   activeTabKey: TTabKey = "display";
+  showAnalyzeDialog = false;
 
   get activeTabIndex(): number {
     return tabs.findIndex(({ key }) => this.activeTabKey === key);
@@ -192,6 +229,13 @@ export default class AnnotationProperties extends Vue {
 
   toggleFilter(propertyPath: string[]) {
     this.filterStore.togglePropertyPathFiltering(propertyPath);
+  }
+
+  onDialogClose(value: boolean) {
+    if (!value) {
+      this.showAnalyzeDialog = false;
+      this.$emit("expand");
+    }
   }
 }
 </script>

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
@@ -1,13 +1,16 @@
 <template>
   <v-card>
+    <div class="d-flex align-center px-4 py-2">
+      <span class="text-subtitle-1">Create new property</span>
+    </div>
     <v-card-text>
-      <v-container>
-        <v-row align="center" class="mb-4" dense>
+      <v-container class="pa-2">
+        <v-row align="center" class="mb-1" dense>
           <v-col cols="3">
-            <v-subheader>Measure by tag:</v-subheader>
+            <v-subheader dense>Measure by tag:</v-subheader>
           </v-col>
           <v-col cols="6">
-            <tag-picker v-model="filteringTags" />
+            <tag-picker v-model="filteringTags" dense />
           </v-col>
           <v-col cols="3">
             <v-checkbox
@@ -20,7 +23,7 @@
         </v-row>
         <v-row align="center" dense>
           <v-col cols="3">
-            <v-subheader>{{ shapeSelectionString }}</v-subheader>
+            <v-subheader dense>{{ shapeSelectionString }}</v-subheader>
           </v-col>
           <v-col cols="9">
             <v-select
@@ -28,14 +31,15 @@
               :items="availableShapes"
               label="Shape"
               hide-details
+              dense
               :disabled="filteringTags.length > 0"
             ></v-select>
           </v-col>
         </v-row>
       </v-container>
-      <v-container class="elevation-3 mt-4" v-if="filteringShape !== null">
-        <div class="pb-4 subtitle-1">Measure this property:</div>
-        <v-row>
+      <v-container class="elevation-3 mt-2 pa-2" v-if="filteringShape !== null">
+        <div class="subtitle-1" mb-3>Measure this property:</div>
+        <v-row dense>
           <v-col>
             <docker-image-select
               dense
@@ -45,20 +49,23 @@
           </v-col>
         </v-row>
         <template v-if="dockerImage !== null">
-          <v-row>
+          <v-row dense>
             <v-col>
               <property-worker-menu
                 v-model="interfaceValues"
                 :image="dockerImage"
+                dense
               />
             </v-col>
           </v-row>
-          <v-row>
+          <v-row dense>
             <v-col>
               <v-textarea
                 v-model="originalName"
                 label="Property name"
                 rows="1"
+                dense
+                hide-details
                 :append-icon="isNameGenerated ? '' : 'mdi-refresh'"
                 @click:append="isNameGenerated = true"
                 @input="isNameGenerated = false"
@@ -70,14 +77,16 @@
       <v-checkbox
         v-model="computeUponCreation"
         label="Compute upon creation"
-        class="mt-4"
+        class="mt-2"
+        dense
+        hide-details
       />
-      <div class="button-bar">
+      <div class="button-bar mt-2">
         <v-spacer></v-spacer>
-        <v-btn class="mr-4" color="primary" @click="createProperty">
+        <v-btn class="mr-2" color="primary" small @click="createProperty">
           Create Property
         </v-btn>
-        <v-btn class="mr-4" color="warning" @click="reset">Cancel</v-btn>
+        <v-btn class="mr-2" color="warning" small @click="reset">Reset</v-btn>
       </div>
     </v-card-text>
   </v-card>

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyList.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyList.vue
@@ -1,46 +1,59 @@
 <template>
-  <v-card>
-    <v-card-title> Object Properties </v-card-title>
-    <v-card-text>
-      <v-btn
-        outlined
-        class="ma-2"
-        @click="computeUncomputedProperties"
-        :disabled="uncomputedRunning > 0 || uncomputedProperties.length <= 0"
-      >
-        {{ uncomputedRunning > 0 ? "Computing all" : "Compute all" }}
-        <template v-if="uncomputedRunning > 0">
-          <v-progress-circular indeterminate />
+  <v-card class="d-flex flex-column property-list">
+    <div class="property-header">
+      <div class="d-flex align-center px-4 py-2">
+        <span class="text-subtitle-1">Object Properties</span>
+        <v-spacer></v-spacer>
+        <template v-if="uncomputedProperties.length <= 0">
+          <span class="text-none px-2 success--text">
+            Computations done
+            <v-icon small color="success">mdi-check</v-icon>
+          </span>
         </template>
-        <template v-else>
-          <v-icon right color="primary"> mdi-play </v-icon>
-        </template>
-      </v-btn>
-      <v-container class="pa-0">
-        <v-expansion-panels>
-          <!-- Header for property -->
-          <v-expansion-panel readonly v-if="properties.length > 0">
-            <v-expansion-panel-header>
-              <template v-slot:actions>
-                <v-icon color="transparent">$expand</v-icon>
-              </template>
-            </v-expansion-panel-header>
-          </v-expansion-panel>
-          <!-- List of all the properties -->
-          <v-expansion-panel
-            v-for="(property, index) in properties"
-            :key="`${property.id} ${index}`"
-          >
-            <v-expansion-panel-header>
-              <annotation-property :property="property" />
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <annotation-property-body :property="property" />
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
-      </v-container>
-    </v-card-text>
+        <v-btn
+          v-else
+          text
+          small
+          color="primary"
+          class="text-none px-2"
+          @click="computeUncomputedProperties"
+          :disabled="uncomputedRunning > 0"
+        >
+          {{
+            uncomputedRunning > 0
+              ? "Running uncomputed properties"
+              : "Compute all"
+          }}
+          <template v-if="uncomputedRunning > 0">
+            <v-progress-circular
+              indeterminate
+              size="16"
+              width="2"
+              class="ml-1"
+            />
+          </template>
+          <template v-else>
+            <v-icon small right>mdi-play</v-icon>
+          </template>
+        </v-btn>
+      </div>
+      <v-divider></v-divider>
+    </div>
+    <div class="property-content">
+      <v-expansion-panels>
+        <v-expansion-panel
+          v-for="(property, index) in properties"
+          :key="`${property.id} ${index}`"
+        >
+          <v-expansion-panel-header>
+            <annotation-property :property="property" />
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <annotation-property-body :property="property" />
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </div>
   </v-card>
 </template>
 
@@ -53,6 +66,7 @@ import filterStore from "@/store/filters";
 import TagFilterEditor from "@/components/AnnotationBrowser/TagFilterEditor.vue";
 import AnnotationProperty from "@/components/AnnotationBrowser/AnnotationProperties/Property.vue";
 import AnnotationPropertyBody from "@/components/AnnotationBrowser/AnnotationProperties/PropertyBody.vue";
+import { IAnnotationProperty } from "@/store/model";
 
 @Component({
   components: {
@@ -71,7 +85,7 @@ export default class PropertyList extends Vue {
   }
 
   get uncomputedProperties() {
-    const res = [];
+    const res: IAnnotationProperty[] = [];
     for (const property of this.propertyStore.properties) {
       if (
         this.propertyStore.uncomputedAnnotationsPerProperty[property.id]
@@ -100,3 +114,18 @@ export default class PropertyList extends Vue {
   }
 }
 </script>
+
+<style scoped>
+.property-list {
+  height: 100%;
+}
+
+.property-header {
+  flex: 0 0 auto;
+}
+
+.property-content {
+  flex: 1 1 auto;
+  overflow-y: scroll;
+}
+</style>


### PR DESCRIPTION
Updated the UI for "Measure Objects":

1. Removed the separate Measure objects panel.
2. Moved it to a button on the "Properties" collapsible panel in the objects panel.
3. When you close the new "Measurements" dialog, it automatically opens the "Properties" collapsible panel, which makes it more discoverable.
4. Minor UI improvements.