### PR TITLE
Fix location chooser file browser layout for Vuetify 4

### DIFF
--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -622,28 +622,24 @@ onBeforeUnmount(() => {
   width: 100%;
 }
 
-// Checkbox column: narrow
-.custom-file-manager-wrapper table col:first-child {
-  width: 40px;
-}
-
-// Size column: narrow, right-aligned
+// Size column: narrow, right-aligned.
+// Checkbox column width is set inline (style="width: 65px") in the Girder
+// DataTable template, so it doesn't need CSS. Content column auto-fills
+// the remaining space.
 .custom-file-manager-wrapper table col:last-child {
-  width: 90px;
-}
-
-// Also target td directly in case <col> elements don't exist
-.custom-file-manager-wrapper table tr td:first-child {
-  width: 40px;
+  width: 100px;
 }
 
 .custom-file-manager-wrapper table tr td:last-child {
-  width: 90px;
+  width: 100px;
   text-align: right;
 }
 
-// Fix file browser rows: icon and content on same line, vertically centered
-.custom-file-manager-wrapper .select-cursor {
+// Fix file browser rows: icon and content on same line, vertically centered.
+// Scoped to td > .select-cursor so it targets the <span> inside cells,
+// NOT the <tr> elements (which also get .select-cursor from getRowClass).
+// display: flex on <tr> would break table-layout: fixed column sizing.
+.custom-file-manager-wrapper td > .select-cursor {
   display: flex !important;
   align-items: center;
 }

--- a/src/components/GirderLocationChooser.vue
+++ b/src/components/GirderLocationChooser.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-dialog v-model="dialogInternal" scrollable width="auto">
+  <v-dialog
+    v-model="dialogInternal"
+    scrollable
+    width="70vw"
+    class="wide-dialog"
+  >
     <template
       #activator="{ props: activatorProps }"
       v-if="activatorDisabled === false"
@@ -19,7 +24,7 @@
         />
       </div>
     </template>
-    <v-card class="pa-2" style="min-width: 70vh">
+    <v-card class="pa-2">
       <v-card-title>{{ title }}</v-card-title>
       <v-card-text style="height: 70vh">
         <custom-file-manager
@@ -122,3 +127,12 @@ function select() {
 
 defineExpose({ dialogInternal, selectedName, select, selected });
 </script>
+
+<style lang="scss">
+// Override Vuetify 3's default .v-dialog { width: 50% } on outer overlay element.
+// Without this, width="80vw" on v-dialog only applies to the inner .v-overlay__content,
+// making the actual dialog 80vw of 50% = 40vw. (See VUE3_STEPS.md P14)
+.wide-dialog.v-dialog {
+  width: auto;
+}
+</style>

--- a/src/components/GirderLocationChooser.vue
+++ b/src/components/GirderLocationChooser.vue
@@ -130,8 +130,10 @@ defineExpose({ dialogInternal, selectedName, select, selected });
 
 <style lang="scss">
 // Override Vuetify 3's default .v-dialog { width: 50% } on outer overlay element.
-// Without this, width="80vw" on v-dialog only applies to the inner .v-overlay__content,
-// making the actual dialog 80vw of 50% = 40vw. (See VUE3_STEPS.md P14)
+// Without this, width="70vw" on v-dialog only applies to the inner .v-overlay__content,
+// making the actual dialog 70vw of 50% = 35vw. (See VUE3_STEPS.md P14)
+// Note: same rule exists in ProjectInfo.vue — both are needed since unscoped
+// styles are only emitted when the component is mounted.
 .wide-dialog.v-dialog {
   width: auto;
 }

--- a/src/components/GirderLocationChooser.vue
+++ b/src/components/GirderLocationChooser.vue
@@ -25,7 +25,7 @@
         <custom-file-manager
           v-model:location="selected"
           v-bind="$attrs"
-          :initial-items-per-page="-1"
+          :items-per-page="-1"
           :items-per-page-options="[-1]"
           :menu-enabled="false"
           :more-chips="false"


### PR DESCRIPTION
## Summary
- Fix overlapping rows in the location chooser file browser caused by `display: flex !important` on `<tr>` elements breaking `table-layout: fixed` column sizing — scoped the rule to only target `<span>` inside cells (`td > .select-cursor`)
- Remove `td:first-child { width: 40px }` rules that crushed the content column to 40px when no checkbox column was present (location chooser has `selectable=false`)
- Fix incorrect prop name `initial-items-per-page` → `items-per-page` on GirderFileManager
- Widen dialog from `min-width: 70vh` to `width: 70vw` with `wide-dialog` class override for Girder's bundled Vuetify 3 CSS (`.v-dialog { width: 50% }`)

## Test plan
- [ ] Open "New Dataset" → location chooser dialog renders with proper row layout (no overlapping text)
- [ ] File sizes display fully (not truncated)
- [ ] Dialog is wide (70vw) and centered
- [ ] Main file browser on home page still renders correctly with checkboxes
- [ ] Navigate into folders in the location chooser — layout stays correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)