### PR TITLE
Add batch upload option for multiple datasets

### DIFF
--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -1293,8 +1293,12 @@ export default class NewDataset extends Vue {
       // but createConfigurationFromDataset needs the full tile/frame metadata
       await this.store.setSelectedDataset(this.dataset!.id);
 
-      // Create the collection using store action
-      await this.createCollection();
+      // Only create a new collection if one isn't already set in the workflow.
+      // When adding datasets to an existing collection, the collection is
+      // pre-set by AddDatasetToCollection before navigating here.
+      if (!this.store.uploadWorkflow.collection) {
+        await this.createCollection();
+      }
 
       if (this.pipelineError || !this.store.uploadWorkflow.collection) {
         logWarning("Failed to create collection");


### PR DESCRIPTION
## Summary
This PR adds a new "batch upload" feature that allows users to upload multiple files as separate datasets in a single operation. Users can select multiple files, customize dataset names, validate for conflicts, and choose an upload location before initiating the batch import process.

## Key Changes

- **New batch upload UI option** in `AddDatasetToCollection.vue`:
  - Added radio button for "Upload multiple files as separate datasets"
  - Implemented drag-and-drop file selection with visual feedback
  - Per-file dataset name customization with real-time validation
  - Location chooser for specifying upload destination
  - Quick Import and Advanced Import buttons for flexible workflows

- **Batch file handling**:
  - File selection via click or drag-and-drop
  - Automatic dataset name generation from filenames (removes extension)
  - Debounced validation of dataset names (300ms delay)

- **Name conflict detection**:
  - Checks for duplicate names within the batch
  - Validates against existing datasets in the target location
  - Displays error messages and prevents upload if conflicts exist
  - Shows loading indicator during validation

- **Integration with upload workflow**:
  - Passes file groups and dataset names to the store's upload workflow
  - Pre-sets the collection to avoid creating duplicates
  - Supports both quick and advanced import modes

- **NewDataset.vue enhancement**:
  - Modified collection creation logic to respect pre-set collections
  - Allows `AddDatasetToCollection` to set the collection before navigation
  - Prevents unnecessary collection creation when adding to existing collections

## Implementation Details

- Added `basename()` utility function to extract filenames without extensions
- Implemented debounced validation to avoid excessive API calls
- Used Vuetify components for consistent UI (cards, lists, progress indicators)
- Added CSS styling for drag-and-drop visual feedback
- Proper cleanup of debounce timer in `beforeDestroy()` hook

https://claude.ai/code/session_018XnmnyN2hx3yvknMhbzwMT