### PR TITLE
Updated scrolling behavior and viewer tour

### DIFF
--- a/src/plugins/tour.ts
+++ b/src/plugins/tour.ts
@@ -237,6 +237,13 @@ export class TourManager {
                   offset: [0, 15],
                 },
               },
+              {
+                name: "preventOverflow",
+                options: {
+                  boundary: "viewport",
+                  padding: 10,
+                },
+              },
             ],
           },
           title: step.title,

--- a/src/plugins/tour.ts
+++ b/src/plugins/tour.ts
@@ -131,7 +131,7 @@ export class TourManager {
       useModalOverlay: true,
       defaultStepOptions: {
         classes: "shepherd-theme-custom",
-        scrollTo: true,
+        scrollTo: false,
         cancelIcon: {
           enabled: true,
         },

--- a/src/tours/IntroViewerTour.yaml
+++ b/src/tours/IntroViewerTour.yaml
@@ -29,6 +29,13 @@ steps:
     modalOverlay: false
     waitForElement: 1000
 
+  - id: zoom-instruction-tourstep
+    route: datasetview
+    title: "Zooming"
+    text: "Use your mouse wheel or trackpad to zoom in and out of the image."
+    position: "left"
+    modalOverlay: false
+    
   - id: pan-instruction-tourstep
     route: datasetview
     title: "Panning the Image"
@@ -36,13 +43,6 @@ steps:
     position: "left"
     modalOverlay: false
     waitForElement: 1000
-
-  - id: zoom-instruction-tourstep
-    route: datasetview
-    title: "Zooming"
-    text: "Use your mouse wheel or trackpad to zoom in and out of the image."
-    position: "left"
-    modalOverlay: false
 
   - id: rotation-instruction-tourstep
     route: datasetview
@@ -57,7 +57,7 @@ steps:
     title: "Reset Rotation"
     text: "Click here to reset the image rotation back to 0 degrees."
     position: "top"
-    waitForElement: 5000
+    waitForElement: 1000
     modalOverlay: false
 
   - id: lock-view-tourstep


### PR DESCRIPTION
Set scrollto to false to avoid the interface shifting around unpredictably. Reduced timeout for the rotation to avoid user confusion. Swapped order of pan and zoom so that hopefully the user zooms first to make panning possible.