### PR TITLE
Wrap GeoJS map layers with markRaw to prevent Vue reactivity

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -868,17 +868,17 @@ export default class ImageViewer extends Vue {
       interactionLayer.node().css({ "mix-blend-mode": "unset" });
 
       const mapentry: IMapEntry = {
-        map,
+        map: markRaw(map),
         imageLayers: markRaw([]),
         params: markRaw(params),
         baseLayerIndex: mllidx ? undefined : 0,
-        annotationLayer,
-        workerPreviewLayer,
-        textLayer,
-        timelapseLayer,
-        timelapseTextLayer,
-        workerPreviewFeature,
-        interactionLayer,
+        annotationLayer: markRaw(annotationLayer),
+        workerPreviewLayer: markRaw(workerPreviewLayer),
+        textLayer: markRaw(textLayer),
+        timelapseLayer: markRaw(timelapseLayer),
+        timelapseTextLayer: markRaw(timelapseTextLayer),
+        workerPreviewFeature: markRaw(workerPreviewFeature),
+        interactionLayer: markRaw(interactionLayer),
       };
       Vue.set(this.maps, mllidx, mapentry);
     } else {


### PR DESCRIPTION
## Summary
- Wraps GeoJS map, annotation layer, interaction layer, and other layer objects with `markRaw()` when storing them in the `maps` reactive array
- Prevents Vue from making these large GeoJS internal objects reactive, which can cause performance degradation

## Test plan
- [ ] Verify map rendering still works correctly
- [ ] Test annotation creation/editing on the map
- [ ] Test multi-layer display modes (single, multiple, unroll)
- [ ] Check for performance improvement with large datasets

🤖 Generated with [Claude Code](https://claude.com/claude-code)