### PR TITLE
Fixed palette icon

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -118,7 +118,7 @@
           v-on="on"
           class="layer-info-btn"
           color="primary"
-          v-if="store.layers.length > 0"
+          :disabled="store.layers.length === 0"
         >
           <v-icon size="38">mdi-palette</v-icon>
         </v-btn>


### PR DESCRIPTION
We were having an issue where the palette icon for the contrast adjustment was sometimes not displaying. It seems to be an issue with the v-if conditional. I changed it to a :disabled logic, and it works fine now.