### PR TITLE
Streamline pixel call

### DIFF
--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -26,6 +26,7 @@ import {
   IImage,
   IScales,
   IPixel,
+  IPixelMultiLayer,
   newLayer,
   TJobType,
   IDatasetConfigurationCompatibility,
@@ -347,6 +348,25 @@ export default class GirderAPI {
     const frame = image.frameIndex;
     const params = { left, top, frame };
     const itemId = toId(image.item);
+    const response = await this.client.get(`item/${itemId}/tiles/pixel`, {
+      params,
+    });
+    return response.data;
+  }
+
+  async getPixelValuesForAllLayers(
+    itemId: string,
+    geoX: number,
+    geoY: number,
+    frameIndices: number[],
+  ): Promise<IPixelMultiLayer[]> {
+    if (geoX < 0 || geoY < 0 || frameIndices.length === 0) {
+      return [];
+    }
+    const left = Math.floor(geoX);
+    const top = Math.floor(geoY);
+    const frameList = frameIndices.join(",");
+    const params = { left, top, frameList };
     const response = await this.client.get(`item/${itemId}/tiles/pixel`, {
       params,
     });

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -449,6 +449,12 @@ export interface IPixel {
   value?: number[];
 }
 
+export interface IPixelMultiLayer {
+  frame: number;
+  l?: number;
+  value?: number[];
+}
+
 // https://opengeoscience.github.io/geojs/apidocs/geo.object.html
 export interface IGeoJsObject {
   modified: () => IGeoJsObject;


### PR DESCRIPTION
Uses new endpoint for getting multiple pixel values in a single call to the server (see https://github.com/girder/large_image/pull/2003). This makes it a lot more efficient to get the pixel values to the front end if you have a lot of channels.