### PR TITLE
Added progress bar and indicators to annotation deletion

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -6,7 +6,14 @@
       <v-container style="width: auto">
         <v-row>
           <v-col class="pa-0 mx-1">
-            <v-btn color="error" small outlined @click.stop="deleteSelected">
+            <v-btn
+              color="error"
+              small
+              outlined
+              :loading="isDeletingAnnotations"
+              :disabled="isDeletingAnnotations"
+              @click.stop="deleteSelected"
+            >
               Delete Selected
             </v-btn>
           </v-col>
@@ -19,7 +26,10 @@
                 </v-btn>
               </template>
               <v-list>
-                <v-list-item @click="deleteUnselected">
+                <v-list-item
+                  @click="deleteUnselected"
+                  :disabled="isDeletingAnnotations"
+                >
                   <v-list-item-icon>
                     <v-icon>mdi-delete-outline</v-icon>
                   </v-list-item-icon>
@@ -286,6 +296,10 @@ export default class AnnotationList extends Vue {
   readonly propertyStore = propertyStore;
   readonly filterStore = filterStore;
   readonly getStringFromPropertiesAndPath = getStringFromPropertiesAndPath;
+
+  get isDeletingAnnotations() {
+    return this.annotationStore.isDeleting;
+  }
 
   readonly columnOptions = allHeaders;
 

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -712,10 +712,10 @@ export class Annotations extends VuexModule {
       type: ProgressType.ANNOTATION_DELETE,
       title: "Deleting annotations",
     });
-    
+
     try {
       await this.annotationsAPI.deleteMultipleAnnotations(ids);
-      
+
       this.setAnnotations(
         this.annotations.filter(
           (annotation: IAnnotation) => !ids.includes(annotation.id),
@@ -741,7 +741,7 @@ export class Annotations extends VuexModule {
     const unselectedIds = this.annotations
       .filter((annotation) => !selectedIds.has(annotation.id))
       .map((annotation) => annotation.id);
-    
+
     await this.deleteAnnotations(unselectedIds);
   }
 

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -54,6 +54,8 @@ export class Annotations extends VuexModule {
   submitPendingAnnotationTimeout: number = 1;
   submitPendingAnnotation: ((submit: boolean) => void) | null = null;
 
+  isDeletingAnnotations: boolean = false;
+
   get selectedAnnotationIds() {
     return this.selectedAnnotations.map(
       (annotation: IAnnotation) => annotation.id,
@@ -67,6 +69,10 @@ export class Annotations extends VuexModule {
   get isAnnotationSelected() {
     const annotationIdsSet = new Set(this.selectedAnnotationIds);
     return (annotationId: string) => annotationIdsSet.has(annotationId);
+  }
+
+  get isDeleting() {
+    return this.isDeletingAnnotations;
   }
 
   get inactiveAnnotationIds() {
@@ -699,15 +705,28 @@ export class Annotations extends VuexModule {
       return;
     }
 
+    this.setDeletingState(true);
     sync.setSaving(true);
-    await this.annotationsAPI.deleteMultipleAnnotations(ids);
-    sync.setSaving(false);
 
-    this.setAnnotations(
-      this.annotations.filter(
-        (annotation: IAnnotation) => !ids.includes(annotation.id),
-      ),
-    );
+    const progressId = await progress.create({
+      type: ProgressType.ANNOTATION_DELETE,
+      title: "Deleting annotations",
+    });
+    
+    try {
+      await this.annotationsAPI.deleteMultipleAnnotations(ids);
+      
+      this.setAnnotations(
+        this.annotations.filter(
+          (annotation: IAnnotation) => !ids.includes(annotation.id),
+        ),
+      );
+    } finally {
+      // Always set the state back to false, even if there's an error
+      sync.setSaving(false);
+      this.setDeletingState(false);
+      progress.complete(progressId);
+    }
   }
 
   @Action
@@ -718,16 +737,12 @@ export class Annotations extends VuexModule {
 
   @Action
   public async deleteUnselectedAnnotations() {
+    const selectedIds = new Set(this.selectedAnnotationIds);
     const unselectedIds = this.annotations
-      .filter(
-        (annotation) =>
-          !this.selectedAnnotations.some(
-            (selected) => selected.id === annotation.id,
-          ),
-      )
+      .filter((annotation) => !selectedIds.has(annotation.id))
       .map((annotation) => annotation.id);
-
-    this.deleteAnnotations(unselectedIds);
+    
+    await this.deleteAnnotations(unselectedIds);
   }
 
   @Action
@@ -1046,6 +1061,11 @@ export class Annotations extends VuexModule {
   @Action
   public clearSelectedAnnotations() {
     this.setSelected([]);
+  }
+
+  @Mutation
+  private setDeletingState(isDeleting: boolean) {
+    this.isDeletingAnnotations = isDeleting;
   }
 }
 

--- a/src/store/progress.ts
+++ b/src/store/progress.ts
@@ -72,6 +72,9 @@ function determineTypeAndTitle(payload: {
       case ProgressType.ANNOTATION_FETCH:
         title = "Fetching annotations";
         break;
+      case ProgressType.ANNOTATION_DELETE:
+        title = "Deleting annotations";
+        break;
       case ProgressType.CONNECTION_FETCH:
         title = "Fetching connections";
         break;


### PR DESCRIPTION
Users have noticed that deleting large number of annotations takes a long time. We should of course fix that :), but for now, we should at least provide some progress indicator so that users know that a deletion is occurring.