### PR TITLE
Fixed blob edit tool to work across polygon "seam"

### DIFF
--- a/src/utils/polygonSlice.ts
+++ b/src/utils/polygonSlice.ts
@@ -134,7 +134,6 @@ export function editPolygonAnnotation(
   // If the first intersection is after the last intersection, we need to rotate the polygon
   // to avoid the "seam" of the polygon.
   if (firstIntersection.index > lastIntersection.index) {
-    console.log("rotating polygon");
     // Rotate the polygon to have the first intersection before the last intersection
     polygon = polygon
       .slice(lastIntersection.index)


### PR DESCRIPTION
We had a problem where if you run the blob edit tool over the polygon "seam", it would have unpredictable behavior. Now, it will perform the expected behavior. It tests the two potential edit options and chooses the one whose centroid is closest to the original polygon's centroid. This heuristic seems to generally correspond to what people expect the tool to do.