### PR TITLE
Add option to display text or number labels

### DIFF
--- a/src/components/ViewerSettings.vue
+++ b/src/components/ViewerSettings.vue
@@ -7,6 +7,28 @@
           <v-switch
             hide-details
             dense
+            v-model="showXYLabels"
+            label="Show XY position labels"
+            title="Display coordinate labels for XY positions"
+          />
+          <v-switch
+            hide-details
+            dense
+            v-model="showZLabels"
+            label="Show Z position labels"
+            title="Display coordinate labels for Z positions"
+          />
+          <v-switch
+            hide-details
+            dense
+            v-model="showTimeLabels"
+            label="Show time labels"
+            title="Display time labels"
+          />
+          <v-divider class="my-2" />
+          <v-switch
+            hide-details
+            dense
             v-model="valueOnHover"
             label="Show channel values on hover"
             title="Show pixel intensity values when hovering cursor over image"
@@ -227,6 +249,30 @@ export default class ViewerSettings extends Vue {
 
   set backgroundColor(value: string) {
     this.store.setBackgroundColor(value);
+  }
+
+  get showXYLabels() {
+    return this.store.showXYLabels;
+  }
+
+  set showXYLabels(value: boolean) {
+    this.store.setShowXYLabels(value);
+  }
+
+  get showZLabels() {
+    return this.store.showZLabels;
+  }
+
+  set showZLabels(value: boolean) {
+    this.store.setShowZLabels(value);
+  }
+
+  get showTimeLabels() {
+    return this.store.showTimeLabels;
+  }
+
+  set showTimeLabels(value: boolean) {
+    this.store.setShowTimeLabels(value);
   }
 }
 </script>

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -285,6 +285,10 @@ export default class ViewerToolbar extends Vue {
   }
 
   get xyLabel() {
+    if (!this.store.showXYLabels) {
+      // User has disabled XY labels
+      return null;
+    }
     if (!this.dimensionLabels || !this.dimensionLabels.xy) {
       return null;
     }
@@ -292,6 +296,10 @@ export default class ViewerToolbar extends Vue {
   }
 
   get zLabel() {
+    if (!this.store.showZLabels) {
+      // User has disabled Z labels
+      return null;
+    }
     if (!this.dimensionLabels || !this.dimensionLabels.z) {
       return null;
     }
@@ -299,6 +307,10 @@ export default class ViewerToolbar extends Vue {
   }
 
   get timeLabel() {
+    if (!this.store.showTimeLabels) {
+      // User has disabled time labels
+      return null;
+    }
     if (!this.dimensionLabels || !this.dimensionLabels.t) {
       return null;
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -171,6 +171,10 @@ export class Main extends VuexModule {
   overview: boolean = true;
   hoverValue: { [layerId: string]: number[] } | null = null;
 
+  showXYLabels: boolean = true;
+  showZLabels: boolean = true;
+  showTimeLabels: boolean = true;
+
   showScalebar: boolean = true;
   showPixelScalebar: boolean = true;
   scalebarColor: string = "#ffffff";
@@ -408,6 +412,21 @@ export class Main extends VuexModule {
   @Mutation
   public setOverview(value: boolean) {
     this.overview = value;
+  }
+
+  @Mutation
+  public setShowXYLabels(value: boolean) {
+    this.showXYLabels = value;
+  }
+
+  @Mutation
+  public setShowZLabels(value: boolean) {
+    this.showZLabels = value;
+  }
+
+  @Mutation
+  public setShowTimeLabels(value: boolean) {
+    this.showTimeLabels = value;
   }
 
   @Mutation


### PR DESCRIPTION
In Viewer Settings, allows you to toggle the ability to either show the name as the label (e.g. "Well A1" or "1 second") or as a number.