### PR TITLE
Fix Add Dataset dialog and route watcher

### DIFF
--- a/src/components/AddDatasetToCollection.vue
+++ b/src/components/AddDatasetToCollection.vue
@@ -21,6 +21,7 @@
           class="smart-overflow"
           :breadcrumb="true"
           :selectable="true"
+          :prevent-dataset-navigation="true"
           @selected="selectAddDatasetFolder"
           v-model:location="option.datasetSelectLocation"
           :initial-items-per-page="-1"

--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -148,6 +148,7 @@ const props = withDefaults(
     clickableChips?: boolean;
     location?: IGirderLocation | null;
     useDefaultLocation?: boolean;
+    preventDatasetNavigation?: boolean;
   }>(),
   {
     menuEnabled: true,
@@ -156,6 +157,7 @@ const props = withDefaults(
     clickableChips: true,
     location: null,
     useDefaultLocation: true,
+    preventDatasetNavigation: false,
   },
 );
 
@@ -201,6 +203,22 @@ const currentLocation = computed({
     return props.location;
   },
   set(value: IGirderLocation | null) {
+    if (
+      props.preventDatasetNavigation &&
+      value &&
+      "_modelType" in value &&
+      isDatasetFolder(value as IGirderSelectAble)
+    ) {
+      const selectable = value as IGirderSelectAble;
+      const idx = selected.value.findIndex((s) => s._id === selectable._id);
+      if (idx >= 0) {
+        selected.value.splice(idx, 1);
+      } else {
+        selected.value.push(selectable);
+      }
+      emitSelected();
+      return;
+    }
     emit("update:location", value);
   },
 });
@@ -538,7 +556,7 @@ defineExpose({
 
 // Watchers
 watch(isLoggedIn, fetchLocation);
-watch([selected, () => props.selectable], emitSelected);
+watch([selected, () => props.selectable], emitSelected, { deep: true });
 
 // Lifecycle
 onMounted(fetchLocation);

--- a/src/layout/BreadCrumbs.test.ts
+++ b/src/layout/BreadCrumbs.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/store", () => ({
       getDatasetView: (...args: any[]) => mockGetDatasetView(...args),
       findDatasetViews: (...args: any[]) => mockFindDatasetViews(...args),
     },
+    setDatasetViewId: vi.fn(),
   },
   girderUrlFromApiRoot: (apiRoot: string) => {
     const suffix = "/api/v1";
@@ -355,21 +356,17 @@ describe("BreadCrumbs", () => {
 
   // --- addedDatasets ---
 
-  it("addedDatasets navigates to first dataset view", async () => {
+  it("addedDatasets sets dataset view in store", async () => {
     mockWatchFolder.mockReturnValue(null);
     mockGetFolder.mockResolvedValue(null);
     const wrapper = mountComponent();
     const vm = wrapper.vm as any;
+    const { default: store } = await import("@/store");
     vm.addedDatasets(
       ["ds1"],
       [{ id: "view1", datasetId: "ds1", configurationId: "cfg1" }],
     );
-    expect(mockRouter.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "datasetview",
-        params: { datasetViewId: "view1" },
-      }),
-    );
+    expect(store.setDatasetViewId).toHaveBeenCalledWith({ id: "view1" });
   });
 
   // --- datasetId computed ---

--- a/src/layout/BreadCrumbs.vue
+++ b/src/layout/BreadCrumbs.vue
@@ -117,6 +117,7 @@
     <!-- Dialog to add a dataset to the current collection -->
     <v-dialog
       content-class="smart-overflow"
+      class="add-dataset-dialog"
       v-model="addDatasetFlag"
       width="60%"
     >
@@ -262,7 +263,7 @@ function addedDatasets(_datasetIds: string[], datasetViews: IDatasetView[]) {
   refreshItems(true);
   addDatasetFlag.value = false;
   if (datasetViews[0]) {
-    goToView(datasetViews[0].id);
+    store.setDatasetViewId({ id: datasetViews[0].id });
   }
 }
 
@@ -560,5 +561,9 @@ defineExpose({
 
 .v-alert__content {
   min-width: 0;
+}
+
+.add-dataset-dialog.v-dialog {
+  width: auto;
 }
 </style>

--- a/src/utils/useRouteMapper.ts
+++ b/src/utils/useRouteMapper.ts
@@ -127,10 +127,11 @@ export function useRouteMapper(
     });
   }
 
-  // Replace beforeRouteUpdate
+  // Replace beforeRouteUpdate — watch fullPath so param changes within the
+  // same route name are detected (reactive proxy identity never changes).
   watch(
-    () => route,
-    (newRoute) => syncFromRoute(newRoute),
+    () => route.fullPath,
+    () => syncFromRoute(route),
   );
 
   // Sync from route during setup (not onMounted) so that store setters


### PR DESCRIPTION
## Summary
- Fix "Add dataset to collection" dialog: checkboxes now toggle selection, clicking dataset rows selects instead of navigating into folders, dialog width corrected for Vuetify 3
- Fix `useRouteMapper` route watcher to detect param-only changes (watch `fullPath` instead of reactive proxy identity)
- Use `store.setDatasetViewId` directly after adding a dataset (store→URL pattern) instead of `router.push` (URL→store pattern)

## Test plan
- [ ] Open "Add dataset to collection" dialog — should be wider, not cramped
- [ ] Click checkbox on a dataset — should check it and enable "Add dataset" button
- [ ] Click dataset row text — should toggle selection, not navigate into folder
- [ ] Click "Add dataset" — should switch to the new dataset view
- [ ] Browser back/forward between dataset views should work
- [ ] Scrubbing Z/time/xy should still update URL without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)