### PR TITLE
Add nimbus-local-ops skill and audit existing skill frontmatter

### DIFF
--- a/.claude/skills/branch-review/SKILL.md
+++ b/.claude/skills/branch-review/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: branch-review
 description: "Use when reviewing code changes on a feature branch before merging, or when the user asks for a code review, PR review, or branch diff analysis. Compares against a base branch (default: master). Checks: pattern consistency, looped API calls that should use batch endpoints, unnecessary temporary variables, proper use of existing utilities, TypeScript type safety, backend access control patterns, and code factorization. References project-specific feature documentation for contextual review."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
-  - Edit
-  - Write
-  - Task
-  - TodoWrite
-user-invocable: true
 ---
 
 # Branch Code Review

--- a/.claude/skills/nimbus-backend/SKILL.md
+++ b/.claude/skills/nimbus-backend/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: nimbus-backend
 description: "Use when writing or modifying Python code in the Girder backend plugin (devops/girder/plugins/AnnotationPlugin/), creating REST API endpoints, writing database queries with MongoDB, implementing access control and sharing, running backend tests with tox/pytest, or debugging Docker compose services. Covers: API endpoint patterns (@autoDescribeRoute, modelParam), access control (AccessType, setUserAccess, setPublic), database queries (Model.find vs collection.find), model loading patterns, error handling, and backend test patterns."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
-  - Edit
-  - Write
-  - Task
-  - TodoWrite
-user-invocable: true
 ---
 
 # Nimbus Backend Development (Girder)

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: nimbus-frontend
 description: "Use when writing or modifying Vue 2 components, Vuex store modules, TypeScript interfaces, or Vuetify UI in the src/ directory. Covers: vue-property-decorator class components, vuex-module-decorators (@Module, @Action, @Mutation), Vuetify 2 theming (light/dark mode), dialog patterns, API client usage (GirderAPI.ts, AnnotationsAPI.ts), logging utilities (logWarning/logError instead of console.*), button loading states, and style guidelines."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
-  - Edit
-  - Write
-  - Task
-  - TodoWrite
-user-invocable: true
 ---
 
 # Nimbus Frontend Development

--- a/.claude/skills/nimbus-local-ops/SKILL.md
+++ b/.claude/skills/nimbus-local-ops/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: nimbus-local-ops
+description: "Use when authenticating with the local Girder backend, making curl requests to REST API endpoints, querying MongoDB directly via docker exec, checking Docker container logs, or debugging backend issues at runtime. Covers: authentication (token retrieval), endpoint name mapping (upenn_annotation not annotation), curl templates for all plugin endpoints, direct MongoDB shell access, container management, and step-by-step test scenarios for verifying backend changes."
+---
+
+# Nimbus Local Operations
+
+## Authentication
+
+Get an auth token:
+
+```bash
+curl -s -u USER:PASS http://localhost:8080/api/v1/user/authentication | python3 -m json.tool
+```
+
+Default dev credentials: `admin` / `password`
+
+Extract just the token:
+
+```bash
+TOKEN=$(curl -s -u admin:password http://localhost:8080/api/v1/user/authentication | python3 -c "import sys,json; print(json.load(sys.stdin)['authToken']['token'])")
+```
+
+Use the token in subsequent requests:
+
+```bash
+curl -s -H "Girder-Token: $TOKEN" http://localhost:8080/api/v1/upenn_annotation?datasetId=DATASET_ID
+```
+
+Tokens expire after ~6 months. Store in a shell variable for the session.
+
+## REST API Quick Reference
+
+**Base URL:** `http://localhost:8080/api/v1/`
+**Swagger UI:** `http://localhost:8080/api/v1#!/`
+
+### Endpoint Name Mapping
+
+Plugin endpoints use custom names that differ from what you might expect:
+
+| REST Path | Source File | Notes |
+|-----------|-------------|-------|
+| `/upenn_annotation` | `server/api/annotation.py` | NOT `/annotation` |
+| `/upenn_collection` | `server/api/collection.py` | NOT `/collection` (Girder has its own) |
+| `/annotation_connection` | `server/api/connections.py` | Connections between annotations |
+| `/annotation_property_values` | `server/api/propertyValues.py` | Computed property data |
+| `/annotation_property` | `server/api/property.py` | Property definitions |
+| `/worker_interface` | `server/api/workerInterfaces.py` | Docker worker registration |
+| `/worker_preview` | `server/api/workerPreviews.py` | Worker preview images |
+| `/dataset_view` | `server/api/datasetView.py` | Per-user view state |
+| `/history` | `server/api/history.py` | Undo/redo history |
+| `/user_assetstore` | `server/api/user_assetstore.py` | Per-user storage |
+| `/user_colors` | `server/api/user_colors.py` | User color preferences |
+| `/export` | `server/api/export.py` | JSON/CSV export |
+| `/project` | `server/api/project.py` | Project management |
+| `/resource` | `server/api/resource.py` | Custom resource search |
+
+All source files live under `devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/`.
+
+### Basic CRUD Pattern
+
+```bash
+# List (usually requires datasetId)
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation?datasetId=$DATASET_ID"
+
+# Get by ID
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation/$ID"
+
+# Create (POST with JSON body)
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"key": "value"}' "http://localhost:8080/api/v1/upenn_annotation"
+
+# Update (PUT with JSON body)
+curl -s -X PUT -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"key": "newValue"}' "http://localhost:8080/api/v1/upenn_annotation/$ID"
+
+# Delete
+curl -s -X DELETE -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation/$ID"
+```
+
+For full endpoint details with request/response examples: read `references/api-endpoints.md`
+
+## Direct MongoDB Access
+
+Connect to MongoDB inside the Docker container:
+
+```bash
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "QUERY" --quiet
+```
+
+### Collection-to-Resource Mapping
+
+| MongoDB Collection | Plugin Resource | Model |
+|-------------------|-----------------|-------|
+| `upenn_annotation` | Annotations | `Annotation` |
+| `folder` | Datasets | Girder `Folder` |
+| `upenn_collection` | Configurations | `Collection` |
+| `annotation_connection` | Connections | `AnnotationConnection` |
+| `dataset_view` | Dataset Views | `DatasetView` |
+| `annotation_property` | Property Definitions | `AnnotationProperty` |
+| `annotation_property_values` | Property Values | `AnnotationPropertyValues` |
+| `upenn_project` | Projects | `Project` |
+| `job` | Worker Jobs | Girder `Job` |
+
+### Quick Inspection
+
+```bash
+# Count annotations
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.countDocuments()" --quiet
+
+# Count annotations in a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.countDocuments({datasetId: ObjectId('DATASET_ID')})" --quiet
+
+# List all datasets (folders with contrastDataset subtype)
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.folder.find({'meta.subtype': 'contrastDataset'}, {name: 1}).toArray()" --quiet
+
+# List collections
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.getCollectionNames()" --quiet
+```
+
+For detailed query recipes: read `references/mongo-recipes.md`
+
+## Docker Operations
+
+### Container Names
+
+| Container | Service | Purpose |
+|-----------|---------|---------|
+| `girder` | Girder API server | Backend REST API |
+| `upenncontrast-mongodb-1` | MongoDB | Database |
+| `worker` | Girder Worker | Background computation |
+| `upenncontrast-broker-1` | RabbitMQ | Message broker for workers |
+| `upenncontrast-memcached-1` | Memcached | Caching layer |
+
+### Common Commands
+
+```bash
+# View logs (last 50 lines)
+docker logs girder --tail 50
+
+# Follow logs in real-time
+docker logs girder -f
+
+# Restart a service
+docker compose restart girder
+
+# Rebuild and restart
+docker compose build girder && docker compose up -d girder
+
+# Check container status
+docker ps
+```
+
+The `docker-compose.yaml` is at the repository root.
+
+## Debugging
+
+### Girder Logs
+
+```bash
+# Check for recent errors
+docker logs girder --tail 100 2>&1 | grep -i error
+
+# Watch for specific endpoint activity
+docker logs girder -f 2>&1 | grep "upenn_annotation"
+```
+
+### Worker Job Status
+
+```bash
+# Check recent jobs
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.job.find({}, {title: 1, status: 1, updated: 1}).sort({updated: -1}).limit(5).toArray()" --quiet
+```
+
+Job status codes: 0=inactive, 1=queued, 2=running, 3=success, 4=error, 5=cancelled
+
+### Common Issues
+
+- **401 Unauthorized**: Token expired or missing. Re-authenticate.
+- **400 Bad Request**: Check JSON body format. Use Swagger UI to see expected schema.
+- **404 Not Found**: Verify endpoint name (e.g., `upenn_annotation` not `annotation`).
+- **Connection refused**: Check `docker ps` to confirm containers are running.
+
+For step-by-step test scenarios: read `references/test-scenarios.md`

--- a/.claude/skills/nimbus-local-ops/references/api-endpoints.md
+++ b/.claude/skills/nimbus-local-ops/references/api-endpoints.md
@@ -1,0 +1,256 @@
+# API Endpoints Reference
+
+Complete curl examples for each plugin endpoint. All examples assume `$TOKEN` is set (see SKILL.md Authentication section).
+
+## upenn_annotation
+
+```bash
+# List annotations for a dataset
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/upenn_annotation?datasetId=$DATASET_ID"
+
+# Get annotation by ID
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/upenn_annotation/$ANNOTATION_ID"
+
+# Create a single annotation
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "tags": ["test"],
+    "shape": "point",
+    "channel": 0,
+    "location": {"Time": 0, "Z": 0, "XY": 0},
+    "coordinates": [{"x": 100, "y": 200, "z": 0}],
+    "datasetId": "DATASET_ID"
+  }' "http://localhost:8080/api/v1/upenn_annotation"
+
+# Create multiple annotations (batch)
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '[
+    {"tags": ["test"], "shape": "point", "channel": 0, "location": {"Time": 0, "Z": 0, "XY": 0}, "coordinates": [{"x": 100, "y": 200, "z": 0}], "datasetId": "DATASET_ID"},
+    {"tags": ["test"], "shape": "point", "channel": 0, "location": {"Time": 0, "Z": 0, "XY": 0}, "coordinates": [{"x": 150, "y": 250, "z": 0}], "datasetId": "DATASET_ID"}
+  ]' "http://localhost:8080/api/v1/upenn_annotation/multiple"
+
+# Delete a single annotation
+curl -s -X DELETE -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/upenn_annotation/$ANNOTATION_ID"
+
+# Delete multiple annotations (batch)
+curl -s -X DELETE -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"ids": ["ID1", "ID2", "ID3"]}' \
+  "http://localhost:8080/api/v1/upenn_annotation/multiple"
+```
+
+## annotation_connection
+
+```bash
+# List connections for a dataset
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_connection?datasetId=$DATASET_ID"
+
+# Create a connection between two annotations
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "parentId": "PARENT_ANNOTATION_ID",
+    "childId": "CHILD_ANNOTATION_ID",
+    "datasetId": "DATASET_ID",
+    "tags": ["connection-tag"]
+  }' "http://localhost:8080/api/v1/annotation_connection"
+
+# Connect to nearest annotation
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "childId": "CHILD_ANNOTATION_ID",
+    "datasetId": "DATASET_ID",
+    "tags": ["parent-tag"],
+    "connectionTags": ["connection-tag"]
+  }' "http://localhost:8080/api/v1/annotation_connection/connect_to_nearest"
+
+# Create multiple connections (batch)
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '[
+    {"parentId": "P1", "childId": "C1", "datasetId": "DATASET_ID", "tags": ["tag"]},
+    {"parentId": "P2", "childId": "C2", "datasetId": "DATASET_ID", "tags": ["tag"]}
+  ]' "http://localhost:8080/api/v1/annotation_connection/multiple"
+
+# Delete a connection
+curl -s -X DELETE -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_connection/$CONNECTION_ID"
+
+# Delete multiple connections (batch)
+curl -s -X DELETE -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"ids": ["ID1", "ID2"]}' \
+  "http://localhost:8080/api/v1/annotation_connection/multiple"
+```
+
+## upenn_collection (Configurations)
+
+```bash
+# List collections/configs for a dataset
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/upenn_collection?datasetId=$DATASET_ID"
+
+# Get collection by ID
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/upenn_collection/$COLLECTION_ID"
+
+# Find collections by folder IDs
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"folderIds": ["FOLDER_ID_1", "FOLDER_ID_2"]}' \
+  "http://localhost:8080/api/v1/upenn_collection/findByFolders"
+
+# Create a collection
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "name": "Test Config",
+    "datasetId": "DATASET_ID",
+    "meta": {}
+  }' "http://localhost:8080/api/v1/upenn_collection"
+
+# Update collection metadata
+curl -s -X PUT -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"meta": {"key": "value"}}' \
+  "http://localhost:8080/api/v1/upenn_collection/$COLLECTION_ID/metadata"
+```
+
+## dataset_view
+
+```bash
+# List views for a dataset
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/dataset_view?datasetId=$DATASET_ID"
+
+# Get view by ID
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/dataset_view/$VIEW_ID"
+
+# Create a view
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "datasetId": "DATASET_ID",
+    "configurationId": "CONFIG_ID"
+  }' "http://localhost:8080/api/v1/dataset_view"
+
+# Share a view with another user
+curl -s -X PUT -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"userId": "USER_ID", "level": 0}' \
+  "http://localhost:8080/api/v1/dataset_view/$VIEW_ID/access"
+
+# Make a view public
+curl -s -X PUT -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"public": true}' \
+  "http://localhost:8080/api/v1/dataset_view/$VIEW_ID/set_public"
+```
+
+## annotation_property
+
+```bash
+# List property definitions for a dataset
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_property?datasetId=$DATASET_ID"
+
+# Create a property definition
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "name": "Area",
+    "image": "properties/area:latest",
+    "datasetId": "DATASET_ID",
+    "tags": {"tags": ["cell"], "exclusive": false},
+    "shape": "polygon",
+    "independentVariables": []
+  }' "http://localhost:8080/api/v1/annotation_property"
+
+# Compute property for entire dataset
+curl -s -X POST -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_property/$PROPERTY_ID/compute?datasetId=$DATASET_ID"
+```
+
+## annotation_property_values
+
+```bash
+# Get property values
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_property_values?propertyId=$PROPERTY_ID&datasetId=$DATASET_ID"
+
+# Add multiple property values (batch)
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "values": [
+      {"annotationId": "ANN_ID", "propertyId": "PROP_ID", "values": {"Area": 1234.5}}
+    ]
+  }' "http://localhost:8080/api/v1/annotation_property_values/multiple"
+
+# Get histogram for a property
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_property_values/histogram?propertyId=$PROPERTY_ID&datasetId=$DATASET_ID"
+```
+
+## project
+
+```bash
+# List all projects
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/project"
+
+# Get project by ID
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/project/$PROJECT_ID"
+
+# Create a project
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name": "Test Project", "description": "For testing"}' \
+  "http://localhost:8080/api/v1/project"
+
+# Add a dataset to a project
+curl -s -X PUT -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/project/$PROJECT_ID/dataset/$DATASET_ID"
+
+# Add a collection/config to a project
+curl -s -X PUT -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/project/$PROJECT_ID/collection/$COLLECTION_ID"
+```
+
+## export
+
+```bash
+# Export annotations as JSON
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/export/json?datasetId=$DATASET_ID" -o annotations.json
+
+# Export annotations as CSV
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/export/csv?datasetId=$DATASET_ID" -o annotations.csv
+```
+
+## Girder Built-in Endpoints
+
+These are Girder-provided, not plugin endpoints, but commonly needed:
+
+```bash
+# Get current user
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/user/me"
+
+# List users
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/user"
+
+# Get folder (dataset) by ID
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/folder/$FOLDER_ID"
+
+# List child folders
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/folder?parentType=folder&parentId=$PARENT_ID"
+
+# Get folder metadata
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/folder/$FOLDER_ID"
+# (metadata is in the .meta field of the response)
+
+# Create a new user
+curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "login": "testuser",
+    "email": "test@example.com",
+    "firstName": "Test",
+    "lastName": "User",
+    "password": "testpass123"
+  }' "http://localhost:8080/api/v1/user"
+```

--- a/.claude/skills/nimbus-local-ops/references/mongo-recipes.md
+++ b/.claude/skills/nimbus-local-ops/references/mongo-recipes.md
@@ -1,0 +1,235 @@
+# MongoDB Recipes
+
+All commands use this pattern:
+
+```bash
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "QUERY" --quiet
+```
+
+## Document Shapes
+
+### upenn_annotation
+
+```javascript
+{
+  _id: ObjectId,
+  tags: ["tag1", "tag2"],
+  shape: "point" | "line" | "polygon" | "rectangle" | "circle",
+  channel: 0,
+  location: { Time: 0, Z: 0, XY: 0 },
+  coordinates: [{ x: Number, y: Number, z: Number }],
+  datasetId: ObjectId,
+  creatorId: ObjectId
+}
+```
+
+### folder (Dataset)
+
+```javascript
+{
+  _id: ObjectId,
+  name: "Dataset Name",
+  parentId: ObjectId,
+  parentCollection: "folder",
+  meta: {
+    subtype: "contrastDataset",
+    // ... image metadata (channels, frames, etc.)
+  }
+}
+```
+
+### upenn_collection (Configuration)
+
+```javascript
+{
+  _id: ObjectId,
+  name: "Config Name",
+  datasetId: ObjectId,
+  meta: {
+    // layers, tools, scales, etc.
+  }
+}
+```
+
+### annotation_connection
+
+```javascript
+{
+  _id: ObjectId,
+  parentId: ObjectId,  // parent annotation
+  childId: ObjectId,   // child annotation
+  datasetId: ObjectId,
+  tags: ["connection-tag"],
+  creatorId: ObjectId
+}
+```
+
+### dataset_view
+
+```javascript
+{
+  _id: ObjectId,
+  datasetId: ObjectId,
+  configurationId: ObjectId,
+  creatorId: ObjectId,
+  lastLocation: { x: Number, y: Number, zoom: Number },
+  // per-user contrast overrides, etc.
+}
+```
+
+### annotation_property
+
+```javascript
+{
+  _id: ObjectId,
+  name: "Property Name",
+  image: "docker/image:tag",
+  datasetId: ObjectId,
+  tags: { tags: ["tag"], exclusive: false },
+  shape: "point" | "polygon" | ...,
+  independentVariables: []
+}
+```
+
+### annotation_property_values
+
+```javascript
+{
+  _id: ObjectId,
+  annotationId: ObjectId,
+  propertyId: ObjectId,
+  values: { "PropertyName": 1234.5 }
+}
+```
+
+### upenn_project
+
+```javascript
+{
+  _id: ObjectId,
+  name: "Project Name",
+  description: "Description",
+  datasetIds: [ObjectId],
+  collectionIds: [ObjectId],
+  creatorId: ObjectId
+}
+```
+
+## Inspection Queries
+
+### Counting
+
+```bash
+# Total annotations
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.countDocuments()" --quiet
+
+# Annotations in a specific dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.countDocuments({datasetId: ObjectId('DATASET_ID')})" --quiet
+
+# Annotations by shape in a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.aggregate([{'\$match': {datasetId: ObjectId('DATASET_ID')}}, {'\$group': {_id: '\$shape', count: {'\$sum': 1}}}]).toArray()" --quiet
+
+# Connections count
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.annotation_connection.countDocuments({datasetId: ObjectId('DATASET_ID')})" --quiet
+```
+
+### Finding
+
+```bash
+# Find annotations with a specific tag
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.find({datasetId: ObjectId('DATASET_ID'), tags: 'mytag'}, {_id: 1, tags: 1, shape: 1}).limit(5).toArray()" --quiet
+
+# Find all distinct tags in a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.distinct('tags', {datasetId: ObjectId('DATASET_ID')})" --quiet
+
+# Find all distinct shapes in a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.distinct('shape', {datasetId: ObjectId('DATASET_ID')})" --quiet
+
+# List all datasets
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.folder.find({'meta.subtype': 'contrastDataset'}, {name: 1, _id: 1}).toArray()" --quiet
+
+# List all projects
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_project.find({}, {name: 1}).toArray()" --quiet
+
+# Find configs for a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_collection.find({datasetId: ObjectId('DATASET_ID')}, {name: 1}).toArray()" --quiet
+
+# Find views for a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.dataset_view.find({datasetId: ObjectId('DATASET_ID')}).toArray()" --quiet
+
+# Find property definitions for a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.annotation_property.find({datasetId: ObjectId('DATASET_ID')}, {name: 1, shape: 1}).toArray()" --quiet
+```
+
+### Aggregation
+
+```bash
+# Annotation count per tag
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.aggregate([{'\$match': {datasetId: ObjectId('DATASET_ID')}}, {'\$unwind': '\$tags'}, {'\$group': {_id: '\$tags', count: {'\$sum': 1}}}, {'\$sort': {count: -1}}]).toArray()" --quiet
+
+# Annotations per time point
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.aggregate([{'\$match': {datasetId: ObjectId('DATASET_ID')}}, {'\$group': {_id: '\$location.Time', count: {'\$sum': 1}}}, {'\$sort': {_id: 1}}]).toArray()" --quiet
+```
+
+## Manipulation Queries
+
+### Insert Test Data
+
+```bash
+# Insert a test annotation
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.insertOne({tags: ['test'], shape: 'point', channel: 0, location: {Time: 0, Z: 0, XY: 0}, coordinates: [{x: 100, y: 200, z: 0}], datasetId: ObjectId('DATASET_ID'), creatorId: ObjectId('USER_ID')})" --quiet
+```
+
+### Bulk Updates
+
+```bash
+# Add a tag to all annotations in a dataset
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.updateMany({datasetId: ObjectId('DATASET_ID')}, {'\$addToSet': {tags: 'new-tag'}})" --quiet
+
+# Remove a tag from all annotations
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.updateMany({datasetId: ObjectId('DATASET_ID')}, {'\$pull': {tags: 'old-tag'}})" --quiet
+```
+
+### Cleanup
+
+```bash
+# Delete test annotations (by tag)
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.deleteMany({tags: 'test', datasetId: ObjectId('DATASET_ID')})" --quiet
+
+# Delete all property values for a property
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.annotation_property_values.deleteMany({propertyId: ObjectId('PROPERTY_ID')})" --quiet
+```
+
+## Cross-Referencing
+
+### Navigate Dataset Relationships
+
+```bash
+# Given a dataset ID, find its configs, views, annotations, and connections
+DATASET_ID="YOUR_DATASET_ID"
+
+# Configs
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_collection.find({datasetId: ObjectId('$DATASET_ID')}, {name: 1}).toArray()" --quiet
+
+# Views
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.dataset_view.find({datasetId: ObjectId('$DATASET_ID')}, {configurationId: 1, creatorId: 1}).toArray()" --quiet
+
+# Annotation count
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.countDocuments({datasetId: ObjectId('$DATASET_ID')})" --quiet
+
+# Connection count
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.annotation_connection.countDocuments({datasetId: ObjectId('$DATASET_ID')})" --quiet
+
+# Properties
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.annotation_property.find({datasetId: ObjectId('$DATASET_ID')}, {name: 1}).toArray()" --quiet
+```
+
+### Find Who Has Access
+
+```bash
+# Check access control on a dataset (folder)
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.folder.findOne({_id: ObjectId('DATASET_ID')}, {access: 1, public: 1})" --quiet
+
+# Check access on a view
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.dataset_view.findOne({_id: ObjectId('VIEW_ID')}, {access: 1, public: 1})" --quiet
+```

--- a/.claude/skills/nimbus-local-ops/references/test-scenarios.md
+++ b/.claude/skills/nimbus-local-ops/references/test-scenarios.md
@@ -1,0 +1,221 @@
+# Test Scenarios
+
+Step-by-step recipes for verifying backend functionality. Each scenario is self-contained.
+
+## Setup: Get Auth Token
+
+All scenarios start with authentication:
+
+```bash
+TOKEN=$(curl -s -u admin:password http://localhost:8080/api/v1/user/authentication | python3 -c "import sys,json; print(json.load(sys.stdin)['authToken']['token'])")
+echo "Token: $TOKEN"
+```
+
+## Setup: Find a Dataset ID
+
+```bash
+# List datasets to pick one
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.folder.find({'meta.subtype': 'contrastDataset'}, {name: 1, _id: 1}).limit(5).toArray()" --quiet
+```
+
+Set the dataset ID for subsequent commands:
+
+```bash
+DATASET_ID="paste-id-here"
+```
+
+## Scenario 1: Create and Delete a Test Annotation
+
+Tests the basic annotation lifecycle via REST API.
+
+```bash
+# 1. Create an annotation
+RESULT=$(curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d "{
+    \"tags\": [\"test-scenario\"],
+    \"shape\": \"point\",
+    \"channel\": 0,
+    \"location\": {\"Time\": 0, \"Z\": 0, \"XY\": 0},
+    \"coordinates\": [{\"x\": 100, \"y\": 200, \"z\": 0}],
+    \"datasetId\": \"$DATASET_ID\"
+  }" "http://localhost:8080/api/v1/upenn_annotation")
+
+echo "Created: $RESULT"
+
+# 2. Extract the annotation ID
+ANN_ID=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['_id'])")
+echo "Annotation ID: $ANN_ID"
+
+# 3. Verify it exists
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation/$ANN_ID" | python3 -m json.tool
+
+# 4. Delete it
+curl -s -X DELETE -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation/$ANN_ID"
+
+# 5. Verify deletion (should 400 or return empty)
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation/$ANN_ID"
+```
+
+## Scenario 2: Create a Connection Between Annotations
+
+Tests connection creation between two annotations.
+
+```bash
+# 1. Create two annotations
+ANN1=$(curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d "{
+    \"tags\": [\"test-parent\"],
+    \"shape\": \"point\",
+    \"channel\": 0,
+    \"location\": {\"Time\": 0, \"Z\": 0, \"XY\": 0},
+    \"coordinates\": [{\"x\": 100, \"y\": 200, \"z\": 0}],
+    \"datasetId\": \"$DATASET_ID\"
+  }" "http://localhost:8080/api/v1/upenn_annotation" | python3 -c "import sys,json; print(json.load(sys.stdin)['_id'])")
+
+ANN2=$(curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d "{
+    \"tags\": [\"test-child\"],
+    \"shape\": \"point\",
+    \"channel\": 0,
+    \"location\": {\"Time\": 0, \"Z\": 0, \"XY\": 0},
+    \"coordinates\": [{\"x\": 150, \"y\": 250, \"z\": 0}],
+    \"datasetId\": \"$DATASET_ID\"
+  }" "http://localhost:8080/api/v1/upenn_annotation" | python3 -c "import sys,json; print(json.load(sys.stdin)['_id'])")
+
+echo "Parent: $ANN1, Child: $ANN2"
+
+# 2. Create a connection
+CONN=$(curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d "{
+    \"parentId\": \"$ANN1\",
+    \"childId\": \"$ANN2\",
+    \"datasetId\": \"$DATASET_ID\",
+    \"tags\": [\"test-connection\"]
+  }" "http://localhost:8080/api/v1/annotation_connection")
+
+echo "Connection: $CONN"
+CONN_ID=$(echo "$CONN" | python3 -c "import sys,json; print(json.load(sys.stdin)['_id'])")
+
+# 3. Verify connection exists
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_connection?datasetId=$DATASET_ID" | python3 -m json.tool
+
+# 4. Cleanup
+curl -s -X DELETE -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/annotation_connection/$CONN_ID"
+curl -s -X DELETE -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation/$ANN1"
+curl -s -X DELETE -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/upenn_annotation/$ANN2"
+```
+
+## Scenario 3: Access Control - Create User and Share Dataset
+
+Tests user creation and dataset sharing.
+
+```bash
+# 1. Create a test user
+USER_RESULT=$(curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "login": "testuser",
+    "email": "test@example.com",
+    "firstName": "Test",
+    "lastName": "User",
+    "password": "testpass123"
+  }' "http://localhost:8080/api/v1/user")
+
+echo "User: $USER_RESULT"
+USER_ID=$(echo "$USER_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['_id'])")
+
+# 2. Share a dataset with the test user (READ access)
+curl -s -X PUT -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"access\": {\"users\": [{\"id\": \"$USER_ID\", \"level\": 0}]}, \"public\": false}" \
+  "http://localhost:8080/api/v1/folder/$DATASET_ID/access"
+
+# 3. Authenticate as the test user
+TEST_TOKEN=$(curl -s -u testuser:testpass123 http://localhost:8080/api/v1/user/authentication | python3 -c "import sys,json; print(json.load(sys.stdin)['authToken']['token'])")
+
+# 4. Verify the test user can read annotations
+curl -s -H "Girder-Token: $TEST_TOKEN" \
+  "http://localhost:8080/api/v1/upenn_annotation?datasetId=$DATASET_ID" | python3 -c "import sys,json; data=json.load(sys.stdin); print(f'Can access: {len(data)} annotations')"
+
+# 5. Verify the test user CANNOT write (should fail)
+curl -s -X POST -H "Girder-Token: $TEST_TOKEN" -H "Content-Type: application/json" \
+  -d "{
+    \"tags\": [\"test\"],
+    \"shape\": \"point\",
+    \"channel\": 0,
+    \"location\": {\"Time\": 0, \"Z\": 0, \"XY\": 0},
+    \"coordinates\": [{\"x\": 100, \"y\": 200, \"z\": 0}],
+    \"datasetId\": \"$DATASET_ID\"
+  }" "http://localhost:8080/api/v1/upenn_annotation"
+
+# 6. Cleanup: delete test user (as admin)
+curl -s -X DELETE -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/user/$USER_ID"
+```
+
+## Scenario 4: Batch Operations
+
+Tests bulk create and delete endpoints.
+
+```bash
+# 1. Batch create 3 annotations
+BATCH_RESULT=$(curl -s -X POST -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d "[
+    {\"tags\": [\"batch-test\"], \"shape\": \"point\", \"channel\": 0, \"location\": {\"Time\": 0, \"Z\": 0, \"XY\": 0}, \"coordinates\": [{\"x\": 10, \"y\": 20, \"z\": 0}], \"datasetId\": \"$DATASET_ID\"},
+    {\"tags\": [\"batch-test\"], \"shape\": \"point\", \"channel\": 0, \"location\": {\"Time\": 0, \"Z\": 0, \"XY\": 0}, \"coordinates\": [{\"x\": 30, \"y\": 40, \"z\": 0}], \"datasetId\": \"$DATASET_ID\"},
+    {\"tags\": [\"batch-test\"], \"shape\": \"point\", \"channel\": 0, \"location\": {\"Time\": 0, \"Z\": 0, \"XY\": 0}, \"coordinates\": [{\"x\": 50, \"y\": 60, \"z\": 0}], \"datasetId\": \"$DATASET_ID\"}
+  ]" "http://localhost:8080/api/v1/upenn_annotation/multiple")
+
+echo "Batch created: $BATCH_RESULT"
+
+# 2. Extract IDs
+IDS=$(echo "$BATCH_RESULT" | python3 -c "import sys,json; ids=json.load(sys.stdin); print(','.join([a['_id'] for a in ids]))")
+echo "Created IDs: $IDS"
+
+# 3. Verify count via MongoDB
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.countDocuments({tags: 'batch-test', datasetId: ObjectId('$DATASET_ID')})" --quiet
+
+# 4. Batch delete
+ID_ARRAY=$(echo "$BATCH_RESULT" | python3 -c "import sys,json; ids=json.load(sys.stdin); print(json.dumps({'ids': [a['_id'] for a in ids]}))")
+curl -s -X DELETE -H "Girder-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d "$ID_ARRAY" "http://localhost:8080/api/v1/upenn_annotation/multiple"
+
+# 5. Verify cleanup
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.upenn_annotation.countDocuments({tags: 'batch-test', datasetId: ObjectId('$DATASET_ID')})" --quiet
+```
+
+## Scenario 5: Verify Property Computation
+
+Tests that a property can be computed for annotations.
+
+```bash
+# 1. List existing properties for the dataset
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_property?datasetId=$DATASET_ID" | python3 -m json.tool
+
+# 2. Pick a property ID from the output
+PROPERTY_ID="paste-property-id-here"
+
+# 3. Trigger computation
+curl -s -X POST -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_property/$PROPERTY_ID/compute?datasetId=$DATASET_ID"
+
+# 4. Check job status
+docker exec upenncontrast-mongodb-1 mongosh girder --eval "db.job.find({}, {title: 1, status: 1}).sort({updated: -1}).limit(3).toArray()" --quiet
+
+# 5. After job completes (status: 3), check property values
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/annotation_property_values?propertyId=$PROPERTY_ID&datasetId=$DATASET_ID" | python3 -c "import sys,json; data=json.load(sys.stdin); print(f'Property values: {len(data)}')"
+```
+
+## Scenario 6: Export Data
+
+Tests JSON and CSV export endpoints.
+
+```bash
+# 1. Export as JSON
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/export/json?datasetId=$DATASET_ID" | python3 -m json.tool | head -50
+
+# 2. Export as CSV
+curl -s -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/export/csv?datasetId=$DATASET_ID" | head -10
+```

--- a/.claude/skills/tool-development/SKILL.md
+++ b/.claude/skills/tool-development/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: tool-development
 description: "Use when creating a new annotation tool, modifying tool templates in public/config/templates.json, adding tool types to TToolType in model.ts, implementing tool interaction logic in AnnotationViewer.vue, or working with the tool selection UI. Covers: template JSON structure, interface element types (annotation, select, checkbox, radio, tags, dockerImage), submenu patterns, tool type registration, GeoJS interaction layer, mouse event handling, hit testing, and worker-based tool configuration."
-allowed-tools:
-  - Bash
-  - Read
-  - Grep
-  - Glob
-  - Edit
-  - Write
-  - Task
-  - TodoWrite
-user-invocable: true
 ---
 
 # NimbusImage Tool Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,29 @@ See `TOOLS.md` for detailed documentation on adding new tools.
 - Histograms cached per-layer for performance
 - Resource metadata cached in `girderResources` module
 
+**API Endpoint Reference:**
+
+Plugin endpoints are registered in `__init__.py` (lines 159-173). Endpoint names differ from what you might expect:
+
+| REST Path | Source File | Notes |
+|-----------|-------------|-------|
+| `/api/v1/upenn_annotation` | `server/api/annotation.py` | NOT `/annotation` |
+| `/api/v1/upenn_collection` | `server/api/collection.py` | NOT `/collection` |
+| `/api/v1/annotation_connection` | `server/api/connections.py` | Connections between annotations |
+| `/api/v1/annotation_property_values` | `server/api/propertyValues.py` | Computed property data |
+| `/api/v1/annotation_property` | `server/api/property.py` | Property definitions |
+| `/api/v1/worker_interface` | `server/api/workerInterfaces.py` | Docker worker registration |
+| `/api/v1/worker_preview` | `server/api/workerPreviews.py` | Worker preview images |
+| `/api/v1/dataset_view` | `server/api/datasetView.py` | Per-user view state |
+| `/api/v1/history` | `server/api/history.py` | Undo/redo history |
+| `/api/v1/user_assetstore` | `server/api/user_assetstore.py` | Per-user storage |
+| `/api/v1/user_colors` | `server/api/user_colors.py` | User color preferences |
+| `/api/v1/export` | `server/api/export.py` | JSON/CSV export |
+| `/api/v1/project` | `server/api/project.py` | Project management |
+| `/api/v1/resource` | `server/api/resource.py` | Custom resource search |
+
+All source files under `devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/`. Swagger UI at `http://localhost:8080/api/v1#!/`.
+
 ### Image Rendering Pipeline
 
 1. **Layer Resolution** - Determine which frames to display based on layer configuration (xy, z, time indices)


### PR DESCRIPTION
## Summary
- Create new `nimbus-local-ops` skill for operating the local backend: authentication, curl templates for all 14 plugin endpoints, MongoDB shell recipes, Docker container management, and step-by-step test scenarios
- Clean up 4 existing skills (`nimbus-backend`, `nimbus-frontend`, `branch-review`, `tool-development`) by removing non-standard frontmatter fields (`allowed-tools`, `user-invocable`)
- Add API endpoint reference table to CLAUDE.md under Backend Integration

## Test plan
- [x] Verified auth curl works against local backend
- [x] Verified MongoDB recipes return correct data (fixed dataset metadata key from `nimbusType` to `subtype: contrastDataset`)
- [x] Confirmed all 5 skills appear in the skill list after changes
- [x] Existing skills still load correctly after frontmatter cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)