### PR TITLE
Adjust default annotation settings for better visibility

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -242,8 +242,8 @@ export class Main extends VuexModule {
   showPixelScalebar: boolean = true;
   scalebarColor: string = "#ffffff";
 
-  scaleAnnotationsWithZoom: boolean = true;
-  annotationsRadius: number = 10;
+  scaleAnnotationsWithZoom: boolean = false;
+  annotationsRadius: number = 4;
   annotationOpacity: number = 0.5;
 
   compositionMode: TCompositionMode = "lighten";


### PR DESCRIPTION
## Summary
Updated default annotation configuration to improve visual clarity and user experience by disabling automatic zoom scaling and reducing the annotation marker size.

## Changes
- Changed `scaleAnnotationsWithZoom` default from `true` to `false` - annotations will now maintain a consistent size regardless of zoom level
- Reduced `annotationsRadius` default from `10` to `4` - smaller annotation markers for less visual clutter

## Details
These changes provide a more refined default behavior for annotations:
- Disabling zoom scaling ensures annotations remain at a readable, consistent size when users zoom in/out
- The smaller radius (4px vs 10px) reduces visual obstruction while still maintaining visibility with the existing opacity setting (0.5)

These defaults can still be customized by users through the application settings.

https://claude.ai/code/session_01GsS9dn2DaH56qQU41m4KkW