### PR TITLE
Fix creating a max-merge cache from a converted image.

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
@@ -147,10 +147,10 @@ def cacheMaxMerge(self, item):
                 ],
             }
             # If this is a file we converted because we used the multi-source
-            # and named it in our project's default manner, make sure we use
-            # the tiff source to read it back
-            if item["name"] == "multi-source2.json":
-                multi["sources"][0]["sourceName"] = "tiff"
+            # make sure we use the same source to read it back
+            if item.get("largeImage", {}).get("sourceName", "") in {"tiff"}:
+                multi["sources"][0]["sourceName"] = item["largeImage"][
+                    "sourceName"]
             datasetFolder = Folder().load(
                 item["folderId"], user=user, level=AccessType.WRITE
             )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
@@ -146,6 +146,11 @@ def cacheMaxMerge(self, item):
                     }
                 ],
             }
+            # If this is a file we converted because we used the multi-source
+            # and named it in our project's default manner, make sure we use
+            # the tiff source to read it back
+            if item["name"] == "multi-source2.json":
+                multi["sources"][0]["sourceName"] = "tiff"
             datasetFolder = Folder().load(
                 item["folderId"], user=user, level=AccessType.WRITE
             )


### PR DESCRIPTION
When we have converted an image and then create a max-merge cache, we end up with a girder item named "multi-source2.json".  When we ask to create the max-merge cache, by the time the multi-source max-merge cache gets processed, the name of the file ends up ending in json, and large-image prefers the alphabetically first openslide source over the tiff source, which fails to read all of the channels and other frames. In this case, require that we use the tiff source for reading the converted file.

Resolves #950