### PR TITLE
Fix collection name field label overlapping input text

### DIFF
--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -121,12 +121,12 @@
               <v-card-text>
                 <div v-if="dataset && datasetViewItems.length <= 0">
                   <v-text-field
-                    v-tooltip
                     v-model="defaultConfigurationName"
                     label="New collection name"
                     density="compact"
                     hide-details
-                    class="ma-1 pb-2 important-field"
+                    variant="outlined"
+                    class="ma-1 pb-2"
                   />
                   <v-divider class="my-4" />
                 </div>
@@ -828,11 +828,6 @@ defineExpose({
 </script>
 
 <style lang="scss" scoped>
-.important-field :deep(.v-label) {
-  font-size: 22px;
-  font-weight: bold;
-}
-
 .button-bar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Fixed the "New collection name" label overlapping the input value in the "Create new collection" card on DatasetInfo
- Root cause: `.important-field` CSS class set `font-size: 22px` on the label, which is too large for Vuetify 3's compact density layout
- Removed the oversized label styling and added `variant="outlined"` to keep the field visually distinct
- Removed the now-unused `.important-field` CSS class

## Test plan
- [ ] Navigate to a dataset info page with no existing collections (should show "Create new collection" card)
- [ ] Verify the "New collection name" label floats above the input without overlapping
- [ ] Verify the field is still visually distinct with the outlined variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)