### PR TITLE
Add hints to avoid query planner

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -225,7 +225,7 @@ class Annotation(Resource):
             sort=sort,
             limit=limit,
             offset=offset,
-        )
+        ).hint([("datasetId", 1), ("_id", 1)])
 
         def generateResult():
             chunk = [b"["]

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
@@ -231,7 +231,7 @@ class AnnotationConnection(Resource):
             sort=sort,
             limit=limit,
             offset=offset,
-        )
+        ).hint([("datasetId", 1), ("_id", 1)])
 
     @access.user
     @autoDescribeRoute(

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
@@ -139,7 +139,7 @@ class PropertyValues(Resource):
             sort=sort,
             limit=limit,
             offset=offset,
-        )
+        ).hint([("datasetId", 1), ("_id", 1)])
 
     @access.user
     @describeRoute(


### PR DESCRIPTION
Query planner takes a long time for big queries, presumably because it tries multiple different queries. By adding a hint, that time is reduced significantly.