### PR TITLE
Refactor tile location to use spread operator from location object

### DIFF
--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -1245,7 +1245,7 @@ export class Annotations extends VuexModule {
 
     const { location, channel } =
       await this.getAnnotationLocationFromTool(tool);
-    const tile = { XY: main.xy, Z: main.z, Time: main.time };
+    const tile = { ...location };
     const response = await this.annotationsAPI.computeAnnotationWithWorker(
       tool,
       main.dataset,

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -515,7 +515,7 @@ export class Properties extends VuexModule {
       "getAnnotationLocationFromTool",
       tool,
     );
-    const tile = { XY: main.xy, Z: main.z, Time: main.time };
+    const tile = { ...location };
     this.propertiesAPI
       .requestWorkerPreview(
         image,


### PR DESCRIPTION
## Summary
Simplified tile location object creation by using the spread operator to directly copy the `location` object instead of manually mapping individual properties.

## Changes
- **annotation.ts**: Replaced manual property mapping (`{ XY: main.xy, Z: main.z, Time: main.time }`) with spread operator (`{ ...location }`)
- **properties.ts**: Applied the same refactoring pattern for consistency

## Benefits
- Reduces code duplication and improves maintainability
- Uses the already-retrieved `location` object from `getAnnotationLocationFromTool()` directly
- Ensures the tile object structure matches the location object structure automatically
- Simplifies future changes to location properties (only need to update in one place)

https://claude.ai/code/session_01NCqaCbTSdKoVgs1sxgrQfK