### PR TITLE
Handle OIB files

### DIFF
--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -239,6 +239,14 @@ export default class GirderAPI {
     return this.client.delete(`item/${itemId}/tiles`);
   }
 
+  async createLargeImage(item: IGirderItem): Promise<any> {
+    const url = `item/${item._id}/tiles`;
+    return this.client.post(url, {
+      fileId: item.largeImage?.fileId || undefined,
+      notify: true,
+    });
+  }
+
   uploadJSONFile(
     name: string,
     content: string,

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -569,8 +569,7 @@ export default class MultiSourceConfiguration extends Vue {
     if (hasOibFiles) {
       try {
         // Process each OIB file to ensure it has a large image
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i];
+        for (const item of items) {
           if (item.name.toLowerCase().endsWith(".oib")) {
             try {
               await this.store.api.createLargeImage(item);


### PR DESCRIPTION
Allows for the uploading of OIB files.
Does so by explicitly asking for a conversion to large_image. Not sure why that's required, but it doesn't work without it.