### PR TITLE
Add "Mine only" filter for recent datasets on home page

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
@@ -143,22 +143,40 @@ class DatasetView(Resource):
             "Get all dataset views using this configuration",
             required=False,
         )
+        .param(
+            "currentUserOnly",
+            "If true, only return views owned by the current user "
+            "(where the user has ADMIN access).",
+            required=False,
+            dataType="boolean",
+        )
         .pagingParams(defaultSort="_id")
         .errorResponse()
     )
     def find(self, params):
         limit, offset, sort = self.getPagingParameters(params, "lowerName")
         query = {}
+        user = self.getCurrentUser()
 
         # Handle single IDs from query params
         for key in ["datasetId", "configurationId"]:
             if key in params:
                 query[key] = ObjectId(params[key])
 
+        # Filter to only views owned by the current user
+        if (params.get("currentUserOnly", "").lower()
+                in ("true", "1", "yes") and user):
+            query["access.users"] = {
+                "$elemMatch": {
+                    "id": user["_id"],
+                    "level": AccessType.ADMIN,
+                }
+            }
+
         return self._datasetViewModel.findWithPermissions(
             query,
             sort=sort,
-            user=self.getCurrentUser(),
+            user=user,
             level=AccessType.READ,
             limit=limit,
             offset=offset,

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
@@ -163,9 +163,17 @@ class DatasetView(Resource):
             if key in params:
                 query[key] = ObjectId(params[key])
 
-        # Filter to only views owned by the current user
-        if (params.get("currentUserOnly", "").lower()
-                in ("true", "1", "yes") and user):
+        # Filter to only views owned by the current user.
+        # describeRoute does not auto-convert types, so coerce to str
+        # before lowering in case a client sends a non-string truthy.
+        # Intentionally checks only direct user grants (not group-based
+        # access) — "Mine only" means views the user personally owns,
+        # which corresponds to the explicit ADMIN entry creators receive.
+        currentUserOnly = (
+            str(params.get("currentUserOnly", "")).lower()
+            in ("true", "1", "yes", "on")
+        )
+        if currentUserOnly and user:
             query["access.users"] = {
                 "$elemMatch": {
                     "id": user["_id"],

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/datasetView.py
@@ -14,6 +14,7 @@ from girder.models.user import User
 from upenncontrast_annotation.server.helpers.access_helpers import (
     formatAccessList
 )
+from upenncontrast_annotation.server.helpers.params import getBooleanParam
 from upenncontrast_annotation.server.models.datasetView import \
     DatasetView as DatasetViewModel
 from upenncontrast_annotation.server.models.collection import \
@@ -163,17 +164,10 @@ class DatasetView(Resource):
             if key in params:
                 query[key] = ObjectId(params[key])
 
-        # Filter to only views owned by the current user.
-        # describeRoute does not auto-convert types, so coerce to str
-        # before lowering in case a client sends a non-string truthy.
-        # Intentionally checks only direct user grants (not group-based
-        # access) — "Mine only" means views the user personally owns,
-        # which corresponds to the explicit ADMIN entry creators receive.
-        currentUserOnly = (
-            str(params.get("currentUserOnly", "")).lower()
-            in ("true", "1", "yes", "on")
-        )
-        if currentUserOnly and user:
+        if getBooleanParam(params, "currentUserOnly") and user:
+            # Intentionally checks only direct user grants (not group-based
+            # access): "Mine only" means views the user personally owns,
+            # which corresponds to the explicit ADMIN entry creators receive.
             query["access.users"] = {
                 "$elemMatch": {
                     "id": user["_id"],

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/params.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/params.py
@@ -1,0 +1,15 @@
+"""Shared helpers for request parameter handling."""
+
+TRUTHY_PARAM_VALUES = {"true", "1", "yes", "on"}
+
+
+def getBooleanParam(params, key, default=False):
+    """Parse a boolean-ish request parameter.
+
+    describeRoute does not always coerce query params, so public endpoints may
+    see strings even when the route declares dataType="boolean".
+    """
+    value = params.get(key, default)
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in TRUTHY_PARAM_VALUES

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_sharing.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_sharing.py
@@ -475,3 +475,157 @@ class TestBulkFind:
         ))
         assert len(views) == 1
         assert views[0]["_id"] == datasetView["_id"]
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestFindCurrentUserOnly:
+    """Tests for the currentUserOnly filter on the find endpoint."""
+
+    def testReturnsOnlyUserOwnedViews(self, admin, user, server):
+        """currentUserOnly=true returns only views the user owns.
+
+        A view shared at READ level should NOT appear, even though it is
+        readable.
+        """
+        # User creates one view they own
+        ownDataset, ownConfig, ownView = createDatasetWithView(user)
+
+        # Admin creates a separate view and shares it with user at READ
+        sharedDataset, sharedConfig, sharedView = createDatasetWithView(
+            admin
+        )
+        DatasetViewModel().setUserAccess(
+            sharedView, user, AccessType.READ, save=True
+        )
+        Folder().setUserAccess(
+            sharedDataset, user, AccessType.READ, save=True
+        )
+        Collection().setUserAccess(
+            sharedConfig, user, AccessType.READ, save=True
+        )
+
+        # Without the filter: user sees both (their own + shared)
+        resp = server.request(
+            path="/dataset_view",
+            method="GET",
+            user=user,
+        )
+        assertStatusOk(resp)
+        ids = {v["_id"] for v in resp.json}
+        assert str(ownView["_id"]) in ids
+        assert str(sharedView["_id"]) in ids
+
+        # With the filter: user sees only the view they own
+        resp = server.request(
+            path="/dataset_view",
+            method="GET",
+            params={"currentUserOnly": "true"},
+            user=user,
+        )
+        assertStatusOk(resp)
+        ids = {v["_id"] for v in resp.json}
+        assert str(ownView["_id"]) in ids
+        assert str(sharedView["_id"]) not in ids
+
+    def testFalsyValuesAreIgnored(self, admin, user, server):
+        """currentUserOnly with a falsy value behaves like the default."""
+        ownDataset, ownConfig, ownView = createDatasetWithView(user)
+        sharedDataset, sharedConfig, sharedView = createDatasetWithView(
+            admin
+        )
+        DatasetViewModel().setUserAccess(
+            sharedView, user, AccessType.READ, save=True
+        )
+        Folder().setUserAccess(
+            sharedDataset, user, AccessType.READ, save=True
+        )
+        Collection().setUserAccess(
+            sharedConfig, user, AccessType.READ, save=True
+        )
+
+        for value in ("false", "0", "no", ""):
+            resp = server.request(
+                path="/dataset_view",
+                method="GET",
+                params={"currentUserOnly": value},
+                user=user,
+            )
+            assertStatusOk(resp)
+            ids = {v["_id"] for v in resp.json}
+            assert str(ownView["_id"]) in ids, value
+            assert str(sharedView["_id"]) in ids, value
+
+    def testTruthyAliases(self, admin, user, server):
+        """Multiple truthy spellings all activate the filter."""
+        ownDataset, ownConfig, ownView = createDatasetWithView(user)
+        sharedDataset, sharedConfig, sharedView = createDatasetWithView(
+            admin
+        )
+        DatasetViewModel().setUserAccess(
+            sharedView, user, AccessType.READ, save=True
+        )
+        Folder().setUserAccess(
+            sharedDataset, user, AccessType.READ, save=True
+        )
+        Collection().setUserAccess(
+            sharedConfig, user, AccessType.READ, save=True
+        )
+
+        for value in ("true", "True", "TRUE", "1", "yes", "on"):
+            resp = server.request(
+                path="/dataset_view",
+                method="GET",
+                params={"currentUserOnly": value},
+                user=user,
+            )
+            assertStatusOk(resp)
+            ids = {v["_id"] for v in resp.json}
+            assert str(ownView["_id"]) in ids, value
+            assert str(sharedView["_id"]) not in ids, value
+
+    def testAdminWithFilterOnlySeesOwnViews(self, admin, user, server):
+        """Site admin with currentUserOnly=true sees only what they own.
+
+        Site admins normally see everything via findWithPermissions, but
+        the filter narrows that to views where their _id appears with
+        ADMIN access — i.e. things they created.
+        """
+        # Other user owns a view
+        otherDataset, otherConfig, otherView = createDatasetWithView(user)
+
+        # Admin owns a view
+        adminDataset, adminConfig, adminView = createDatasetWithView(admin)
+
+        resp = server.request(
+            path="/dataset_view",
+            method="GET",
+            params={"currentUserOnly": "true"},
+            user=admin,
+        )
+        assertStatusOk(resp)
+        ids = {v["_id"] for v in resp.json}
+        assert str(adminView["_id"]) in ids
+        assert str(otherView["_id"]) not in ids
+
+    def testAnonymousIgnoresFilter(self, admin, server):
+        """Anonymous users have no _id; filter is skipped, returns
+        whatever READ permissions allow (typically only public views).
+        """
+        dataset, config, datasetView = createDatasetWithView(admin)
+        # Make public so anonymous can read
+        Folder().setPublic(dataset, True, save=True)
+        DatasetViewModel().setPublic(datasetView, True, save=True)
+        Collection().setPublic(config, True, save=True)
+
+        resp = server.request(
+            path="/dataset_view",
+            method="GET",
+            params={"currentUserOnly": "true"},
+            user=None,
+        )
+        assertStatusOk(resp)
+        # Should not crash; returns the public view since filter is
+        # skipped when no current user.
+        ids = {v["_id"] for v in resp.json}
+        assert str(datasetView["_id"]) in ids

--- a/src/components/RecentDatasets.test.ts
+++ b/src/components/RecentDatasets.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import RecentDatasets from "./RecentDatasets.vue";
+import type { IRecentDatasetViewItem } from "@/store/model";
 
 const sampleItems = [
   {
@@ -13,13 +14,14 @@ const sampleItems = [
     datasetInfo: { name: "Dataset B", description: "", creatorId: "" },
     configInfo: { name: "Config 2", description: "" },
   },
-];
+] as unknown as IRecentDatasetViewItem[];
 
 function mountComponent(props = {}) {
   return mount(RecentDatasets, {
     props: {
       datasetViewItems: sampleItems,
-      getUserDisplayName: vi.fn((id: string) => `User ${id}`),
+      getUserDisplayName: vi.fn((id: string) => `User ${id} (u-${id}@x)`),
+      getUserShortName: vi.fn((id: string) => `User ${id}`),
       formatDateNumber: vi.fn((d: number) => new Date(d).toLocaleString()),
       ...props,
     },
@@ -39,15 +41,15 @@ describe("RecentDatasets", () => {
     expect(wrapper.text()).toContain("Config 2");
   });
 
-  it("calls getUserDisplayName for items with creatorId", () => {
-    const getUserDisplayName = vi.fn(() => "Test User");
-    mountComponent({ getUserDisplayName });
-    expect(getUserDisplayName).toHaveBeenCalledWith("u1");
+  it("calls getUserShortName for items with creatorId", () => {
+    const getUserShortName = vi.fn(() => "Test User");
+    mountComponent({ getUserShortName });
+    expect(getUserShortName).toHaveBeenCalledWith("u1");
   });
 
   it("emits dataset-clicked when a dataset is clicked", async () => {
     const wrapper = mountComponent();
-    const listItems = wrapper.findAll(".v-list-item");
+    const listItems = wrapper.findAll(".recent-item");
     await listItems.at(0)!.trigger("click");
     expect(wrapper.emitted("dataset-clicked")).toBeTruthy();
     expect(wrapper.emitted("dataset-clicked")![0]).toEqual(["dv1"]);

--- a/src/components/RecentDatasets.vue
+++ b/src/components/RecentDatasets.vue
@@ -1,49 +1,68 @@
 <template>
   <div class="recent-datasets-container">
-    <v-list lines="two" class="scrollable py-0">
-      <div v-for="d in datasetViewItems" :key="d.datasetView.id">
+    <v-list class="recent-list scrollable py-0" :lines="false">
+      <div
+        v-for="(d, index) in datasetViewItems"
+        :key="d.datasetView.id"
+        class="recent-item-wrapper"
+      >
+        <div v-if="index > 0" class="recent-divider" aria-hidden="true" />
         <v-tooltip
           location="top"
           :disabled="!d.datasetInfo.description && !d.configInfo.description"
         >
-          <template v-slot:activator="{ props: activatorProps }">
-            <v-list-item
-              @click="handleDatasetClick(d.datasetView.id)"
+          <template #activator="{ props: activatorProps }">
+            <button
+              type="button"
+              class="recent-item"
               v-bind="activatorProps"
+              :title="formatDateNumber(d.datasetView.lastViewed)"
+              @click="handleDatasetClick(d.datasetView.id)"
             >
-              <v-list-item-title>
+              <span class="recent-item__name">
                 {{
                   d.datasetInfo.name ? d.datasetInfo.name : "Unnamed dataset"
                 }}
-              </v-list-item-title>
-              <v-list-item-subtitle>
-                {{
-                  d.configInfo.name
-                    ? d.configInfo.name
-                    : "Unnamed configuration"
-                }}
+              </span>
+              <span class="recent-item__date">
+                {{ formatDayShort(d.datasetView.lastViewed) }}
+              </span>
+              <span class="recent-item__meta">
+                <span class="recent-item__config">
+                  {{
+                    d.configInfo.name
+                      ? d.configInfo.name
+                      : "Unnamed configuration"
+                  }}
+                </span>
                 <template v-if="d.datasetInfo.creatorId">
-                  <br />
-                  <span class="text-caption">
-                    Owner:
-                    {{ getUserDisplayName(d.datasetInfo.creatorId) }}
+                  <span class="recent-item__sep" aria-hidden="true">·</span>
+                  <span class="recent-item__owner">
+                    <v-icon
+                      size="13"
+                      class="recent-item__owner-icon"
+                      aria-hidden="true"
+                    >
+                      mdi-account-outline
+                    </v-icon>
+                    {{ getUserShortName(d.datasetInfo.creatorId) }}
                   </span>
                 </template>
-              </v-list-item-subtitle>
-              <span class="my-0 d-flex flex-column justify-center">
-                <div class="text-caption text-medium-emphasis text-left">
-                  <div>Last accessed:</div>
-                  <div style="line-height: 1.1">
-                    {{ formatDateNumber(d.datasetView.lastViewed) }}
-                  </div>
-                </div>
               </span>
-            </v-list-item>
+              <span class="recent-item__time">
+                {{ formatTimeOfDay(d.datasetView.lastViewed) }}
+              </span>
+              <v-icon size="16" class="recent-item__chevron" aria-hidden="true">
+                mdi-chevron-right
+              </v-icon>
+            </button>
           </template>
           <div v-if="d.datasetInfo.description">
             {{ d.datasetInfo.description }}
           </div>
-          <v-divider />
+          <v-divider
+            v-if="d.datasetInfo.description && d.configInfo.description"
+          />
           <div v-if="d.configInfo.description">
             {{ d.configInfo.description }}
           </div>
@@ -54,9 +73,13 @@
 </template>
 
 <script setup lang="ts">
+import { IRecentDatasetViewItem } from "@/store/model";
+import { formatDayShort, formatTimeOfDay } from "@/utils/date";
+
 defineProps<{
-  datasetViewItems: any[];
+  datasetViewItems: IRecentDatasetViewItem[];
   getUserDisplayName: (creatorId: string) => string;
+  getUserShortName: (creatorId: string) => string;
   formatDateNumber: (date: number) => string;
 }>();
 
@@ -69,7 +92,7 @@ function handleDatasetClick(datasetViewId: string) {
 }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .recent-datasets-container {
   height: 100%;
   display: flex;
@@ -80,5 +103,166 @@ function handleDatasetClick(datasetViewId: string) {
   overflow-y: auto;
   flex-grow: 1;
   min-height: 0;
+}
+
+.recent-list {
+  background: transparent;
+}
+
+.recent-divider {
+  height: 1px;
+  margin: 0 12px;
+  background: rgb(var(--v-theme-on-surface) / 0.06);
+}
+
+.recent-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-rows: auto auto;
+  column-gap: 12px;
+  row-gap: 2px;
+  align-items: baseline;
+  width: 100%;
+  padding: 10px 14px 10px 16px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  color: inherit;
+  font: inherit;
+  transition:
+    background-color 120ms ease,
+    padding-left 120ms ease;
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 6px;
+    bottom: 6px;
+    width: 2px;
+    border-radius: 2px;
+    background: rgb(var(--v-theme-primary));
+    opacity: 0;
+    transform: scaleY(0.4);
+    transform-origin: center;
+    transition:
+      opacity 140ms ease,
+      transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: rgb(var(--v-theme-on-surface) / 0.045);
+    padding-left: 18px;
+    outline: none;
+
+    &::before {
+      opacity: 1;
+      transform: scaleY(1);
+    }
+
+    .recent-item__chevron {
+      opacity: 0.7;
+      transform: translateX(0);
+    }
+  }
+
+  &:active {
+    background: rgb(var(--v-theme-on-surface) / 0.07);
+  }
+}
+
+.recent-item__name {
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: rgb(var(--v-theme-on-surface));
+  line-height: 1.35;
+}
+
+.recent-item__date {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: end;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: rgb(var(--v-theme-on-surface-variant));
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.recent-item__meta {
+  grid-column: 1;
+  grid-row: 2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.recent-item__time {
+  grid-column: 2;
+  grid-row: 2;
+  justify-self: end;
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  color: rgb(var(--v-theme-on-surface-variant) / 0.75);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.recent-item__config {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  color: rgb(var(--v-theme-on-surface-variant));
+  line-height: 1.4;
+}
+
+.recent-item__sep {
+  flex: 0 0 auto;
+  color: rgb(var(--v-theme-on-surface-variant) / 0.6);
+  user-select: none;
+}
+
+.recent-item__owner {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  color: rgb(var(--v-theme-on-surface-variant));
+  white-space: nowrap;
+}
+
+.recent-item__owner-icon {
+  opacity: 0.7;
+}
+
+.recent-item__chevron {
+  grid-column: 3;
+  grid-row: 1 / -1;
+  align-self: center;
+  margin-left: 4px;
+  color: rgb(var(--v-theme-on-surface-variant));
+  opacity: 0;
+  transform: translateX(-4px);
+  transition:
+    opacity 140ms ease,
+    transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 </style>

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -479,13 +479,18 @@ export default class GirderAPI {
     }
   }
 
-  async getRecentDatasetViews(limit: number, offset: number = 0) {
+  async getRecentDatasetViews(
+    limit: number,
+    offset: number = 0,
+    currentUserOnly: boolean = false,
+  ) {
     const formData: AxiosRequestConfig = {
       params: {
         limit,
         offset,
         sort: "lastViewed",
         sortdir: -1,
+        ...(currentUserOnly ? { currentUserOnly: true } : {}),
       },
     };
     const response = await this.client.get("dataset_view", formData);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -794,7 +794,7 @@ export class Main extends VuexModule {
     promises.push(
       this.setSelectedConfiguration(this.selectedConfigurationId),
       this.setSelectedDataset(this.selectedDatasetId),
-      this.fetchRecentDatasetViews(),
+      this.fetchRecentDatasetViews(!this.isAdmin),
     );
     // Initialize notification websocket as soon as the user has logged in because
     // any notification sent without would be lost.
@@ -1075,12 +1075,12 @@ export class Main extends VuexModule {
   }
 
   @Action
-  async fetchRecentDatasetViews() {
+  async fetchRecentDatasetViews(currentUserOnly: boolean = false) {
     try {
       const recentDatasetViews = await this.api.getRecentDatasetViews(
         MAX_NUMBER_OF_RECENT_DATASET_VIEWS,
         0,
-        !this.isAdmin,
+        currentUserOnly,
       );
       this.setRecentDatasetViewsImpl(recentDatasetViews);
     } catch {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1079,6 +1079,8 @@ export class Main extends VuexModule {
     try {
       const recentDatasetViews = await this.api.getRecentDatasetViews(
         MAX_NUMBER_OF_RECENT_DATASET_VIEWS,
+        0,
+        !this.isAdmin,
       );
       this.setRecentDatasetViewsImpl(recentDatasetViews);
     } catch {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -98,6 +98,12 @@ function apiRootFromGirderUrl(girderUrl: string) {
   return girderUrl + apiRootSuffix;
 }
 
+// Tracks the most recently issued fetchRecentDatasetViews call so older
+// in-flight requests can detect they are stale and skip the state write.
+// Without this, a slower request with a different filter can land last and
+// overwrite the result of a newer request.
+let recentDatasetViewsRequestId = 0;
+
 @Module({ dynamic: true, store, name: "main" })
 export class Main extends VuexModule {
   girderRest = new RestClient({
@@ -1076,14 +1082,21 @@ export class Main extends VuexModule {
 
   @Action
   async fetchRecentDatasetViews(currentUserOnly: boolean = false) {
+    const requestId = ++recentDatasetViewsRequestId;
     try {
       const recentDatasetViews = await this.api.getRecentDatasetViews(
         MAX_NUMBER_OF_RECENT_DATASET_VIEWS,
         0,
         currentUserOnly,
       );
+      if (requestId !== recentDatasetViewsRequestId) {
+        return;
+      }
       this.setRecentDatasetViewsImpl(recentDatasetViews);
     } catch {
+      if (requestId !== recentDatasetViewsRequestId) {
+        return;
+      }
       this.setRecentDatasetViewsImpl([]);
     }
   }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1,4 +1,4 @@
-import { IGirderItem } from "@/girder";
+import { IGirderItem, IGirderFolder, IUPennCollection } from "@/girder";
 import type { ITileHistogram } from "./images";
 import Shepherd from "shepherd.js";
 
@@ -427,6 +427,15 @@ export interface IDatasetViewBase {
 export interface IDatasetView extends IDatasetViewBase {
   readonly id: string;
   readonly _accessLevel?: number;
+}
+
+// Resolved view tile shown in the Recent Datasets list.
+// Built in Home.vue by joining a datasetView with the corresponding
+// resolved Girder folder (dataset) and configuration documents.
+export interface IRecentDatasetViewItem {
+  datasetView: IDatasetView;
+  datasetInfo: IGirderFolder;
+  configInfo: IUPennCollection;
 }
 
 // Access control types for sharing datasets

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -30,6 +30,19 @@ export function formatDateNumber(timestamp: number) {
   }
 }
 
+// Short calendar day, dropping the year when it matches the current year.
+// e.g. "Apr 24" (current year) or "Apr 24, 2024" (other years).
+export function formatDayShort(timestamp: number): string {
+  const date = new Date(timestamp);
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+  return format(date, sameYear ? "MMM d" : "MMM d, yyyy");
+}
+
+// Time of day in 12-hour format with AM/PM, e.g. "10:50 AM".
+export function formatTimeOfDay(timestamp: number): string {
+  return format(new Date(timestamp), "h:mm a");
+}
+
 export function formatDuration(milliseconds: number): string {
   if (!milliseconds || milliseconds <= 0) {
     return "00:00:00";

--- a/src/views/Home.test.ts
+++ b/src/views/Home.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { nextTick } from "vue";
-import { shallowMount } from "@vue/test-utils";
+import { shallowMount, type VueWrapper } from "@vue/test-utils";
 
 // --- Top-level mock fn handles (hoisted before vi.mock calls) ---
 const mockSetFolderLocation = vi.fn();
@@ -16,26 +16,33 @@ const mockPersisterGet = vi.fn(
 const mockPersisterSet = vi.fn();
 
 // --- Store mocks ---
-vi.mock("@/store", () => ({
-  default: {
-    isLoggedIn: true,
-    folderLocation: {
-      _id: "folder1",
-      _modelType: "folder",
-      name: "My Folder",
-    },
-    recentDatasetViews: [],
-    setFolderLocation: (...args: any[]) => mockSetFolderLocation(...args),
-    initializeUploadWorkflow: (...args: any[]) =>
-      mockInitializeUploadWorkflow(...args),
-    fetchRecentDatasetViews: (...args: any[]) =>
-      mockFetchRecentDatasetViews(...args),
-    api: {
-      checkDatasetNameExists: (...args: any[]) =>
-        mockCheckDatasetNameExists(...args),
-    },
-  },
-}));
+// Wrap in reactive() so watch(() => store.isLoggedIn, ...) can fire when
+// tests mutate properties — this is required to test the post-login
+// reset of recentsShowMineOnly.
+vi.mock("@/store", async () => {
+  const { reactive } = await import("vue");
+  return {
+    default: reactive({
+      isLoggedIn: true,
+      isAdmin: false,
+      folderLocation: {
+        _id: "folder1",
+        _modelType: "folder",
+        name: "My Folder",
+      },
+      recentDatasetViews: [],
+      setFolderLocation: (...args: any[]) => mockSetFolderLocation(...args),
+      initializeUploadWorkflow: (...args: any[]) =>
+        mockInitializeUploadWorkflow(...args),
+      fetchRecentDatasetViews: (...args: any[]) =>
+        mockFetchRecentDatasetViews(...args),
+      api: {
+        checkDatasetNameExists: (...args: any[]) =>
+          mockCheckDatasetNameExists(...args),
+      },
+    }),
+  };
+});
 
 vi.mock("@/store/girderResources", () => ({
   default: {
@@ -108,12 +115,17 @@ import { isDatasetFolder, isConfigurationItem } from "@/utils/girderSelectable";
 const mockRouter = { push: vi.fn() };
 const mockStartTour = vi.fn();
 
+// Track every mounted Home wrapper so afterEach can unmount them. Without
+// this, watchers (e.g. on store.isLoggedIn) leak between tests and fire
+// when later tests mutate reactive store state.
+const mountedWrappers: VueWrapper[] = [];
+
 function mountComponent() {
   const app = document.createElement("div");
   app.setAttribute("data-app", "true");
   document.body.appendChild(app);
 
-  return shallowMount(Home, {
+  const wrapper = shallowMount(Home, {
     attachTo: app,
     global: {
       provide: {
@@ -134,6 +146,8 @@ function mountComponent() {
       },
     },
   });
+  mountedWrappers.push(wrapper);
+  return wrapper;
 }
 
 // --- Import standalone functions for direct testing ---
@@ -159,6 +173,7 @@ describe("Home", () => {
 
     // Reset store state
     (store as any).isLoggedIn = true;
+    (store as any).isAdmin = false;
     (store as any).folderLocation = {
       _id: "folder1",
       _modelType: "folder",
@@ -170,6 +185,12 @@ describe("Home", () => {
     vi.mocked(girderResources.watchFolder).mockReturnValue(null as any);
     vi.mocked(girderResources.watchCollection).mockReturnValue(null as any);
     (girderResources as any).resourcesLocks = {};
+  });
+
+  afterEach(() => {
+    while (mountedWrappers.length > 0) {
+      mountedWrappers.pop()!.unmount();
+    }
   });
 
   // =========================================================================
@@ -745,7 +766,10 @@ describe("Home", () => {
       await new Promise((r) => setTimeout(r, 0));
       await nextTick();
 
-      expect(vm.userDisplayNames["user1"]).toBe("John Doe (jdoe@test.com)");
+      expect(vm.userDisplayNames["user1"]).toEqual({
+        full: "John Doe (jdoe@test.com)",
+        short: "John Doe",
+      });
     });
   });
 
@@ -919,6 +943,55 @@ describe("Home", () => {
       const wrapper = mountComponent();
       const vm = wrapper.vm as any;
       expect(vm.isNavigating).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // 20. recentsShowMineOnly default & login transition
+  // =========================================================================
+  describe("recentsShowMineOnly", () => {
+    it("defaults to !isAdmin at mount (admin → off)", () => {
+      (store as any).isLoggedIn = true;
+      (store as any).isAdmin = true;
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      expect(vm.recentsShowMineOnly).toBe(false);
+    });
+
+    it("defaults to !isAdmin at mount (non-admin → on)", () => {
+      (store as any).isLoggedIn = true;
+      (store as any).isAdmin = false;
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      expect(vm.recentsShowMineOnly).toBe(true);
+    });
+
+    it("resets to !isAdmin when isLoggedIn flips false → true", async () => {
+      // Mount while still authenticating: pretend we're an admin who has
+      // not yet been recognized. Setup snapshot would yield true (chip on)
+      // even though admin should default to off.
+      (store as any).isLoggedIn = false;
+      (store as any).isAdmin = false;
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      expect(vm.recentsShowMineOnly).toBe(true);
+
+      // Auth resolves: user is actually an admin.
+      (store as any).isAdmin = true;
+      (store as any).isLoggedIn = true;
+      await nextTick();
+
+      expect(vm.recentsShowMineOnly).toBe(false);
+    });
+
+    it("triggers refetch when toggled", async () => {
+      mockFetchRecentDatasetViews.mockClear();
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      mockFetchRecentDatasetViews.mockClear();
+      vm.recentsShowMineOnly = !vm.recentsShowMineOnly;
+      await nextTick();
+      expect(mockFetchRecentDatasetViews).toHaveBeenCalled();
     });
   });
 });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -78,17 +78,29 @@
           </v-col>
           <v-col class="fill-height recent-dataset">
             <section class="mb-4 home-section">
-              <v-tabs v-model="datasetsTab" color="primary">
-                <v-tab>Recent Datasets</v-tab>
-                <v-tab>Recent Projects</v-tab>
-                <v-tab
-                  v-if="Boolean(zenodoCommunityId)"
-                  id="try-sample-dataset-tourstep"
-                  v-tour-trigger="'try-sample-dataset-tourtrigger'"
+              <div class="d-flex align-center">
+                <v-tabs v-model="datasetsTab" color="primary">
+                  <v-tab>Recent Datasets</v-tab>
+                  <v-tab>Recent Projects</v-tab>
+                  <v-tab
+                    v-if="Boolean(zenodoCommunityId)"
+                    id="try-sample-dataset-tourstep"
+                    v-tour-trigger="'try-sample-dataset-tourtrigger'"
+                  >
+                    Sample Datasets
+                  </v-tab>
+                </v-tabs>
+                <v-chip
+                  v-if="datasetsTab === 0"
+                  size="small"
+                  variant="tonal"
+                  :color="recentsShowMineOnly ? 'primary' : undefined"
+                  class="ml-2"
+                  @click="recentsShowMineOnly = !recentsShowMineOnly"
                 >
-                  Sample Datasets
-                </v-tab>
-              </v-tabs>
+                  Mine only
+                </v-chip>
+              </div>
               <v-window v-model="datasetsTab" class="fill-height">
                 <v-window-item class="fill-height">
                   <recent-datasets
@@ -537,6 +549,7 @@ const browseMode = ref<"files" | "collections" | "projects">("files");
 const fileBrowserExpanded = ref(Persister.get("fileBrowserExpanded", false));
 const datasetsTab = ref(0);
 const loadingProjects = ref(false);
+const recentsShowMineOnly = ref(!store.isAdmin);
 
 const pendingFiles = ref<File[]>([]);
 const datasetName = ref("");
@@ -877,7 +890,7 @@ async function fetchDatasetsAndConfigurations() {
 
 async function initializeRecentViews() {
   try {
-    await store.fetchRecentDatasetViews();
+    await store.fetchRecentDatasetViews(recentsShowMineOnly.value);
   } catch (error) {
     logError("Failed to initialize recent views:", error);
   }
@@ -1128,6 +1141,7 @@ async function initializeWelcomeTour() {
 
 // Watchers
 watch(datasetViews, () => fetchDatasetsAndConfigurations());
+watch(recentsShowMineOnly, () => initializeRecentViews());
 watch(
   () => girderResources.resources,
   () => fetchDatasetsAndConfigurations(),
@@ -1237,6 +1251,7 @@ defineExpose({
   fileBrowserExpanded,
   datasetsTab,
   loadingProjects,
+  recentsShowMineOnly,
   pendingFiles,
   datasetName,
   selectedLocation,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -106,6 +106,7 @@
                   <recent-datasets
                     :dataset-view-items="datasetViewItems"
                     :get-user-display-name="getUserDisplayName"
+                    :get-user-short-name="getUserShortName"
                     :format-date-number="formatDateNumber"
                     @dataset-clicked="navigateToDatasetView"
                     class="fill-height"
@@ -484,6 +485,7 @@ import {
 import girderResources from "@/store/girderResources";
 import {
   IDatasetView,
+  IRecentDatasetViewItem,
   WelcomeTourNames,
   WelcomeTourTypes,
   WelcomeTourStatus,
@@ -565,7 +567,11 @@ const nameConflicts = ref<number[]>([]);
 const validatingNames = ref(false);
 let validateNamesDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-const userDisplayNames = ref<Record<string, string>>({});
+interface IUserDisplayInfo {
+  full: string; // "Name (email)" — used in tooltips and project list
+  short: string; // "Name" only — used in dense recents row
+}
+const userDisplayNames = ref<Record<string, IUserDisplayInfo>>({});
 
 const selectedZenodoDataset = ref<any>(null);
 
@@ -684,8 +690,8 @@ const configInfo = computed(() => {
   return infos;
 });
 
-const datasetViewItems = computed(() => {
-  const items = [];
+const datasetViewItems = computed<IRecentDatasetViewItem[]>(() => {
+  const items: IRecentDatasetViewItem[] = [];
   for (const datasetView of datasetViews.value) {
     const configI = configInfo.value[datasetView.configurationId];
     const datasetI = datasetInfo.value[datasetView.datasetId];
@@ -813,20 +819,31 @@ async function getUsernameFromId(
   };
 }
 
-function getUserDisplayName(creatorId: string): string {
+function ensureUserDisplayInfo(creatorId: string) {
   if (!userDisplayNames.value[creatorId]) {
     userDisplayNames.value = {
       ...userDisplayNames.value,
-      [creatorId]: "Loading...",
+      [creatorId]: { full: "Loading...", short: "Loading..." },
     };
     getUsernameFromId(creatorId).then((user) => {
       userDisplayNames.value = {
         ...userDisplayNames.value,
-        [creatorId]: `${user.fullname} (${user.username})`,
+        [creatorId]: {
+          full: `${user.fullname} (${user.username})`,
+          short: user.fullname,
+        },
       };
     });
   }
   return userDisplayNames.value[creatorId];
+}
+
+function getUserDisplayName(creatorId: string): string {
+  return ensureUserDisplayInfo(creatorId).full;
+}
+
+function getUserShortName(creatorId: string): string {
+  return ensureUserDisplayInfo(creatorId).short;
 }
 
 async function fetchUsersForDatasets() {
@@ -844,12 +861,16 @@ async function fetchUsersForDatasets() {
     });
 
     // Update display names using object spread for reactivity
-    const updates: Record<string, string> = {};
+    const updates: Record<string, IUserDisplayInfo> = {};
     for (const userId of userIds) {
       const user = girderResources.watchUser(userId);
       if (user) {
-        const fullname = `${user.firstName} ${user.lastName}`.trim();
-        updates[userId] = `${fullname || user.email} (${user.email})`;
+        const fullname =
+          `${user.firstName} ${user.lastName}`.trim() || user.email;
+        updates[userId] = {
+          full: `${fullname} (${user.email})`,
+          short: fullname,
+        };
       }
     }
     if (Object.keys(updates).length > 0) {
@@ -1152,6 +1173,11 @@ watch(
   () => store.isLoggedIn,
   (val) => {
     if (val) {
+      // Auth has resolved — set the mine-only default based on the now-known
+      // admin status. Without this, an admin who reloads the page sees the
+      // chip stuck on "Mine only" because Home's setup ran before
+      // store.isAdmin was populated.
+      recentsShowMineOnly.value = !store.isAdmin;
       initializeWelcomeTour();
       fetchRecentProjects();
     }
@@ -1282,6 +1308,7 @@ defineExpose({
   validateDatasetNames,
   getNameError,
   getUserDisplayName,
+  getUserShortName,
   setLocation,
   onLocationUpdate,
   handleDrop,


### PR DESCRIPTION
## Summary
This PR adds a "Mine only" filter toggle to the Recent Datasets tab on the home page, allowing users to view only dataset views they own (have ADMIN access to). Non-admin users see this filter enabled by default.

## Key Changes
- **Frontend (Home.vue)**:
  - Added a "Mine only" chip button next to the datasets/projects tabs that toggles the `recentsShowMineOnly` state
  - The chip is only visible when the Recent Datasets tab is active
  - Added a watcher to refresh recent views when the filter state changes
  - Exposed the `recentsShowMineOnly` ref for testing

- **Backend (datasetView.py)**:
  - Added `currentUserOnly` query parameter to the dataset view `find` endpoint
  - When enabled, filters results to only show views where the current user has ADMIN access via the `access.users` array
  - Properly handles the boolean parameter parsing

- **Store (GirderAPI.ts & index.ts)**:
  - Updated `getRecentDatasetViews()` to accept and pass through the `currentUserOnly` parameter
  - Updated `fetchRecentDatasetViews()` action to accept the filter parameter
  - Changed initial load behavior: non-admin users now load with the filter enabled by default

## Implementation Details
- The filter state is stored in a reactive ref that defaults to `!store.isAdmin` (enabled for non-admins, disabled for admins)
- The backend uses MongoDB's `$elemMatch` operator to query the access control list
- The chip uses Vuetify's tonal variant and changes color to primary when active

https://claude.ai/code/session_01U53GqfMbMQb2ZwmYUmh9Ch