### PR TITLE
Fix tooltip vertical stripe on DatasetInfo collection buttons

### DIFF
--- a/codebaseDocumentation/VUE3_STEPS.md
+++ b/codebaseDocumentation/VUE3_STEPS.md
@@ -853,6 +853,35 @@ The "Preparing layers (0/2)" progress bar could get stuck permanently when switc
 
 - [x] Refactored `draw()` layer tracking in `ImageViewer.vue` into two-pass approach
 
+### P22. Vuetify 3 v-tooltip narrow vertical stripe fix (DatasetInfo.vue) ✅
+
+Tooltips on the "Add to an existing collection", "Copy existing collection", and "Add a new collection" buttons rendered as a narrow vertical stripe instead of a normal-width tooltip box.
+
+**Root cause:** In Vuetify 3, placing raw text directly in the `v-tooltip` default slot (outside the `#activator` template) can cause the tooltip overlay to render with an incorrect width, producing a narrow vertical column of text. This did not happen in Vuetify 2.
+
+**Fix:** Use the `text` prop on `<v-tooltip>` instead of placing content in the default slot. Also changed `max-width` from `"50vh"` (viewport-height units, unusual for width) to `"300"` (pixels). The `text` prop is the recommended Vuetify 3 pattern for simple text tooltips and correctly handles content sizing.
+
+**Before:**
+```html
+<v-tooltip location="top" max-width="50vh">
+  <template #activator="{ props }">
+    <v-btn v-bind="props">Button</v-btn>
+  </template>
+  Raw tooltip text here that renders as vertical stripe
+</v-tooltip>
+```
+
+**After:**
+```html
+<v-tooltip location="top" max-width="300" text="Tooltip text here">
+  <template #activator="{ props }">
+    <v-btn v-bind="props">Button</v-btn>
+  </template>
+</v-tooltip>
+```
+
+- [x] Fixed 3 tooltips in `src/views/dataset/DatasetInfo.vue`
+
 ### SAM integration test failures — FIXED (Phase 4)
 4 tests in `src/components/AnnotationViewer.test.ts` were failing (SAM integration: `samToolState`, `samPrompts`, `onSamMainOutputChanged`, `onSamLivePreviewOutputChanged`). Root cause: R35 changed the runtime code to read `state.mapEntry` (a reactive mirror) instead of `state.nodes.input.geoJSMap.output` (markRaw'd, not reactive). The test mocks didn't include the `mapEntry` field.
 

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -213,7 +213,11 @@
               </div>
             </v-radio-group>
             <div>
-              <v-tooltip location="top" max-width="50vh">
+              <v-tooltip
+                location="top"
+                max-width="300"
+                text="Add this dataset to an existing collection. Shows a list of all collections that are compatible with the current dataset."
+              >
                 <template v-slot:activator="{ props: activatorProps }">
                   <v-btn
                     v-bind="activatorProps"
@@ -228,12 +232,14 @@
                     Add to an existing collection…
                   </v-btn>
                 </template>
-                Add this dataset to an existing collection. Shows a list of all
-                collections that are compatible with the current dataset.
               </v-tooltip>
             </div>
             <div>
-              <v-tooltip location="top" max-width="50vh">
+              <v-tooltip
+                location="top"
+                max-width="300"
+                text="Make a copy of an existing collection and apply it to the current dataset, leaving the original collection unchanged."
+              >
                 <template v-slot:activator="{ props: activatorProps }">
                   <v-btn
                     v-bind="activatorProps"
@@ -248,12 +254,14 @@
                     Copy existing collection…
                   </v-btn>
                 </template>
-                Make a copy of an existing collection and apply it to the
-                current dataset, leaving the original collection unchanged.
               </v-tooltip>
             </div>
             <div v-if="dataset && datasetViewItems.length > 0">
-              <v-tooltip location="top" max-width="50vh">
+              <v-tooltip
+                location="top"
+                max-width="300"
+                text="Create a new collection with a custom name and location for this dataset."
+              >
                 <template v-slot:activator="{ props: activatorProps }">
                   <v-btn
                     v-bind="activatorProps"
@@ -265,8 +273,6 @@
                     Add a new collection…
                   </v-btn>
                 </template>
-                Create a new collection with a custom name and location for this
-                dataset.
               </v-tooltip>
             </div>
 


### PR DESCRIPTION
## Summary
- Fixed tooltips on "Add to an existing collection", "Copy existing collection", and "Add a new collection" buttons rendering as a narrow vertical stripe
- Switched from raw text in `v-tooltip` default slot to the `text` prop, which is the recommended Vuetify 3 pattern
- Changed `max-width` from `"50vh"` to `"300"` (pixels)
- Documented the fix in VUE3_STEPS.md as P22

## Test plan
- [ ] Navigate to a dataset's info page
- [ ] Hover over "Add to an existing collection" button — tooltip should display normally
- [ ] Hover over "Copy existing collection" button — tooltip should display normally
- [ ] Hover over "Add a new collection" button — tooltip should display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)