### PR TITLE
Fix skill configuration structure

### DIFF
--- a/.claude/skills/nimbus-backend/SKILL.md
+++ b/.claude/skills/nimbus-backend/SKILL.md
@@ -1,3 +1,18 @@
+---
+name: nimbus-backend
+description: Guidelines for backend development in the NimbusImage Girder plugin including API patterns, access control, database queries, testing, and Docker development.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Task
+  - TodoWrite
+user-invocable: true
+---
+
 # Nimbus Backend Development (Girder)
 
 Guidelines for backend development in the NimbusImage Girder plugin.

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -1,3 +1,18 @@
+---
+name: nimbus-frontend
+description: Guidelines for frontend development in the NimbusImage application including Vue 2, Vuetify, Vuex patterns, theming, and component structure.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Task
+  - TodoWrite
+user-invocable: true
+---
+
 # Nimbus Frontend Development
 
 Guidelines for frontend development in the NimbusImage application.

--- a/.claude/skills/tool-development/SKILL.md
+++ b/.claude/skills/tool-development/SKILL.md
@@ -1,3 +1,18 @@
+---
+name: tool-development
+description: Guidelines for creating and modifying tools in the NimbusImage application including template structure, interface elements, and implementation patterns.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Task
+  - TodoWrite
+user-invocable: true
+---
+
 # NimbusImage Tool Development
 
 Guidelines for creating and modifying tools in the NimbusImage application.


### PR DESCRIPTION
Migrate skills from flat markdown files to proper directory structure with SKILL.md files containing required frontmatter (name, description, allowed-tools, user-invocable), following the pattern of branch-review.