### PR TITLE
Add DATA_READ token scope to public API endpoints

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -287,7 +287,7 @@ class Annotation(Resource):
             annotationIdToUpdate, self.getCurrentUser()
         )
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Search for annotations")
         .responseClass("upenn_annotation")
@@ -366,7 +366,7 @@ class Annotation(Resource):
             cherrypy.response.headers['Girder-Total-Count'] = cursor.count()
         return generateResult
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Get annotation count for a dataset")
         .param("datasetId", "Get count for this dataset", required=True)
@@ -401,7 +401,7 @@ class Annotation(Resource):
             "count": self._annotationModel.collection.count_documents(query)
         }
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Get an annotation by its id.").param(
             "id", "The annotation's id", paramType="path"

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/collection.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/collection.py
@@ -51,7 +51,7 @@ class Collection(Resource):
             metadata=metadata, description=description,
             reuseExisting=reuseExisting)
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model=CollectionModel)
     @autoDescribeRoute(
         Description('List or search for collections.')
@@ -75,7 +75,7 @@ class Collection(Resource):
         return self._collectionModel.findWithPermissions(
             query, offset, limit, sort=sort, user=self.getCurrentUser())
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model=CollectionModel)
     @autoDescribeRoute(
         Description('Get an collection by ID.')
@@ -150,7 +150,7 @@ class Collection(Resource):
         self._collectionModel.remove(upenn_collection)
         return {'message': 'Deleted collection %s.' % upenn_collection['name']}
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model=CollectionModel)
     @autoDescribeRoute(
         Description('List collections grouped by folder ids')

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
@@ -204,7 +204,7 @@ class AnnotationConnection(Resource):
         annotation_connection.update(filtered)
         self._connectionModel.save(annotation_connection)
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Search for connections")
         .responseClass("annotation_connection")
@@ -268,7 +268,7 @@ class AnnotationConnection(Resource):
             offset=offset,
         ).hint([("datasetId", 1), ("_id", 1)])
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Get connection count for a dataset")
         .param("datasetId", "Get count for this dataset", required=True)
@@ -286,7 +286,7 @@ class AnnotationConnection(Resource):
             "count": self._connectionModel.collection.count_documents(query)
         }
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Get an connection by its id.").param(
             "id", "The connection's id", paramType="path"

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
@@ -44,7 +44,7 @@ class DatasetView(Resource):
         # Bulk mapping endpoint to resolve datasetId <-> configurationId pairs
         self.route("POST", ("map",), self.map)
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Get a dataset view by its id.").param(
             "id", "The dataset view's id", paramType="path"
@@ -129,7 +129,7 @@ class DatasetView(Resource):
         self._datasetViewModel.updateDatasetView(
             dataset_view, new_dataset_view)
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Search for dataset views.")
         .responseClass("dataset_view")
@@ -164,7 +164,7 @@ class DatasetView(Resource):
             offset=offset,
         )
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("""
         Bulk search for dataset views (READ OPERATION).
@@ -464,7 +464,7 @@ class DatasetView(Resource):
         result['datasets'] = datasets
         return result
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Bulk map dataset and configuration ids")
         .notes(

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
@@ -13,7 +13,7 @@ from bson.objectid import ObjectId
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
 from girder.api.rest import Resource, setResponseHeader, setContentDisposition
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.models.folder import Folder
 
 from ..models.annotation import Annotation as AnnotationModel
@@ -66,7 +66,7 @@ class Export(Resource):
         self.route("GET", ("json",), self.exportJson)
         self.route("POST", ("csv",), self.exportCsv)
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Export dataset annotations and related data as JSON")
         .param("datasetId", "The dataset ID", required=True)
@@ -251,7 +251,7 @@ class Export(Resource):
 
         return result
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description("Export dataset annotations as CSV")
         .notes("""

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/project.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/project.py
@@ -80,7 +80,7 @@ class Project(Resource):
         user = self.getCurrentUser()
         return self._projectModel.createProject(name, user, description)
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model=ProjectModel)
     @autoDescribeRoute(
         Description('Get a project by ID.')
@@ -97,7 +97,7 @@ class Project(Resource):
     def get(self, upenn_project):
         return upenn_project
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model=ProjectModel)
     @autoDescribeRoute(
         Description('List projects.')

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
@@ -119,7 +119,7 @@ class AnnotationProperty(Resource):
         annotation_property.update(filtered)
         self._propertyModel.save(annotation_property)
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Search for properties")
         .responseClass("property")
@@ -162,7 +162,7 @@ class AnnotationProperty(Resource):
             offset=offset,
         )
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Get property count for a configuration")
         .param(
@@ -192,7 +192,7 @@ class AnnotationProperty(Resource):
 
         return {"count": count}
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Get a property by its id.").param(
             "id", "The annotation property's id", paramType="path"

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
@@ -121,7 +121,7 @@ class PropertyValues(Resource):
             params["propertyId"], params["datasetId"]
         )
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Search for property values")
         .responseClass("annotation")
@@ -172,7 +172,7 @@ class PropertyValues(Resource):
             offset=offset,
         ).hint([("datasetId", 1), ("_id", 1)])
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description("Get property value count for a dataset")
         .param("datasetId", "Get count for this dataset", required=True)
@@ -195,7 +195,7 @@ class PropertyValues(Resource):
             )
         }
 
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(
         Description(
             "Get a histogram for property values in the specified dataset"


### PR DESCRIPTION
## Summary
This PR adds explicit `TokenScope.DATA_READ` scope requirements to all public-facing read-only API endpoints across the annotation plugin. This enhances security by ensuring that API tokens used to access these endpoints have the appropriate scope for data reading operations.

## Key Changes
- Added `scope=TokenScope.DATA_READ` parameter to `@access.public` decorators on all read-only endpoints in:
  - `datasetView.py`: 4 endpoints (get, find, bulk search, map)
  - `annotation.py`: 3 endpoints (search, count, get)
  - `collection.py`: 3 endpoints (find, get, list by folder)
  - `connections.py`: 3 endpoints (find, count, get)
  - `export.py`: 2 endpoints (JSON export, CSV export)
  - `property.py`: 3 endpoints (search, count, get)
  - `propertyValues.py`: 3 endpoints (find, count, histogram)
  - `project.py`: 2 endpoints (get, list)
- Added missing `TokenScope` import to `export.py`

## Implementation Details
All modified endpoints are read-only operations that retrieve or search for data without modifying state. By adding the `DATA_READ` scope requirement, these endpoints now enforce token-based access control, allowing for more granular permission management and improved API security. The changes are consistent across all affected modules and follow the existing access control patterns in the codebase.

https://claude.ai/code/session_01AbHmNxukpK98YcaZixxhRm