### PR TITLE
Fix dataset selection in project dialog and widen dialogs

### DIFF
--- a/src/components/AddDatasetToProjectDialog.vue
+++ b/src/components/AddDatasetToProjectDialog.vue
@@ -10,6 +10,7 @@
         class="file-manager-container"
         :breadcrumb="true"
         :selectable="true"
+        :prevent-dataset-navigation="true"
         @selected="onSelectDataset"
         v-model:location="selectLocation"
         :initial-items-per-page="-1"

--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -211,9 +211,9 @@ const currentLocation = computed({
       const selectable = value as IGirderSelectAble;
       const idx = selected.value.findIndex((s) => s._id === selectable._id);
       if (idx >= 0) {
-        selected.value.splice(idx, 1);
+        selected.value = selected.value.filter((s) => s._id !== selectable._id);
       } else {
-        selected.value.push(selectable);
+        selected.value = [...selected.value, selectable];
       }
       emitSelected();
       return;

--- a/src/views/project/ProjectInfo.vue
+++ b/src/views/project/ProjectInfo.vue
@@ -407,7 +407,7 @@
     </v-dialog>
 
     <!-- Add Dataset Dialog -->
-    <v-dialog v-model="addDatasetDialog" width="60%">
+    <v-dialog v-model="addDatasetDialog" width="90%">
       <add-dataset-to-project-dialog
         v-if="project"
         :project="project"
@@ -419,7 +419,7 @@
     </v-dialog>
 
     <!-- Add Collection Dialog -->
-    <v-dialog v-model="addCollectionDialog" width="60%">
+    <v-dialog v-model="addCollectionDialog" width="90%">
       <add-collection-to-project-filter-dialog
         v-if="project"
         :project="project"


### PR DESCRIPTION
## Summary
- Add `prevent-dataset-navigation` prop to `AddDatasetToProjectDialog` so clicking datasets selects them instead of navigating into their contents
- Fix Vue 3 reactivity issue in `CustomFileManager` by using array replacement instead of in-place `splice()`/`push()` mutations, ensuring checkbox state stays in sync with `v-model:selected`
- Widen project add-dataset and add-collection dialogs from 60% to 90% for better content visibility

## Test plan
- [ ] Open a project page, click "Add dataset to project"
- [ ] Verify clicking a dataset row selects it (checkbox checked, green alert) instead of navigating into the folder
- [ ] Verify clicking a second dataset adds it to the selection (multi-select works)
- [ ] Verify clicking a selected dataset deselects it
- [ ] Verify the dialog is wide enough to show all content without truncation
- [ ] Verify "Add collection to project" dialog is also wider

🤖 Generated with [Claude Code](https://claude.com/claude-code)