### PR TITLE
Fix tag chips rendering empty after Vuetify 4 migration

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -112,10 +112,11 @@ Vuetify 4 changed the default theme from `"light"` to `"system"`. Our config set
 
 ### Select/Combobox Slot Items (No `.raw` Wrapper)
 
-Vuetify 4 removed the `.raw` wrapper from select slot items. Items are passed directly:
+Vuetify 4 removed the `.raw` wrapper from select slot items. Items are passed directly. This applies to ALL slot types: `#item`, `#chip`, and `#selection`.
 
+**Object items** — access properties directly:
 ```vue
-<!-- Vuetify 4: access properties directly -->
+<!-- Vuetify 4: access properties directly on object items -->
 <v-select :items="items" item-title="displayName">
   <template v-slot:item="{ item, props: itemProps }">
     <v-list-item v-bind="itemProps">
@@ -124,6 +125,23 @@ Vuetify 4 removed the `.raw` wrapper from select slot items. Items are passed di
     </v-list-item>
   </template>
 </v-select>
+```
+
+**String items** — `item` IS the string, not a wrapped object. Do NOT use `item.title`:
+```vue
+<!-- BAD: item.title is undefined on a string — renders empty chips -->
+<v-combobox :items="tagList" chips multiple>
+  <template v-slot:chip="{ item, props: chipProps }">
+    <v-chip v-bind="chipProps">{{ item.title }}</v-chip>  <!-- WRONG -->
+  </template>
+</v-combobox>
+
+<!-- GOOD: use item directly for string items -->
+<v-combobox :items="tagList" chips multiple>
+  <template v-slot:chip="{ item, props: chipProps }">
+    <v-chip v-bind="chipProps">{{ item }}</v-chip>  <!-- CORRECT -->
+  </template>
+</v-combobox>
 ```
 
 **The `#item` slot name did NOT change** (contrary to some sources claiming rename to `#internalItem`).

--- a/src/components/TagPicker.vue
+++ b/src/components/TagPicker.vue
@@ -16,7 +16,7 @@
   >
     <template v-slot:chip="{ item, props: chipProps }">
       <v-chip v-bind="chipProps" class="pa-2" closable pill size="x-small">
-        {{ (item as any).title }}
+        {{ item }}
       </v-chip>
     </template>
   </v-combobox>


### PR DESCRIPTION
## Summary
- Fixed TagPicker.vue `#chip` slot using `item.title` on string items — in Vuetify 4, slot items are raw values, so `item` IS the tag string (not a wrapped object with `.title`)
- Updated nimbus-frontend skill docs to document the distinction between object items (access properties directly) and string items (use `item` directly)

## Test plan
- [ ] Open "Add a new tool" dialog, select a tool type that shows Annotation Configuration
- [ ] Add tags — verify chip labels display the tag text instead of empty circles
- [ ] Verify tags can still be removed via the close icon
- [ ] Verify tag selection dropdown still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)