### PR TITLE
Fix compatible collections

### DIFF
--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -207,7 +207,7 @@
                       query: { datasetId },
                     }"
                   >
-                    Add an existing collection…
+                    Add to an existing collection…
                   </v-btn>
                 </template>
                 Add this dataset to an existing collection. Shows a list of all


### PR DESCRIPTION
After uploading a file, when on the dataset view, you have the option to "Add to existing collection". That was broken because it was using some old method for finding collections from before the collections were moved to the database. Now fixed to use the new upenn_collection endpoints.