### PR TITLE
Fix LargeImageDropdown item slot for Vuetify 3

### DIFF
--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -19,7 +19,10 @@
               formatMeta(listItem.raw.meta)
             }}</span>
           </template>
-          <template #append v-if="listItem.raw.name !== DEFAULT_LARGE_IMAGE_SOURCE">
+          <template
+            #append
+            v-if="listItem.raw.name !== DEFAULT_LARGE_IMAGE_SOURCE"
+          >
             <v-btn
               icon
               size="small"


### PR DESCRIPTION
## Summary
- Fix image selector dropdown items being unclickable and misrendered after Vue 3 / Vuetify 3 migration
- Wrap `v-select` item slot content in `v-list-item` with bound `props` (required by Vuetify 3)
- Move delete button into `#append` slot for proper layout

## Test plan
- [ ] Open a dataset with worker-generated images (so multiple large images exist)
- [ ] Click the "Select Image" dropdown — items should render correctly
- [ ] Click a different image — it should switch successfully
- [ ] Delete button on non-original images should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)