### PR TITLE
Tag intro tour

### DIFF
--- a/src/plugins/tour.ts
+++ b/src/plugins/tour.ts
@@ -25,6 +25,7 @@ export class TourManager {
     Vue.prototype.$startTour = this.startTour.bind(this);
     Vue.prototype.$nextStep = this.nextStep.bind(this);
     Vue.prototype.$loadAllTours = this.loadAllTours.bind(this);
+    Vue.prototype.$isTourActive = this.isTourActive.bind(this);
 
     // Watch for route changes
     this.router.afterEach(() => {
@@ -32,6 +33,10 @@ export class TourManager {
         this.checkCurrentStep();
       }
     });
+  }
+
+  public isTourActive(): boolean {
+    return this.isActive;
   }
 
   private async checkCurrentStep() {
@@ -408,6 +413,7 @@ declare module "vue/types/vue" {
     $startTour: (tourName: string) => Promise<void>;
     $nextStep: (targetElementId?: string) => Promise<void>;
     $loadAllTours: () => Promise<Record<string, ITourMetadata>>;
+    $isTourActive: () => boolean;
   }
 }
 

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1468,6 +1468,7 @@ export enum WelcomeTourTypes {
   HOME = "WelcomeTourType.home",
   VIEWER = "WelcomeTourType.viewer",
   ADVANCED_UPLOAD = "WelcomeTourType.advancedUpload",
+  WORKING_WITH_TAGS = "WelcomeTourType.workingWithTags",
 }
 
 export enum WelcomeTourStatus {
@@ -1480,6 +1481,7 @@ export const WelcomeTourNames = {
   [WelcomeTourTypes.HOME]: "WelcomeTourHome",
   [WelcomeTourTypes.VIEWER]: "WelcomeTourViewer",
   [WelcomeTourTypes.ADVANCED_UPLOAD]: "WelcomeTourAdvancedUpload",
+  [WelcomeTourTypes.WORKING_WITH_TAGS]: "WorkingWithTags",
 };
 
 // https://opengeoscience.github.io/geojs/apidocs/geo.util.html#.pixelCoordinateParams

--- a/src/tools/creation/templates/AnnotationConfiguration.vue
+++ b/src/tools/creation/templates/AnnotationConfiguration.vue
@@ -110,8 +110,14 @@ import { Vue, Component, Prop, Watch } from "vue-property-decorator";
 import store from "@/store";
 import LayerSelect from "@/components/LayerSelect.vue";
 import TagPicker from "@/components/TagPicker.vue";
-
-import { AnnotationNames, AnnotationShape } from "@/store/model";
+import Persister from "@/store/Persister";
+import {
+  AnnotationNames,
+  AnnotationShape,
+  WelcomeTourTypes,
+  WelcomeTourStatus,
+  WelcomeTourNames,
+} from "@/store/model";
 
 type VForm = Vue & { validate: () => boolean };
 
@@ -244,6 +250,27 @@ export default class AnnotationConfiguration extends Vue {
       this.useAutoTags = false;
     }
     this.updateFromValue();
+
+    // Tour logic to show the "Working with tags" tour
+    // if the user has not seen it yet
+    // Note for the future: somehow, this component gets mounted twice.
+    // Hence, if you just run the tour here, it will run twice, causing problems.
+    // Given that we only want to show the tour once and we gate that by the
+    // Persister state, this code will just run the one time and it should be fine.
+    // However, this does hide the underlying, but as yet unsolved, problem of the
+    // component getting mounted twice.
+    const tourStatus = Persister.get(
+      WelcomeTourTypes.WORKING_WITH_TAGS,
+      WelcomeTourStatus.NOT_YET_RUN,
+    );
+
+    if (tourStatus === WelcomeTourStatus.NOT_YET_RUN) {
+      Persister.set(
+        WelcomeTourTypes.WORKING_WITH_TAGS,
+        WelcomeTourStatus.ALREADY_RUN,
+      );
+      this.$startTour(WelcomeTourNames[WelcomeTourTypes.WORKING_WITH_TAGS]);
+    }
   }
 
   @Watch("value")

--- a/src/tools/creation/templates/AnnotationConfiguration.vue
+++ b/src/tools/creation/templates/AnnotationConfiguration.vue
@@ -246,7 +246,6 @@ export default class AnnotationConfiguration extends Vue {
   }
 
   mounted() {
-    console.log("AnnotationConfiguration mounted.");
     if (this.value?.tags) {
       this.useAutoTags = false;
     }

--- a/src/tools/creation/templates/AnnotationConfiguration.vue
+++ b/src/tools/creation/templates/AnnotationConfiguration.vue
@@ -246,6 +246,7 @@ export default class AnnotationConfiguration extends Vue {
   }
 
   mounted() {
+    console.log("AnnotationConfiguration mounted.");
     if (this.value?.tags) {
       this.useAutoTags = false;
     }
@@ -264,12 +265,14 @@ export default class AnnotationConfiguration extends Vue {
       WelcomeTourStatus.NOT_YET_RUN,
     );
 
-    if (tourStatus === WelcomeTourStatus.NOT_YET_RUN) {
-      Persister.set(
-        WelcomeTourTypes.WORKING_WITH_TAGS,
-        WelcomeTourStatus.ALREADY_RUN,
-      );
-      this.$startTour(WelcomeTourNames[WelcomeTourTypes.WORKING_WITH_TAGS]);
+    if (!(this.$isTourActive && this.$isTourActive())) {
+      if (tourStatus === WelcomeTourStatus.NOT_YET_RUN) {
+        Persister.set(
+          WelcomeTourTypes.WORKING_WITH_TAGS,
+          WelcomeTourStatus.ALREADY_RUN,
+        );
+        this.$startTour(WelcomeTourNames[WelcomeTourTypes.WORKING_WITH_TAGS]);
+      }
     }
   }
 

--- a/src/tours/WorkingWithTags.yaml
+++ b/src/tours/WorkingWithTags.yaml
@@ -1,0 +1,14 @@
+name: "Working with Tags"
+entryPoint: datasetview
+popular: false
+category: Introduction
+steps:
+  - id: tag-picker-tourstep3
+    route: datasetview
+    element: "#tool-creation-tag-picker-tourstep"
+    title: "Tagging"
+    text: "Tags are a way to label the objects in your dataset. Every object can have one or more tags. These are ways to organize your data and analyses. You can pick which tags to show and which to quantify, allowing you complete flexibility."
+    position: "bottom"
+    waitForElement: 1000
+    modalOverlay: false
+    showNextButton: true


### PR DESCRIPTION
Introductory tour that shows up when the AnnotationConfiguration.vue mounts and displays the TagPicker component.

Also added an `isTourActive` check to `tour.ts` to ensure that we don't have collisions between tours.