### PR TITLE
Restore Girder BaseModel update method in AnnotationPlugin

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -158,7 +158,7 @@ class Annotation(Resource):
     def update(self, upenn_annotation, params, *args, **kwargs):
         bodyJson = kwargs["memoizedBodyJson"]
         upenn_annotation.update(bodyJson)
-        self._annotationModel.update(upenn_annotation)
+        self._annotationModel.save(upenn_annotation)
 
     @describeRoute(
         Description("Update multiple existing annotation")

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
@@ -176,7 +176,7 @@ class AnnotationConnection(Resource):
     def update(self, connection, params, *args, **kwargs):
         bodyJson = kwargs["memoizedBodyJson"]
         connection.update(bodyJson)
-        self._connectionModel.update(connection)
+        self._connectionModel.save(connection)
 
     @access.user
     @autoDescribeRoute(

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
@@ -92,7 +92,8 @@ class DatasetView(Resource):
         level=AccessType.WRITE,
     )
     def update(self, dataset_view, params):
-        self._datasetViewModel.update(dataset_view, self.getBodyJson())
+        self._datasetViewModel.updateDatasetView(
+            dataset_view, self.getBodyJson())
 
     @access.user
     @describeRoute(

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
@@ -108,7 +108,7 @@ class AnnotationProperty(Resource):
     )
     def update(self, property, params):
         property.update(self.getBodyJson())
-        self._propertyModel.update(property)
+        self._propertyModel.save(property)
 
     @access.user
     @describeRoute(

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/workerInterfaces.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/workerInterfaces.py
@@ -32,7 +32,7 @@ class WorkerInterfaces(Resource):
         if "image" not in params:
             raise RestException(code=400, message="Missing 'image' parameter")
         image = params.get("image")
-        return self._interfaceModel.update(
+        return self._interfaceModel.updateWorkerInterface(
             self.getCurrentUser(), image, self.getBodyJson()
         )
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/workerPreviews.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/workerPreviews.py
@@ -44,7 +44,7 @@ class WorkerPreviews(Resource):
         if "image" not in params:
             raise RestException(code=400, message="Missing 'image' parameter")
         image = params.get("image")
-        return self._previewModel.update(
+        return self._previewModel.updateWorkerPreview(
             self.getCurrentUser(), image, self.getBodyJson()
         )
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
@@ -211,9 +211,6 @@ class Annotation(ProxiedAccessControlledModel):
     def getAnnotationById(self, id, user=None):
         return self.load(id, user=user, level=AccessType.READ)
 
-    def update(self, annotation):
-        return self.save(annotation)
-
     def updateMultiple(self, annotationUpdates, user):
         annotationIdToUpdate = dict((ObjectId(update["id"]), update)
                                     for update in annotationUpdates)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/connections.py
@@ -138,9 +138,6 @@ class AnnotationConnection(ProxiedAccessControlledModel):
         }
         return self.removeWithQuery(query)
 
-    def update(self, connection):
-        return self.save(connection)
-
     def getClosestAnnotation(self, annotationRef, annotations):
         """Get the closest annotation based on its distance to a reference
         annotation.

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/datasetView.py
@@ -82,7 +82,7 @@ class DatasetView(ProxiedAccessControlledModel):
     def delete(self, dataset_view):
         self.remove(dataset_view)
 
-    def update(self, dataset_view, new_dataset_view):
+    def updateDatasetView(self, dataset_view, new_dataset_view):
         id = dataset_view["_id"]
         dataset_view.update(new_dataset_view)
         dataset_view["_id"] = id

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/property.py
@@ -57,9 +57,6 @@ class AnnotationProperty(ProxiedAccessControlledModel):
     def delete(self, property):
         self.remove(property)
 
-    def update(self, property):
-        return self.save(property)
-
     def getPropertyById(self, id, user=None):
         return self.load(id, user=user)
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerInterfaces.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerInterfaces.py
@@ -56,7 +56,7 @@ class WorkerInterfaceModel(ProxiedAccessControlledModel):
     def delete(self, interface):
         self.remove(self.find(interface))
 
-    def update(self, creator, image, interface):
+    def updateWorkerInterface(self, creator, image, interface):
         existing = self.findOne({"image": image})
         if existing is None:
             return self.create(creator, image, interface)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerPreviews.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerPreviews.py
@@ -56,7 +56,7 @@ class WorkerPreviewModel(ProxiedAccessControlledModel):
     def delete(self, image):
         self.remove(self.getImagePreview(image))
 
-    def update(self, creator, image, preview):
+    def updateWorkerPreview(self, creator, image, preview):
         existing = self.getImagePreview(image)
         if existing is None:
             return self.create(creator, image, preview)


### PR DESCRIPTION
The models defined in AnnotationPlugin used to define a method `update()` used in its API, but this actually overrides a base Girder BaseModel method used to update the document.
This prevented users from being deleted.