### PR TITLE
Allow for "any" as a property shape

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
@@ -232,7 +232,8 @@ export default class PropertyCreation extends Vue {
     return (labels: IWorkerLabels) => {
       return (
         labels.isPropertyWorker !== undefined &&
-        (labels.annotationShape || null) === this.filteringShape
+        ((labels.annotationShape || null) === this.filteringShape ||
+          (labels.annotationShape || null) === AnnotationShape.Any)
       );
     };
   }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1178,6 +1178,7 @@ export enum AnnotationShape {
   Line = "line",
   Polygon = "polygon",
   Rectangle = "rectangle",
+  Any = "any",
 }
 
 export enum FeatureShape {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1193,6 +1193,7 @@ export const AnnotationNames = {
   [AnnotationShape.Line]: "Line",
   [AnnotationShape.Polygon]: "Blob",
   [AnnotationShape.Rectangle]: "Rectangle",
+  [AnnotationShape.Any]: "Any", // This was added to support the "Any" shape
 };
 
 export interface IAnnotationLocation {


### PR DESCRIPTION
When finding the list of properties, include images labeled with annotationShape="any".