### PR TITLE
Multiple large images

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -265,7 +265,7 @@ export default class ImageViewer extends Vue {
   @Prop({ type: Boolean, default: false }) readonly shouldResetMaps!: boolean;
 
   @Watch("shouldResetMaps")
-  onShouldResetMapsChange(newValue: boolean) {
+  onShouldResetMaps(newValue: boolean) {
     if (newValue) {
       this.resetMapsOnDraw = true;
       this.draw();

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -157,7 +157,7 @@
 <script lang="ts">
 // in cosole debugging, you can access the map via
 //  $('.geojs-map').data('data-geojs-map')
-import { Vue, Component, Watch } from "vue-property-decorator";
+import { Vue, Component, Watch, Prop } from "vue-property-decorator";
 import annotationStore from "@/store/annotation";
 import progressStore from "@/store/progress";
 import store from "@/store";
@@ -260,6 +260,19 @@ function isMouseStartEvent(evt: MouseEvent): boolean {
   },
 })
 export default class ImageViewer extends Vue {
+  // TODO: I'm not sure if we really need this watcher, because I'm not sure this is how to redraw
+  // the images after a large image change.
+  @Prop({ type: Boolean, default: false }) readonly shouldResetMaps!: boolean;
+
+  @Watch("shouldResetMaps")
+  onShouldResetMapsChange(newValue: boolean) {
+    if (newValue) {
+      this.resetMapsOnDraw = true;
+      this.draw();
+      this.$emit("reset-complete");
+    }
+  }
+
   readonly store = store;
   readonly annotationStore = annotationStore;
   readonly girderResources = girderResources;
@@ -531,9 +544,9 @@ export default class ImageViewer extends Vue {
   }
 
   // TODO: This currently does nothing. However, this used to be where the
-  // histogram cachine was reloaded based on the running jobs. We could implement
-  // something like that again if we want to show the progress bars for the
-  // various caching processes (histograms, annotations, quad frames, etc.).
+  // histogram cache progress was reloaded based on the running jobs. We could
+  // implement something like that again if we want to show the progress bars for
+  // the various caching processes (histograms, annotations, quad frames, etc.).
   async datasetReset() {
     const datasetId = this.dataset?.id;
     if (!datasetId) {

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -65,6 +65,7 @@ import { Vue, Component, Watch } from "vue-property-decorator";
 import store from "@/store";
 import { IGirderLargeImage } from "@/girder";
 import { DEFAULT_LARGE_IMAGE_SOURCE } from "@/girder/index";
+import { logError } from "@/utils/log";
 
 @Component
 export default class LargeImageDropdown extends Vue {
@@ -157,6 +158,8 @@ export default class LargeImageDropdown extends Vue {
       );
       if (image) {
         this.store.updateCurrentLargeImage(image);
+      } else {
+        logError("LargeImageDropdown", "Current large image not found");
       }
     }
   }

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -1,0 +1,101 @@
+<template>
+  <v-select
+    v-model="currentLargeImage"
+    :items="formattedLargeImages"
+    item-text="displayName"
+    item-value="_id"
+    label="Select Image"
+    dense
+    style="width: auto; padding: 4px 0"
+    hide-details
+  >
+    <template v-slot:item="{ item }">
+      <v-list-item-content>
+        <v-list-item-title>{{ item.displayName }}</v-list-item-title>
+        <v-list-item-subtitle
+          v-if="item.meta"
+          class="text--secondary"
+          style="font-size: 0.875rem; opacity: 0.7"
+          >{{ formatMeta(item.meta) }}</v-list-item-subtitle
+        >
+      </v-list-item-content>
+    </template>
+    <template v-slot:selection="{ item }">
+      <v-list-item-content style="max-width: none; white-space: normal">
+        <v-list-item-title>{{ item.displayName }}</v-list-item-title>
+        <v-list-item-subtitle
+          v-if="item.meta"
+          class="text--secondary"
+          style="white-space: normal; font-size: 0.875rem; opacity: 0.7"
+          >{{ formatMeta(item.meta) }}</v-list-item-subtitle
+        >
+      </v-list-item-content>
+    </template>
+  </v-select>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from "vue-property-decorator";
+import store from "@/store";
+import { IGirderLargeImage } from "@/girder";
+
+@Component
+export default class LargeImageDropdown extends Vue {
+  readonly store = store;
+
+  get largeImages() {
+    return this.store.allLargeImages;
+  }
+
+  get formattedLargeImages() {
+    return this.largeImages.map((img: IGirderLargeImage) => ({
+      ...img,
+      displayName: this.formatName(img.name),
+    }));
+  }
+
+  formatName(name: string): string {
+    if (name === "multi-source2.json") {
+      return "Original image";
+    }
+    // Handle cases like "output.tiff (1)" -> "output (1)"
+    const baseName = name.replace(/^(.+)\.[^.\s(]+(.*)$/, "$1$2");
+    return baseName;
+  }
+
+  formatMeta(meta: Record<string, any>): string {
+    const pairs: string[] = [];
+
+    // Add tool first if it exists
+    if (meta.tool) {
+      pairs.push(`tool: ${meta.tool}`);
+    }
+
+    // Add remaining keys in alphabetical order
+    Object.entries(meta)
+      .filter(([key]) => key !== "tool")
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([key, value]) => {
+        pairs.push(`${key}: ${value}`);
+      });
+
+    return pairs.join("; ");
+  }
+
+  get currentLargeImage() {
+    return this.store.currentLargeImage?._id || null;
+  }
+
+  set currentLargeImage(imageId: string | null) {
+    if (imageId) {
+      // Find the full image object from the ID
+      const image = this.largeImages.find(
+        (img: IGirderLargeImage) => img._id === imageId,
+      );
+      if (image) {
+        this.store.updateCurrentLargeImage(image);
+      }
+    }
+  }
+}
+</script>

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -11,7 +11,7 @@
     hide-details
   >
     <template v-slot:item="{ item }">
-      <v-list-item-content>
+      <v-list-item-content style="flex: 1 1 auto; min-width: 0">
         <v-list-item-title>{{ item.displayName }}</v-list-item-title>
         <v-list-item-subtitle
           v-if="item.meta"
@@ -33,7 +33,9 @@
       </v-btn>
     </template>
     <template v-slot:selection="{ item }">
-      <v-list-item-content style="max-width: none; white-space: normal">
+      <v-list-item-content
+        style="flex: 1 1 auto; min-width: 0; white-space: normal"
+      >
         <v-list-item-title>{{ item.displayName }}</v-list-item-title>
         <v-list-item-subtitle
           v-if="item.meta"

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -75,7 +75,6 @@ export default class LargeImageDropdown extends Vue {
 
   mounted() {
     this.previousNumberOfImages = this.numberOfLargeImages;
-    console.log("mounted", this.previousNumberOfImages);
   }
 
   get largeImages() {

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -1,55 +1,67 @@
 <template>
-  <v-select
-    v-if="shouldShow"
-    v-model="currentLargeImage"
-    :items="formattedLargeImages"
-    item-text="displayName"
-    item-value="_id"
-    label="Select Image"
-    dense
-    style="width: auto; padding: 4px 0"
-    hide-details
-  >
-    <template v-slot:item="{ item }">
-      <v-list-item-content style="flex: 1 1 auto; min-width: 0">
-        <v-list-item-title>{{ item.displayName }}</v-list-item-title>
-        <v-list-item-subtitle
-          v-if="item.meta"
-          class="text--secondary"
-          style="font-size: 0.875rem; opacity: 0.7"
-          >{{ formatMeta(item.meta) }}</v-list-item-subtitle
+  <div style="position: relative">
+    <v-select
+      v-if="shouldShow"
+      v-model="currentLargeImage"
+      :items="formattedLargeImages"
+      item-text="displayName"
+      item-value="_id"
+      label="Select Image"
+      dense
+      style="width: auto; padding: 4px 0"
+      hide-details
+    >
+      <template v-slot:item="{ item }">
+        <v-list-item-content style="flex: 1 1 auto; min-width: 0">
+          <v-list-item-title>{{ item.displayName }}</v-list-item-title>
+          <v-list-item-subtitle
+            v-if="item.meta"
+            class="text--secondary"
+            style="font-size: 0.875rem; opacity: 0.7"
+            >{{ formatMeta(item.meta) }}</v-list-item-subtitle
+          >
+        </v-list-item-content>
+        <v-btn
+          v-if="item.name !== 'multi-source2.json'"
+          icon
+          small
+          color="error"
+          class="ml-2"
+          :loading="deletingImageId === item._id"
+          @click.stop="deleteImage(item)"
         >
-      </v-list-item-content>
-      <v-btn
-        v-if="item.name !== 'multi-source2.json'"
-        icon
-        small
-        color="error"
-        class="ml-2"
-        :loading="deletingImageId === item._id"
-        @click.stop="deleteImage(item)"
-      >
-        <v-icon small>mdi-delete</v-icon>
-      </v-btn>
-    </template>
-    <template v-slot:selection="{ item }">
-      <v-list-item-content
-        style="flex: 1 1 auto; min-width: 0; white-space: normal"
-      >
-        <v-list-item-title>{{ item.displayName }}</v-list-item-title>
-        <v-list-item-subtitle
-          v-if="item.meta"
-          class="text--secondary"
-          style="white-space: normal; font-size: 0.875rem; opacity: 0.7"
-          >{{ formatMeta(item.meta) }}</v-list-item-subtitle
+          <v-icon small>mdi-delete</v-icon>
+        </v-btn>
+      </template>
+      <template v-slot:selection="{ item }">
+        <v-list-item-content
+          style="flex: 1 1 auto; min-width: 0; white-space: normal"
         >
-      </v-list-item-content>
-    </template>
-  </v-select>
+          <v-list-item-title>{{ item.displayName }}</v-list-item-title>
+          <v-list-item-subtitle
+            v-if="item.meta"
+            class="text--secondary"
+            style="white-space: normal; font-size: 0.875rem; opacity: 0.7"
+            >{{ formatMeta(item.meta) }}</v-list-item-subtitle
+          >
+        </v-list-item-content>
+      </template>
+    </v-select>
+
+    <v-fade-transition>
+      <v-overlay
+        v-if="showNewImageIndicator"
+        absolute
+        opacity="0.2"
+        color="success"
+      >
+      </v-overlay>
+    </v-fade-transition>
+  </div>
 </template>
 
 <script lang="ts">
-import { Vue, Component } from "vue-property-decorator";
+import { Vue, Component, Watch } from "vue-property-decorator";
 import store from "@/store";
 import { IGirderLargeImage } from "@/girder";
 
@@ -58,8 +70,34 @@ export default class LargeImageDropdown extends Vue {
   readonly store = store;
   deletingImageId: string | null = null;
 
+  previousNumberOfImages = 0;
+  showNewImageIndicator = false;
+
+  mounted() {
+    this.previousNumberOfImages = this.numberOfLargeImages;
+    console.log("mounted", this.previousNumberOfImages);
+  }
+
   get largeImages() {
     return this.store.allLargeImages;
+  }
+
+  get numberOfLargeImages() {
+    return this.largeImages.length;
+  }
+
+  @Watch("numberOfLargeImages")
+  onNumberOfLargeImagesChange(newValue: number) {
+    if (
+      newValue > this.previousNumberOfImages &&
+      this.previousNumberOfImages > 0
+    ) {
+      this.showNewImageIndicator = true;
+      setTimeout(() => {
+        this.showNewImageIndicator = false;
+      }, 1500); // Hide after 1.5 seconds
+    }
+    this.previousNumberOfImages = newValue;
   }
 
   get formattedLargeImages() {

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -19,6 +19,17 @@
           >{{ formatMeta(item.meta) }}</v-list-item-subtitle
         >
       </v-list-item-content>
+      <v-btn
+        v-if="item.name !== 'multi-source2.json'"
+        icon
+        small
+        color="error"
+        class="ml-2"
+        :loading="deletingImageId === item._id"
+        @click.stop="deleteImage(item)"
+      >
+        <v-icon small>mdi-delete</v-icon>
+      </v-btn>
     </template>
     <template v-slot:selection="{ item }">
       <v-list-item-content style="max-width: none; white-space: normal">
@@ -42,6 +53,7 @@ import { IGirderLargeImage } from "@/girder";
 @Component
 export default class LargeImageDropdown extends Vue {
   readonly store = store;
+  deletingImageId: string | null = null;
 
   get largeImages() {
     return this.store.allLargeImages;
@@ -80,6 +92,15 @@ export default class LargeImageDropdown extends Vue {
       });
 
     return pairs.join("; ");
+  }
+
+  async deleteImage(image: IGirderLargeImage) {
+    this.deletingImageId = image._id;
+    try {
+      await this.store.deleteLargeImage(image);
+    } finally {
+      this.deletingImageId = null;
+    }
   }
 
   get currentLargeImage() {

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -22,7 +22,7 @@
           >
         </v-list-item-content>
         <v-btn
-          v-if="item.name !== 'multi-source2.json'"
+          v-if="item.name !== DEFAULT_LARGE_IMAGE_SOURCE"
           icon
           small
           color="error"
@@ -64,10 +64,12 @@
 import { Vue, Component, Watch } from "vue-property-decorator";
 import store from "@/store";
 import { IGirderLargeImage } from "@/girder";
+import { DEFAULT_LARGE_IMAGE_SOURCE } from "@/girder/index";
 
 @Component
 export default class LargeImageDropdown extends Vue {
   readonly store = store;
+  readonly DEFAULT_LARGE_IMAGE_SOURCE = DEFAULT_LARGE_IMAGE_SOURCE;
   deletingImageId: string | null = null;
 
   previousNumberOfImages = 0;
@@ -107,7 +109,7 @@ export default class LargeImageDropdown extends Vue {
   }
 
   formatName(name: string): string {
-    if (name === "multi-source2.json") {
+    if (name === DEFAULT_LARGE_IMAGE_SOURCE) {
       return "Original image";
     }
     // Handle cases like "output.tiff (1)" -> "output (1)"

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -1,5 +1,6 @@
 <template>
   <v-select
+    v-if="shouldShow"
     v-model="currentLargeImage"
     :items="formattedLargeImages"
     item-text="displayName"
@@ -117,6 +118,10 @@ export default class LargeImageDropdown extends Vue {
         this.store.updateCurrentLargeImage(image);
       }
     }
+  }
+
+  get shouldShow(): boolean {
+    return this.largeImages.length > 1;
   }
 }
 </script>

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -200,24 +200,25 @@ export default class ViewerToolbar extends Vue {
   }
 
   @Watch("currentLargeImage")
-  handleImageChange(largeImageId: string) {
+  async handleImageChange(largeImageId: string) {
     if (!largeImageId || !this.store.dataset?.id) return;
     const largeImage = this.largeImages.find((d) => d._id === largeImageId);
     if (!largeImage) return;
 
-    this.girderResources.setCurrentLargeImage({
+    await this.girderResources.setCurrentLargeImage({
       datasetId: this.store.dataset.id,
       largeImage,
     });
 
-    this.store.api.flushCaches();
-    this.store.refreshDataset();
+    await this.girderResources.forceFetchResource({
+      id: this.store.dataset.id,
+      type: "folder",
+    });
 
-    // Emit event to trigger map redraw
-    // TODO: I'm not sure if this is necessary, because I'm not sure this is how to redraw
-    // the images after a large image change. Passes event up to Viewer.vue, which send a prop
-    // to ImageViewer.vue, which triggers a redraw.
-    this.$emit("image-changed");
+    // TODO: Perhaps we need to flush caches here? Otherwise, we might not update the histograms and so on appropriately.
+    // It doesn't seem to be a problem, but probably requires more testing.
+    // this.store.api.flushCaches();
+    await this.store.refreshDataset();
   }
 
   get xy() {

--- a/src/girder/index.ts
+++ b/src/girder/index.ts
@@ -42,15 +42,20 @@ export interface IGirderFile extends IGirderBase {
   _modelType: "file";
 }
 
-// TODO: Update this type as we decide what the largeImage object should look like
+// TODO: This type is essentially a wrapper around the IGirderItem type for now.
+// It is defined in case we want to add more properties to the largeImage object in the future.
 export interface IGirderLargeImage extends IGirderItem {
   largeImage: {
-    sourceName: string;
-    sourceKey: string;
     fileId: string;
     [key: string]: any;
   };
 }
+
+// For whatever reason, the default large image source was named "multi-source2.json"
+// This constant is used to identify the default large image source throughout the interface.
+// See, for instance, the LargeImageDropdown.vue component, in which it is used to determine
+// which large image is the "original" large image.
+export const DEFAULT_LARGE_IMAGE_SOURCE = "multi-source2.json";
 
 export type IGirderLocation =
   | IGirderUser

--- a/src/girder/index.ts
+++ b/src/girder/index.ts
@@ -42,6 +42,16 @@ export interface IGirderFile extends IGirderBase {
   _modelType: "file";
 }
 
+// TODO: Update this type as we decide what the largeImage object should look like
+export interface IGirderLargeImage extends IGirderItem {
+  largeImage: {
+    sourceName: string;
+    sourceKey: string;
+    fileId: string;
+    [key: string]: any;
+  };
+}
+
 export type IGirderLocation =
   | IGirderUser
   | IGirderFolder

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -6,6 +6,7 @@ import {
   IGirderUser,
   IGirderFile,
   IGirderAssetstore,
+  IGirderLargeImage,
 } from "@/girder";
 import {
   configurationBaseKeys,
@@ -418,6 +419,7 @@ export default class GirderAPI {
       "metadata",
       JSON.stringify({
         subtype: "contrastDataset",
+        selectedLargeImageId: null,
       }),
     );
     return this.client.post("folder", data).then((r) => asDataset(r.data));
@@ -429,6 +431,28 @@ export default class GirderAPI {
         subtype: "contrastDataset",
       })
       .then((r) => asDataset(r.data));
+  }
+
+  async updateDatasetMetadata(
+    datasetId: string,
+    metadata: Record<string, any>,
+  ) {
+    // First get existing metadata
+    const response = await this.client.get(`folder/${datasetId}`);
+    const existingMetadata = response.data.meta || {};
+
+    // Merge existing metadata with new metadata
+    const updatedMetadata = {
+      ...existingMetadata,
+      ...metadata,
+    };
+
+    const data = new FormData();
+    data.set("id", datasetId);
+    data.set("metadata", JSON.stringify(updatedMetadata));
+
+    // Update the dataset metadata
+    return this.client.put(`folder/${datasetId}/metadata`, data);
   }
 
   deleteDataset(dataset: IDataset): Promise<IDataset> {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -6,6 +6,7 @@ import {
   IGirderUser,
   IGirderFile,
   IGirderAssetstore,
+  IGirderLargeImage,
 } from "@/girder";
 import {
   configurationBaseKeys,
@@ -328,6 +329,10 @@ export default class GirderAPI {
     return this.getItems(folderId).then((items) =>
       items.filter((d) => d.largeImage),
     );
+  }
+
+  deleteLargeImage(largeImage: IGirderLargeImage) {
+    return this.client.delete(`/item/${largeImage._id}`);
   }
 
   createDatasetView(datasetViewBase: IDatasetViewBase) {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -6,7 +6,6 @@ import {
   IGirderUser,
   IGirderFile,
   IGirderAssetstore,
-  IGirderLargeImage,
 } from "@/girder";
 import {
   configurationBaseKeys,

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -995,7 +995,12 @@ export class Annotations extends VuexModule {
 
     jobs.addJob(computeJob).then((success: boolean) => {
       this.fetchAnnotations();
-      main.loadLargeImages(); // I'm pretty sure this function won't reload the large image if it's already loaded
+      // If this was a worker that makes a new large_image, this line will load it
+      // I'm pretty sure this function won't reload the large image if it's already loaded
+      main.loadLargeImages();
+      main.scheduleTileFramesComputation(datasetId);
+      main.scheduleMaxMergeCache(datasetId);
+      main.scheduleHistogramCache(datasetId);
       // TODO: We may also want to fetch connections and properties here, depending on flags set in the worker image
       progress.complete(progressId);
       callback(success);

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -997,7 +997,7 @@ export class Annotations extends VuexModule {
       this.fetchAnnotations();
       // If this was a worker that makes a new large_image, this line will load it
       // I'm pretty sure this function won't reload the large image if it's already loaded
-      main.loadLargeImages();
+      main.loadLargeImages(true); // true means switch to the new large image
       main.scheduleTileFramesComputation(datasetId);
       main.scheduleMaxMergeCache(datasetId);
       main.scheduleHistogramCache(datasetId);

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -995,6 +995,7 @@ export class Annotations extends VuexModule {
 
     jobs.addJob(computeJob).then((success: boolean) => {
       this.fetchAnnotations();
+      main.loadLargeImages(); // I'm pretty sure this function won't reload the large image if it's already loaded
       // TODO: We may also want to fetch connections and properties here, depending on flags set in the worker image
       progress.complete(progressId);
       callback(success);

--- a/src/store/girderResources.ts
+++ b/src/store/girderResources.ts
@@ -211,11 +211,7 @@ export class GirderResources extends VuexModule {
     datasetId: string,
   ): Promise<IGirderLargeImage | null> {
     const resource = await this.getFolder(datasetId);
-    if (!resource) {
-      return null;
-    }
-
-    if (resource.meta.subtype !== "contrastDataset") {
+    if (!resource || resource.meta.subtype !== "contrastDataset") {
       return null;
     }
 

--- a/src/store/girderResources.ts
+++ b/src/store/girderResources.ts
@@ -15,14 +15,10 @@ import {
 } from "@/girder";
 import Vue from "vue";
 import { IDataset, IDatasetConfiguration } from "./model";
-import GirderAPI, {
-  asConfigurationItem,
-  asDataset,
-  parseTiles,
-} from "./GirderAPI";
+import { asConfigurationItem, asDataset, parseTiles } from "./GirderAPI";
 
 /**
- * Store to cache requests to resources, mostly items and folder
+ * Store to cache requests to resources, mostly items and folders
  */
 @Module({ dynamic: true, store, name: "girderResources" })
 export class GirderResources extends VuexModule {
@@ -229,7 +225,7 @@ export class GirderResources extends VuexModule {
       const item = await this.getItem(resource.meta.selectedLargeImageId);
       if (item) {
         return item as IGirderLargeImage;
-      } // If there is no item with that id, then just keep going to look for first large image
+      }
     }
 
     // If there is no selectedLargeImageId, then return the first large image

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -659,10 +659,10 @@ export class Main extends VuexModule {
           }
         }
       }
-    } else {
-      logError("Store", "No large images found");
-      return null;
     }
+
+    logError("Store", "No large images found");
+    return null;
   }
 
   @Action

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -621,8 +621,10 @@ export class Main extends VuexModule {
   }
 
   @Action
-  async loadLargeImages(switchToNewLargeImage: boolean = false) {
-    if (!this.dataset?.id) return;
+  async loadLargeImages(
+    switchToNewLargeImage: boolean = false,
+  ): Promise<IGirderLargeImage | null> {
+    if (!this.dataset?.id) return null;
 
     const oldAllLargeImages = this.allLargeImages;
 
@@ -641,6 +643,9 @@ export class Main extends VuexModule {
         // If we are switching to a new large image, we need to update the current large image
         if (newLargeImage) {
           this.updateCurrentLargeImage(newLargeImage);
+          return newLargeImage;
+        } else {
+          return null;
         }
       } else {
         if (newAllLargeImages.length > 0 && !this.currentLargeImage) {
@@ -648,10 +653,12 @@ export class Main extends VuexModule {
             await this.girderResources.getCurrentLargeImage(this.dataset.id);
           if (currentLargeImage) {
             this.setCurrentLargeImage(currentLargeImage);
+            return currentLargeImage;
           }
         }
       }
     }
+    return null;
   }
 
   @Action

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -594,6 +594,27 @@ export class Main extends VuexModule {
     await this.refreshDataset();
   }
 
+  @Action
+  async deleteLargeImage(largeImage: IGirderLargeImage) {
+    if (!this.dataset?.id || !largeImage._id) return;
+
+    if (largeImage.name === "multi-source2.json") {
+      return;
+    }
+
+    if (largeImage._id === this.currentLargeImage?._id) {
+      const originalLargeImage = this.allLargeImages.find(
+        (img) => img.name === "multi-source2.json",
+      );
+      if (originalLargeImage) {
+        this.updateCurrentLargeImage(originalLargeImage);
+      }
+    }
+
+    await this.api.deleteLargeImage(largeImage);
+    await this.loadLargeImages();
+  }
+
   @Mutation
   setAllLargeImages(images: IGirderLargeImage[]) {
     this.allLargeImages = images;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,6 +7,7 @@ import {
   IGirderSelectAble,
   IGirderUser,
   IGirderLargeImage,
+  DEFAULT_LARGE_IMAGE_SOURCE,
 } from "@/girder";
 import type { AxiosError } from "axios";
 import {
@@ -598,13 +599,14 @@ export class Main extends VuexModule {
   async deleteLargeImage(largeImage: IGirderLargeImage) {
     if (!this.dataset?.id || !largeImage._id) return;
 
-    if (largeImage.name === "multi-source2.json") {
+    // Do not delete the default large image (original data)
+    if (largeImage.name === DEFAULT_LARGE_IMAGE_SOURCE) {
       return;
     }
 
     if (largeImage._id === this.currentLargeImage?._id) {
       const originalLargeImage = this.allLargeImages.find(
-        (img) => img.name === "multi-source2.json",
+        (img) => img.name === DEFAULT_LARGE_IMAGE_SOURCE,
       );
       if (originalLargeImage) {
         this.updateCurrentLargeImage(originalLargeImage);
@@ -657,8 +659,10 @@ export class Main extends VuexModule {
           }
         }
       }
+    } else {
+      logError("Store", "No large images found");
+      return null;
     }
-    return null;
   }
 
   @Action
@@ -1120,7 +1124,7 @@ export class Main extends VuexModule {
       sync.setSaving(true);
       const newFile = (
         await this.api.uploadJSONFile(
-          "multi-source2.json",
+          DEFAULT_LARGE_IMAGE_SOURCE,
           metadata,
           parentId,
           "folder",

--- a/src/utils/girderSelectable.ts
+++ b/src/utils/girderSelectable.ts
@@ -20,6 +20,7 @@ export function isDatasetFolder(selectable: IGirderSelectAble): boolean {
     selectable.meta.subtype === "contrastDataset"
   );
 }
+
 export function toDatasetFolder(
   selectable: IGirderSelectAble,
 ): IGirderFolder | null {

--- a/src/views/datasetView/Viewer.vue
+++ b/src/views/datasetView/Viewer.vue
@@ -1,12 +1,16 @@
 <template>
   <div class="viewer">
     <aside class="side">
-      <viewer-toolbar class="toolbar">
+      <viewer-toolbar class="toolbar" @image-changed="handleImageChanged">
         <!-- <contrast-panels /> -->
         <display-layers />
       </viewer-toolbar>
     </aside>
-    <image-viewer class="main" />
+    <image-viewer
+      class="main"
+      :should-reset-maps="shouldResetMaps"
+      @reset-complete="handleResetComplete"
+    />
   </div>
 </template>
 <script lang="ts">
@@ -32,6 +36,8 @@ export default class Viewer extends Vue {
   readonly store = store;
   readonly annotationStore = annotationStore;
   readonly propertyStore = propertiesStore;
+
+  shouldResetMaps = false;
 
   mounted() {
     this.datasetChanged();
@@ -61,6 +67,14 @@ export default class Viewer extends Vue {
   @Watch("configuration")
   configurationChanged() {
     this.propertyStore.fetchProperties();
+  }
+
+  handleImageChanged() {
+    this.shouldResetMaps = true;
+  }
+
+  handleResetComplete() {
+    this.shouldResetMaps = false;
   }
 }
 </script>


### PR DESCRIPTION
Adds support for multiple large_images as the raw data. This allows for e.g. gaussian blurring, registration, and other types of pixel-level manipulation.

To test, run

```
docker build -f ./workers/annotations/gaussian_blur/Dockerfile -t annotations/gaussian_blur:latest ./workers/annotations/gaussian_blur/
```

Then you will have a new Gaussian Blur worker that can be used to do some processing.

Some future work could be:
1. To create either a subsection of tools or even a whole other panel to select these particular image processing workers.
2. Build a few more abstractions for workers to list and access various large_images more easily.
3. When the dataset refreshes, maintain the zoom level.
4. Watch out for quotas.