### PR TITLE
Set default location to private folder when uploading dataset to existing collection

### DIFF
--- a/src/components/AddDatasetToCollection.vue
+++ b/src/components/AddDatasetToCollection.vue
@@ -67,9 +67,15 @@
       </template>
       <template v-if="option.type == 'upload'">
         <new-dataset
+          v-if="uploadLocation"
           @datasetUploaded="addDatasetToCollectionUploaded"
           :autoMultiConfig="false"
+          :initialUploadLocation="uploadLocation"
         />
+        <div v-else class="text-center my-4">
+          <v-progress-circular indeterminate />
+          <div class="mt-2">Loading upload location...</div>
+        </div>
         <div class="d-flex justify-end mt-2">
           <v-simple-checkbox v-model="option.editVariables" dense />
           Review variables
@@ -106,7 +112,7 @@ import store from "@/store";
 
 import { isDatasetFolder } from "@/utils/girderSelectable";
 import { logError } from "@/utils/log";
-import { IGirderSelectAble } from "@/girder";
+import { IGirderSelectAble, IGirderLocation } from "@/girder";
 
 import CustomFileManager from "@/components/CustomFileManager.vue";
 import MultiSourceConfiguration from "@/views/dataset/MultiSourceConfiguration.vue";
@@ -158,10 +164,19 @@ export default class AddDatasetToCollection extends Vue {
   collection!: IDatasetConfiguration;
 
   option: TAddDatasetOption = defaultDatasetUploadOption();
+  uploadLocation: IGirderLocation | null = null;
 
   $refs!: {
     configuration?: MultiSourceConfiguration;
   };
+
+  async mounted() {
+    try {
+      this.uploadLocation = await this.store.api.getUserPrivateFolder();
+    } catch (error) {
+      this.uploadLocation = this.store.girderUser;
+    }
+  }
 
   get addDatasetOptionType(): TAddDatasetOption["type"] {
     return this.option.type;

--- a/src/layout/BreadCrumbs.vue
+++ b/src/layout/BreadCrumbs.vue
@@ -33,7 +33,7 @@
                   @click="openAddDatasetDialog(configurationId)"
                 >
                   <v-icon class="pr-2" color="primary">mdi-plus-circle</v-icon>
-                  Add a dataset in this collection
+                  Add a dataset to this collection
                 </div>
               </template>
             </v-select>


### PR DESCRIPTION
Before, when you try to upload a dataset to add it to an existing collection, it wouldn't show the file dropzone for uploading because there was no default selected location. Changed it to use the user's private folder by default, solving the problem.