### PR TITLE
Enable api_keys for larger file uploads

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
@@ -32,6 +32,59 @@ class UPennContrastAnnotationAPIPlugin(GirderPlugin):
     DISPLAY_NAME = "UPennContrast Annotation Plugin"
 
     def load(self, info):
+
+        # Define custom upload limit scopes
+        TokenScope.UPLOAD_500MB = "nimbus.upload.limit.500mb"
+        TokenScope.UPLOAD_1GB = "nimbus.upload.limit.1gb"
+        TokenScope.UPLOAD_2GB = "nimbus.upload.limit.2gb"
+        TokenScope.UPLOAD_5GB = "nimbus.upload.limit.5gb"
+        TokenScope.UPLOAD_10GB = "nimbus.upload.limit.10gb"
+        TokenScope.UPLOAD_20GB = "nimbus.upload.limit.20gb"
+        TokenScope.UPLOAD_50GB = "nimbus.upload.limit.50gb"
+        TokenScope.UPLOAD_100GB = "nimbus.upload.limit.100gb"
+        TokenScope.UPLOAD_200GB = "nimbus.upload.limit.200gb"
+        TokenScope.UPLOAD_500GB = "nimbus.upload.limit.500gb"
+        TokenScope.UPLOAD_1TB = "nimbus.upload.limit.1tb"
+        TokenScope.UPLOAD_2TB = "nimbus.upload.limit.2tb"
+
+        # Register the custom scopes with the system
+        TokenScope.describeScope(TokenScope.UPLOAD_500MB,
+                                 name="Upload 500MB",
+                                 description="Allows uploads up to 500MB")
+        TokenScope.describeScope(TokenScope.UPLOAD_1GB,
+                                 name="Upload 1GB",
+                                 description="Allows uploads up to 1GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_2GB,
+                                 name="Upload 2GB",
+                                 description="Allows uploads up to 2GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_5GB,
+                                 name="Upload 5GB",
+                                 description="Allows uploads up to 5GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_10GB,
+                                 name="Upload 10GB",
+                                 description="Allows uploads up to 10GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_20GB,
+                                 name="Upload 20GB",
+                                 description="Allows uploads up to 20GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_50GB,
+                                 name="Upload 50GB",
+                                 description="Allows uploads up to 50GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_100GB,
+                                 name="Upload 100GB",
+                                 description="Allows uploads up to 100GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_200GB,
+                                 name="Upload 200GB",
+                                 description="Allows uploads up to 200GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_500GB,
+                                 name="Upload 500GB",
+                                 description="Allows uploads up to 500GB")
+        TokenScope.describeScope(TokenScope.UPLOAD_1TB,
+                                 name="Upload 1TB",
+                                 description="Allows uploads up to 1TB")
+        TokenScope.describeScope(TokenScope.UPLOAD_2TB,
+                                 name="Upload 2TB",
+                                 description="Allows uploads up to 2TB")
+
         # Laziliy do these imports as they can connect to the database
         from .server.api.annotation import Annotation
         from .server.api.connections import AnnotationConnection

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
@@ -9,6 +9,7 @@ __version__ = "0.0.0"
 
 from girder.plugin import GirderPlugin
 
+from girder.constants import TokenScope
 from girder.utility.model_importer import ModelImporter
 
 from . import system

--- a/src/girder/index.ts
+++ b/src/girder/index.ts
@@ -73,3 +73,17 @@ export type IGirderSelectAble =
   | IGirderUser
   | IGirderFolder
   | IGirderFile;
+
+export interface IGirderApiKey {
+  _accessLevel: number;
+  _id: string;
+  _modelType: "api_key";
+  active: boolean;
+  created: string;
+  key: string;
+  lastUse: string | null;
+  name: string;
+  scope: string[] | null;
+  tokenDuration: number;
+  userId: string;
+}

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -7,6 +7,7 @@ import {
   IGirderFile,
   IGirderAssetstore,
   IGirderLargeImage,
+  IGirderApiKey,
 } from "@/girder";
 import {
   configurationBaseKeys,
@@ -731,6 +732,23 @@ export default class GirderAPI {
         },
       },
     );
+  }
+
+  async getUserApiKeys(): Promise<IGirderApiKey[]> {
+    try {
+      const response = await this.client.get("api_key", {
+        params: {
+          limit: 50,
+          offset: 0,
+          sort: "name",
+          sortdir: 1,
+        },
+      });
+      return response.data;
+    } catch (error) {
+      logError("Failed to fetch user API keys");
+      return [];
+    }
   }
 }
 

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -419,9 +419,6 @@ export default class NewDataset extends Vue {
   async mounted() {
     this.path = this.initialUploadLocation;
     this.maxApiKeyFileSize = await this.getMaxUploadSize();
-    console.log(this.maxApiKeyFileSize);
-    // const apiKeys = await this.store.api.getUserApiKeys();
-    // console.log(apiKeys);
   }
 
   async getMaxUploadSize() {

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -90,30 +90,45 @@
       </v-alert>
       <v-alert v-if="fileSizeExceeded" text type="error">
         Total file size ({{ totalSizeMB }} MB) exceeds the maximum allowed size
-        of {{ maxTotalFileSize }} MB
+        of
+        {{
+          maxTotalFileSize === Infinity
+            ? "No file size limit"
+            : `${maxTotalFileSize} MB`
+        }}
       </v-alert>
       <v-alert v-if="invalidLocation" text type="error">
         Cannot create datasets in this location. Please select a subfolder
         within your user directory or group folder.
       </v-alert>
 
-      <div class="button-bar" v-if="!quickupload || pipelineError">
-        <v-btn
-          id="upload-button-tourstep"
-          v-tour-trigger="'upload-button-tourtrigger'"
-          :disabled="
-            !valid ||
-            !filesSelected ||
-            uploading ||
-            fileSizeExceeded ||
-            invalidLocation
-          "
-          color="success"
-          class="mr-4"
-          @click="submit"
-        >
-          Upload
-        </v-btn>
+      <div
+        class="button-bar d-flex justify-space-between align-center"
+        v-if="!quickupload || pipelineError"
+      >
+        <div>
+          <span class="mr-2">File size limit: {{ maxTotalFileSize }} MB</span>
+          <span v-if="maxApiKeyFileSize" class="mr-2">
+            (using special permission code)</span
+          >
+        </div>
+        <div>
+          <v-btn
+            id="upload-button-tourstep"
+            v-tour-trigger="'upload-button-tourtrigger'"
+            :disabled="
+              !valid ||
+              !filesSelected ||
+              uploading ||
+              fileSizeExceeded ||
+              invalidLocation
+            "
+            color="success"
+            @click="submit"
+          >
+            Upload
+          </v-btn>
+        </div>
       </div>
     </v-form>
 
@@ -148,7 +163,7 @@
 import { Vue, Component, Prop } from "vue-property-decorator";
 import store from "@/store";
 import girderResources from "@/store/girderResources";
-import { IGirderLocation } from "@/girder";
+import { IGirderApiKey, IGirderLocation } from "@/girder";
 import GirderLocationChooser from "@/components/GirderLocationChooser.vue";
 import FileDropzone from "@/components/Files/FileDropzone.vue";
 import { IDataset } from "@/store/model";
@@ -275,12 +290,21 @@ export default class NewDataset extends Vue {
 
   pipelineError = false;
 
-  maxTotalFileSize =
-    Number(import.meta.env.VITE_MAX_TOTAL_FILE_SIZE) || Infinity;
   fileSizeExceeded = false;
   fileSizeExceededMessage = "";
 
+  maxApiKeyFileSize: number | null = null;
+
   allFiles: File[] = [];
+
+  get maxTotalFileSize() {
+    // If the maxApiKeyFileSize is set, use that
+    if (this.maxApiKeyFileSize) {
+      return this.maxApiKeyFileSize;
+    }
+    // Otherwise, use the default max total file size
+    return Number(import.meta.env.VITE_MAX_TOTAL_FILE_SIZE) || Infinity;
+  }
 
   get invalidLocation() {
     if (!this.path) return false;
@@ -394,6 +418,57 @@ export default class NewDataset extends Vue {
 
   async mounted() {
     this.path = this.initialUploadLocation;
+    this.maxApiKeyFileSize = await this.getMaxUploadSize();
+    console.log(this.maxApiKeyFileSize);
+    // const apiKeys = await this.store.api.getUserApiKeys();
+    // console.log(apiKeys);
+  }
+
+  async getMaxUploadSize() {
+    const apiKeys = await this.store.api.getUserApiKeys();
+    // First filter by all active keys, then find the maximum upload size
+    // Else, return none
+    const activeKeys = apiKeys.filter((key: IGirderApiKey) => key.active);
+    const maxUploadSize = activeKeys.reduce(
+      (max: number | null, key: IGirderApiKey) => {
+        const size = this.convertScopeToBytes(key.scope);
+        return size ? Math.max(max || 0, size) : max;
+      },
+      null,
+    );
+    return maxUploadSize;
+  }
+
+  convertScopeToBytes(scope: string[] | null): number | null {
+    if (!scope) {
+      return null;
+    }
+
+    // Note that the maxTotalFileSize is expected to be in MB,
+    // so we need to convert the scope to MB
+    const sizeMap: Record<string, number> = {
+      "nimbus.upload.limit.500mb": 500,
+      "nimbus.upload.limit.1gb": 1 * 1024,
+      "nimbus.upload.limit.2gb": 2 * 1024,
+      "nimbus.upload.limit.5gb": 5 * 1024,
+      "nimbus.upload.limit.10gb": 10 * 1024,
+      "nimbus.upload.limit.20gb": 20 * 1024,
+      "nimbus.upload.limit.50gb": 50 * 1024,
+      "nimbus.upload.limit.100gb": 100 * 1024,
+      "nimbus.upload.limit.200gb": 200 * 1024,
+      "nimbus.upload.limit.500gb": 500 * 1024,
+      "nimbus.upload.limit.1tb": 1 * 1024 * 1024,
+      "nimbus.upload.limit.2tb": 2 * 1024 * 1024,
+    };
+
+    // Find the first matching scope and return its byte value
+    for (const key of scope) {
+      if (key in sizeMap) {
+        return sizeMap[key];
+      }
+    }
+
+    return null;
   }
 
   async uploadMounted() {


### PR DESCRIPTION
Admin can make an api_key for a particular user to enable a different upload quota.