### PR TITLE
Fix missing spacing before Modified date in file browser

### DIFF
--- a/src/components/CollectionItemRow.vue
+++ b/src/components/CollectionItemRow.vue
@@ -10,7 +10,11 @@
       location="end"
     >
       <template v-slot:activator="{ props: activatorProps }">
-        <span v-bind="activatorProps" class="text-caption text-grey mx-2">
+        <span
+          v-bind="activatorProps"
+          class="text-caption"
+          style="margin-left: 8px; margin-right: 8px; opacity: 0.4"
+        >
           Modified:
           {{
             collection.updated

--- a/src/components/FileItemRow.vue
+++ b/src/components/FileItemRow.vue
@@ -39,7 +39,8 @@
       <template v-slot:activator="{ props: activatorProps }">
         <span
           v-bind="activatorProps"
-          class="text-caption text-medium-emphasis mx-2"
+          class="text-caption"
+          style="margin-left: 8px; margin-right: 8px; opacity: 0.4"
         >
           Modified:
           {{ item.updated ? formatDateString(item.updated) : "Unknown" }}


### PR DESCRIPTION
## Summary
- Fixed folder names running directly into "Modified: ..." text with no spacing in the file browser
- Replaced Vuetify utility classes (`mx-2`, `text-medium-emphasis`) with explicit inline styles to avoid conflicts with bundled Vuetify 3 CSS from `@girder/components`
- Reduced Modified date text opacity to 0.4 for a subtler appearance

## Test plan
- [x] Open the file browser and verify spacing between folder names and "Modified: ..." text
- [x] Check both regular folders and collection items
- [x] Verify the date text is visible but subtly dimmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)