### PR TITLE
Add expandable full-screen file browser mode

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -164,6 +164,52 @@ defaults: {
 - `CustomFileManager.vue` has targeted CSS overrides for the file manager table layout
 - See `codebaseDocumentation/VUETIFY4_MIGRATION.md` for full details
 
+### GirderFileManager Prop Names
+
+GirderFileManager (from `@girder/components`) uses **Vuetify 3 prop naming**, not Vuetify 4. Key props:
+
+- `itemsPerPage` (kebab: `items-per-page`) — sets default page size. **NOT** `initialItemsPerPage`.
+- `itemsPerPageOptions` (kebab: `items-per-page-options`) — array of page size choices.
+
+These props are defined in `node_modules/@girder/components/src/components/FileManager.vue`. If you use a wrong prop name, it silently falls through as an unrecognized attribute and the component uses its internal default (10).
+
+### Overriding Girder DataTable Row Styles
+
+Girder's `DataTable.vue` renders a `v-data-table-server` with `<tr>` > `<td>` rows. The DOM structure is:
+
+```html
+<tr class="v-data-table__tr">
+  <td class="...">checkbox</td>
+  <td>icon + #row slot content</td>
+  <td class="text-right">file size</td>
+</tr>
+```
+
+To override row styles from a parent component:
+- Use **unscoped** `<style>` blocks (scoped styles can't reach into Girder internals)
+- Target `table tr` and `table tr td` — these cover both raw elements and Vuetify class selectors (`.v-data-table__tr`, `.v-data-table__td`) since they're the same DOM nodes. No need to duplicate selectors for both.
+- `!important` is required because Girder's bundled Vuetify 3 CSS is un-layered
+- Scope overrides with a parent wrapper class (e.g., `.browse-expanded .custom-file-manager-wrapper`) to avoid leaking globally
+
+### Persisting User Preferences with Persister
+
+For UI preferences that should survive page reloads (expand/collapse states, view modes, etc.), use `Persister` from `@/store/Persister`:
+
+```typescript
+import Persister from "@/store/Persister";
+
+// Read with default
+const expanded = ref(Persister.get("myPreferenceKey", false));
+
+// Write on change
+function toggle() {
+  expanded.value = !expanded.value;
+  Persister.set("myPreferenceKey", expanded.value);
+}
+```
+
+Persister wraps `localStorage` with JSON serialization. It's already used for theme, tour status, and browse mode preferences.
+
 ## Dialogs
 
 ```vue

--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -79,8 +79,13 @@
                 v-if="menuEnabled"
               >
                 <template v-slot:activator="{ props: activatorProps }">
-                  <v-btn icon v-bind="activatorProps">
-                    <v-icon>mdi-dots-vertical</v-icon>
+                  <v-btn
+                    icon
+                    v-bind="activatorProps"
+                    size="x-small"
+                    variant="text"
+                  >
+                    <v-icon size="small">mdi-dots-vertical</v-icon>
                   </v-btn>
                 </template>
                 <file-manager-options

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -19,8 +19,11 @@
           <div class="loading-text">Loading dataset information...</div>
         </div>
       </v-overlay>
-      <v-container class="home-container">
-        <v-row class="home-row">
+      <v-container
+        class="home-container"
+        :class="{ 'browse-expanded': fileBrowserExpanded }"
+      >
+        <v-row v-if="!fileBrowserExpanded" class="home-row">
           <v-col class="fill-height">
             <section class="mb-4 home-section">
               <!-- Upload Files -->
@@ -120,8 +123,11 @@
             </section>
           </v-col>
         </v-row>
-        <v-divider class="my-4"></v-divider>
-        <v-row class="home-row">
+        <v-divider v-if="!fileBrowserExpanded" class="my-4"></v-divider>
+        <v-row
+          class="home-row"
+          :class="{ 'browse-row-expanded': fileBrowserExpanded }"
+        >
           <v-col class="fill-height">
             <section class="mb-4 home-section">
               <div class="d-flex align-center mb-4">
@@ -145,6 +151,31 @@
                     Projects
                   </v-btn>
                 </v-btn-toggle>
+                <v-spacer />
+                <v-tooltip
+                  :text="
+                    fileBrowserExpanded
+                      ? 'Exit full screen'
+                      : 'Expand to full screen'
+                  "
+                  location="top"
+                >
+                  <template v-slot:activator="{ props: tooltipProps }">
+                    <v-btn
+                      v-bind="tooltipProps"
+                      icon
+                      size="small"
+                      variant="text"
+                      @click="toggleFileBrowserExpanded"
+                    >
+                      <v-icon>{{
+                        fileBrowserExpanded
+                          ? "mdi-arrow-collapse"
+                          : "mdi-arrow-expand"
+                      }}</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
               </div>
               <div class="scrollable">
                 <v-dialog
@@ -163,8 +194,8 @@
                   v-if="browseMode === 'files'"
                   :location="location"
                   @update:location="onLocationUpdate"
-                  :initial-items-per-page="100"
-                  :items-per-page-options="[10, 20, 50, 100, -1]"
+                  :items-per-page="25"
+                  :items-per-page-options="[10, 25, 50, 100, -1]"
                 >
                   <template #options="{ items }">
                     <!--
@@ -503,6 +534,7 @@ const showZenodoImporter = ref(false);
 const showUploadDialog = ref(false);
 const showUploadInfo = ref(false);
 const browseMode = ref<"files" | "collections" | "projects">("files");
+const fileBrowserExpanded = ref(Persister.get("fileBrowserExpanded", false));
 const datasetsTab = ref(0);
 const loadingProjects = ref(false);
 
@@ -1050,6 +1082,11 @@ function handleSampleDatasetSelected(dataset: any) {
   showZenodoImporter.value = true;
 }
 
+function toggleFileBrowserExpanded() {
+  fileBrowserExpanded.value = !fileBrowserExpanded.value;
+  Persister.set("fileBrowserExpanded", fileBrowserExpanded.value);
+}
+
 function handleProjectClicked() {
   // Switch to Projects browse mode when clicking a project
   browseMode.value = "projects";
@@ -1192,6 +1229,7 @@ defineExpose({
   showUploadDialog,
   showUploadInfo,
   browseMode,
+  fileBrowserExpanded,
   datasetsTab,
   loadingProjects,
   pendingFiles,
@@ -1235,6 +1273,7 @@ defineExpose({
   closeUploadDialog,
   toggleZenodoImporter,
   handleSampleDatasetSelected,
+  toggleFileBrowserExpanded,
   handleProjectClicked,
   navigateToDatasetView,
   quickUpload,
@@ -1261,12 +1300,19 @@ defineExpose({
   flex-wrap: nowrap;
 }
 
-.home-row:nth-of-type(1) {
+.home-container:not(.browse-expanded) > .home-row:nth-of-type(1) {
   height: 40%;
 }
 
-.home-row:nth-of-type(2) {
+.home-container:not(.browse-expanded) > .home-row:nth-of-type(2) {
   height: 60%;
+}
+
+.browse-expanded {
+  .browse-row-expanded {
+    height: 100%;
+    flex: 1 1 auto;
+  }
 }
 
 .recent-dataset {
@@ -1402,5 +1448,46 @@ defineExpose({
 .flex-window-items,
 .flex-window-items .v-window-item {
   height: inherit;
+}
+
+// Compact row padding when file browser is in expanded mode.
+// Girder bundles Vuetify 3 CSS (un-layered), so !important is required.
+.browse-expanded .custom-file-manager-wrapper {
+  table tr td {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    height: 28px !important;
+  }
+
+  table tr {
+    height: 28px !important;
+  }
+
+  // Vuetify 3 data-table row height
+  .v-data-table__tr {
+    height: 28px !important;
+  }
+
+  .v-data-table__td {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    height: 28px !important;
+  }
+
+  .itemRow {
+    padding-top: 0;
+    padding-bottom: 0;
+    min-height: 0;
+  }
+
+  // Compact the checkbox cells
+  .v-checkbox-btn {
+    min-height: 0 !important;
+  }
+
+  // Reduce icon spacing
+  .v-icon.pr-2 {
+    padding-right: 4px !important;
+  }
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1116,6 +1116,11 @@ async function initializeWelcomeTour() {
 
   // If it was the default value of NOT_YET_RUN, then update the status and start tour
   if (tourStatus === WelcomeTourStatus.NOT_YET_RUN) {
+    // Collapse expanded file browser so tour anchors (#upload-files-tourstep, etc.) are mounted
+    if (fileBrowserExpanded.value) {
+      fileBrowserExpanded.value = false;
+      Persister.set("fileBrowserExpanded", false);
+    }
     Persister.set(WelcomeTourTypes.HOME, WelcomeTourStatus.ALREADY_RUN);
     startTour(WelcomeTourNames[WelcomeTourTypes.HOME]);
   }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1451,24 +1451,15 @@ defineExpose({
 }
 
 // Compact row padding when file browser is in expanded mode.
-// Girder bundles Vuetify 3 CSS (un-layered), so !important is required.
+// Girder's DataTable renders <tr class="v-data-table__tr"> > <td class="v-data-table__td">,
+// so targeting `table tr` / `table tr td` covers both Vuetify class names and raw elements.
+// !important is required because Girder bundles un-layered Vuetify 3 CSS.
 .browse-expanded .custom-file-manager-wrapper {
-  table tr td {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-    height: 28px !important;
-  }
-
   table tr {
     height: 28px !important;
   }
 
-  // Vuetify 3 data-table row height
-  .v-data-table__tr {
-    height: 28px !important;
-  }
-
-  .v-data-table__td {
+  table tr td {
     padding-top: 0 !important;
     padding-bottom: 0 !important;
     height: 28px !important;
@@ -1480,12 +1471,10 @@ defineExpose({
     min-height: 0;
   }
 
-  // Compact the checkbox cells
   .v-checkbox-btn {
     min-height: 0 !important;
   }
 
-  // Reduce icon spacing
   .v-icon.pr-2 {
     padding-right: 4px !important;
   }


### PR DESCRIPTION
## Summary
- Adds an expand/collapse toggle button on the Browse section header that hides the upload and recents panels, letting the file browser fill the full page height
- Preference is persisted in localStorage so it survives reloads
- Fixes `items-per-page` prop name (was `initial-items-per-page`, silently ignored by GirderFileManager) and defaults to 25
- Shrinks row action menu buttons (`size="x-small"`) for a cleaner look
- Compact 28px row height in expanded mode

## Test plan
- [ ] Click the expand icon (arrow-expand) next to the Browse toggle — upload card and recents should disappear, file browser fills the page
- [ ] Click the collapse icon (arrow-collapse) — upload card and recents reappear
- [ ] Hard reload the page — expanded/collapsed state should persist
- [ ] Verify items per page defaults to 25 (not 10)
- [ ] Verify the three-dot action menu buttons are smaller than before
- [ ] Check expanded mode rows are visually compact

🤖 Generated with [Claude Code](https://claude.com/claude-code)