### PR TITLE
Added channel checkbox group to worker interface

### DIFF
--- a/src/components/ChannelCheckboxGroup.vue
+++ b/src/components/ChannelCheckboxGroup.vue
@@ -1,17 +1,19 @@
 <template>
   <v-container class="pa-0">
     <v-subheader v-if="label" class="px-0">{{ label }}</v-subheader>
-    <v-row v-for="item in channelItems" :key="item.value" class="ma-0">
-      <v-col cols="12" class="pa-1">
-        <v-checkbox
-          v-model="selectedChannels[item.value]"
-          :label="item.text"
-          dense
-          hide-details
-          v-bind="$attrs"
-        ></v-checkbox>
-      </v-col>
-    </v-row>
+    <template v-if="channelItems && channelItems.length">
+      <v-row v-for="item in channelItems" :key="item.value" class="ma-0">
+        <v-col cols="12" class="pa-1">
+          <v-checkbox
+            v-model="selectedChannels[item.value]"
+            :label="item.text"
+            dense
+            hide-details
+            v-bind="$attrs"
+          ></v-checkbox>
+        </v-col>
+      </v-row>
+    </template>
   </v-container>
 </template>
 
@@ -26,34 +28,32 @@ export default class ChannelCheckboxGroup extends Vue {
   @Prop({ default: "" })
   readonly label!: string;
 
-  @VModel({ type: Object })
+  @VModel({ type: Object, default: () => ({}) })
   selectedChannels!: { [key: number]: boolean };
 
   get channelItems() {
-    const res = [];
-    if (this.store.dataset) {
-      for (const channel of this.store.dataset.channels) {
-        res.push({
-          text:
-            this.store.dataset.channelNames.get(channel) ||
-            `Channel ${channel}`,
-          value: channel,
-        });
-      }
-    }
-    return res;
+    if (!this.store.dataset) return [];
+
+    return this.store.dataset.channels.map((channel: number) => ({
+      text:
+        this.store.dataset?.channelNames?.get(channel) || `Channel ${channel}`,
+      value: channel,
+    }));
   }
 
   created() {
-    // Initialize selectedChannels if empty
-    if (!this.selectedChannels) {
-      const initial: { [key: number]: boolean } = {};
-      if (this.store.dataset) {
-        for (const channel of this.store.dataset.channels) {
-          initial[channel] = false;
+    // Initialize selectedChannels with an empty object if undefined
+    this.selectedChannels = this.selectedChannels || {};
+
+    // Then add any missing channels
+    if (this.store.dataset?.channels) {
+      const updatedChannels = { ...this.selectedChannels };
+      for (const channel of this.store.dataset.channels) {
+        if (!(channel in updatedChannels)) {
+          updatedChannels[channel] = false;
         }
       }
-      this.selectedChannels = initial;
+      this.selectedChannels = updatedChannels;
     }
   }
 }

--- a/src/components/ChannelCheckboxGroup.vue
+++ b/src/components/ChannelCheckboxGroup.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-container class="pa-0">
+    <v-subheader v-if="label" class="px-0">{{ label }}</v-subheader>
+    <v-row v-for="item in channelItems" :key="item.value" class="ma-0">
+      <v-col cols="12" class="pa-1">
+        <v-checkbox
+          v-model="selectedChannels[item.value]"
+          :label="item.text"
+          dense
+          hide-details
+          v-bind="$attrs"
+        ></v-checkbox>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, VModel } from "vue-property-decorator";
+import store from "@/store";
+
+@Component({})
+export default class ChannelCheckboxGroup extends Vue {
+  readonly store = store;
+
+  @Prop({ default: "" })
+  readonly label!: string;
+
+  @VModel({ type: Object })
+  selectedChannels!: { [key: number]: boolean };
+
+  get channelItems() {
+    const res = [];
+    if (this.store.dataset) {
+      for (const channel of this.store.dataset.channels) {
+        res.push({
+          text:
+            this.store.dataset.channelNames.get(channel) ||
+            `Channel ${channel}`,
+          value: channel,
+        });
+      }
+    }
+    return res;
+  }
+
+  created() {
+    // Initialize selectedChannels if empty
+    if (!this.selectedChannels) {
+      const initial: { [key: number]: boolean } = {};
+      if (this.store.dataset) {
+        for (const channel of this.store.dataset.channels) {
+          initial[channel] = false;
+        }
+      }
+      this.selectedChannels = initial;
+    }
+  }
+}
+</script>

--- a/src/components/WorkerInterfaceValues.vue
+++ b/src/components/WorkerInterfaceValues.vue
@@ -76,6 +76,11 @@
                 v-bind="item.vueAttrs"
                 v-model="interfaceValues[id]"
               ></channel-select>
+              <channel-checkbox-group
+                v-if="item.type === 'channelCheckboxes'"
+                v-bind="item.vueAttrs"
+                v-model="interfaceValues[id]"
+              ></channel-checkbox-group>
               <v-checkbox
                 v-if="item.type === 'checkbox'"
                 v-bind="item.vueAttrs"
@@ -99,9 +104,17 @@ import {
 } from "@/store/model";
 import LayerSelect from "@/components/LayerSelect.vue";
 import ChannelSelect from "@/components/ChannelSelect.vue";
+import ChannelCheckboxGroup from "@/components/ChannelCheckboxGroup.vue";
 import TagPicker from "@/components/TagPicker.vue";
 // Popup for new tool configuration
-@Component({ components: { LayerSelect, ChannelSelect, TagPicker } })
+@Component({
+  components: {
+    LayerSelect,
+    ChannelSelect,
+    ChannelCheckboxGroup,
+    TagPicker,
+  },
+})
 export default class WorkerInterfaceValues extends Vue {
   @Prop()
   readonly workerInterface!: IWorkerInterface;
@@ -135,6 +148,9 @@ export default class WorkerInterfaceValues extends Vue {
 
       case "channel":
         return 0;
+
+      case "channelCheckboxes":
+        return {};
 
       case "checkbox":
         return false;

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1093,6 +1093,13 @@ export interface IChannelWorkerInterfaceElement
   required?: boolean;
 }
 
+export interface IChannelCheckboxesWorkerInterfaceElement
+  extends ICommonWorkerInterfaceElement {
+  type: "channelCheckboxes";
+  default?: { [channel: number]: boolean };
+  required?: boolean;
+}
+
 export interface ICheckboxWorkerInterfaceElement
   extends ICommonWorkerInterfaceElement {
   type: "checkbox";
@@ -1107,6 +1114,7 @@ export type TWorkerInterfaceElement =
   | ILayerWorkerInterfaceElement
   | ISelectWorkerInterfaceElement
   | IChannelWorkerInterfaceElement
+  | IChannelCheckboxesWorkerInterfaceElement
   | ICheckboxWorkerInterfaceElement;
 
 export type TWorkerInterfaceType = TWorkerInterfaceElement["type"];


### PR DESCRIPTION
Allows a checkbox group for channels as a worker interface element.

Can be added using e.g.:
```
'All channels': {
            'type': 'channelCheckboxes',
            'tooltip': 'Blur selected channels.',
            'displayOrder': 2,
        },
```