### PR TITLE
Add copy link button component for sharing resources

### DIFF
--- a/src/components/CopyLinkButton.vue
+++ b/src/components/CopyLinkButton.vue
@@ -61,14 +61,17 @@ const fullUrl = computed(() => {
   return `${base}#${props.routePath}`;
 });
 
+function markCopied() {
+  copied.value = true;
+  if (resetTimer) clearTimeout(resetTimer);
+  resetTimer = setTimeout(() => {
+    copied.value = false;
+  }, 2000);
+}
+
 async function copyLink() {
   try {
     await navigator.clipboard.writeText(fullUrl.value);
-    copied.value = true;
-    if (resetTimer) clearTimeout(resetTimer);
-    resetTimer = setTimeout(() => {
-      copied.value = false;
-    }, 2000);
   } catch {
     // Fallback for older browsers
     const textarea = document.createElement("textarea");
@@ -79,12 +82,8 @@ async function copyLink() {
     textarea.select();
     document.execCommand("copy");
     document.body.removeChild(textarea);
-    copied.value = true;
-    if (resetTimer) clearTimeout(resetTimer);
-    resetTimer = setTimeout(() => {
-      copied.value = false;
-    }, 2000);
   }
+  markCopied();
 }
 
 defineExpose({ copied, fullUrl, copyLink });

--- a/src/components/CopyLinkButton.vue
+++ b/src/components/CopyLinkButton.vue
@@ -1,0 +1,91 @@
+<template>
+  <v-tooltip :text="copied ? 'Copied!' : tooltip" location="bottom">
+    <template #activator="{ props: activatorProps }">
+      <v-btn
+        v-bind="{ ...activatorProps, ...$attrs }"
+        :icon="iconOnly"
+        :size="size"
+        :color="copied ? 'success' : color"
+        :variant="variant"
+        @click="copyLink"
+      >
+        <v-icon :size="iconSize">
+          {{ copied ? "mdi-check" : "mdi-link-variant" }}
+        </v-icon>
+        <span v-if="!iconOnly" class="ml-1">{{ label }}</span>
+      </v-btn>
+    </template>
+  </v-tooltip>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    /** The route path to generate the link for (e.g. /project/abc123) */
+    routePath: string;
+    /** Tooltip text */
+    tooltip?: string;
+    /** Button label (hidden when iconOnly) */
+    label?: string;
+    /** Render as icon-only button */
+    iconOnly?: boolean;
+    /** Button size */
+    size?: string;
+    /** Icon size */
+    iconSize?: string;
+    /** Button color */
+    color?: string;
+    /** Button variant */
+    variant?: "flat" | "text" | "elevated" | "tonal" | "outlined" | "plain";
+  }>(),
+  {
+    tooltip: "Copy shareable link",
+    label: "Copy Link",
+    iconOnly: false,
+    size: "small",
+    iconSize: "small",
+    color: "primary",
+    variant: "outlined",
+  },
+);
+
+defineOptions({ inheritAttrs: false });
+
+const copied = ref(false);
+let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+const fullUrl = computed(() => {
+  const base = window.location.origin + window.location.pathname;
+  return `${base}#${props.routePath}`;
+});
+
+async function copyLink() {
+  try {
+    await navigator.clipboard.writeText(fullUrl.value);
+    copied.value = true;
+    if (resetTimer) clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => {
+      copied.value = false;
+    }, 2000);
+  } catch {
+    // Fallback for older browsers
+    const textarea = document.createElement("textarea");
+    textarea.value = fullUrl.value;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+    copied.value = true;
+    if (resetTimer) clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => {
+      copied.value = false;
+    }, 2000);
+  }
+}
+
+defineExpose({ copied, fullUrl, copyLink });
+</script>

--- a/src/components/CopyLinkButton.vue
+++ b/src/components/CopyLinkButton.vue
@@ -70,8 +70,10 @@ function markCopied() {
 }
 
 async function copyLink() {
+  let success = false;
   try {
     await navigator.clipboard.writeText(fullUrl.value);
+    success = true;
   } catch {
     // Fallback for older browsers
     const textarea = document.createElement("textarea");
@@ -80,10 +82,10 @@ async function copyLink() {
     textarea.style.opacity = "0";
     document.body.appendChild(textarea);
     textarea.select();
-    document.execCommand("copy");
+    success = document.execCommand("copy");
     document.body.removeChild(textarea);
   }
-  markCopied();
+  if (success) markCopied();
 }
 
 defineExpose({ copied, fullUrl, copyLink });

--- a/src/components/ShareDataset.vue
+++ b/src/components/ShareDataset.vue
@@ -215,6 +215,11 @@
         </v-container>
       </v-card-text>
       <v-card-actions>
+        <copy-link-button
+          v-if="datasetId"
+          :route-path="`/dataset/${datasetId}`"
+          tooltip="Copy shareable link to this dataset"
+        />
         <v-spacer />
         <v-btn color="primary" variant="text" @click="close">Done</v-btn>
       </v-card-actions>
@@ -246,13 +251,18 @@ import store from "@/store";
 import { logError } from "@/utils/log";
 import { accessLevelLabel } from "@/utils/accessLevel";
 import {
+  IDataset,
   IDatasetAccessUser,
   IDatasetAccessConfiguration,
   IDatasetView,
 } from "@/store/model";
+import CopyLinkButton from "@/components/CopyLinkButton.vue";
+
+// Suppress unused import warnings — auto-registered in <script setup>
+void CopyLinkButton;
 
 const props = defineProps<{
-  dataset: IGirderSelectAble | null;
+  dataset: IGirderSelectAble | IDataset | null;
   modelValue: boolean;
 }>();
 
@@ -263,6 +273,14 @@ const emit = defineEmits<{
 const dialog = computed({
   get: () => props.modelValue,
   set: (val: boolean) => emit("update:modelValue", val),
+});
+
+/** Extract the dataset ID regardless of whether it's IGirderSelectAble or IDataset */
+const datasetId = computed((): string | null => {
+  if (!props.dataset) return null;
+  if ("_id" in props.dataset) return (props.dataset as IGirderSelectAble)._id;
+  if ("id" in props.dataset) return (props.dataset as IDataset).id;
+  return null;
 });
 
 const loading = ref(false);
@@ -304,7 +322,7 @@ const isResourceAdmin = computed((): boolean => {
 
 watch(dialog, (val) => {
   if (val && props.dataset) {
-    fetchAccessInfo(props.dataset._id);
+    fetchAccessInfo(datasetId.value!);
   } else if (!val) {
     resetState();
   }
@@ -368,7 +386,7 @@ async function togglePublic(newValue: boolean | null) {
   publicLoading.value = true;
   showError.value = false;
   try {
-    await store.api.setDatasetPublic(props.dataset._id, value);
+    await store.api.setDatasetPublic(datasetId.value!, value);
     isPublic.value = value;
   } catch (error) {
     logError("Failed to toggle public access", error);
@@ -495,7 +513,7 @@ async function addUser() {
     } else {
       // Refresh the access list to show the new user
       if (props.dataset) {
-        await fetchAccessInfo(props.dataset._id);
+        await fetchAccessInfo(datasetId.value!);
       }
       // Clear the form
       newUserEmail.value = "";
@@ -512,6 +530,7 @@ async function addUser() {
 
 defineExpose({
   dialog,
+  datasetId,
   loading,
   showError,
   errorString,

--- a/src/components/ShareProject.vue
+++ b/src/components/ShareProject.vue
@@ -175,6 +175,11 @@
         </v-container>
       </v-card-text>
       <v-card-actions>
+        <copy-link-button
+          v-if="project"
+          :route-path="`/project/${project.id}`"
+          tooltip="Copy shareable link to this project"
+        />
         <v-spacer />
         <v-btn color="primary" variant="text" @click="close">Done</v-btn>
       </v-card-actions>
@@ -218,6 +223,10 @@ import { isAxiosError } from "axios";
 import store from "@/store";
 import { logError } from "@/utils/log";
 import { IDatasetAccessUser, IProject } from "@/store/model";
+import CopyLinkButton from "@/components/CopyLinkButton.vue";
+
+// Suppress unused import warnings — auto-registered in <script setup>
+void CopyLinkButton;
 
 const props = defineProps<{
   project: IProject | null;

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -7,6 +7,7 @@
         v-if="configuration"
         :route-path="`/configuration/${configuration.id}`"
         tooltip="Copy shareable link to this collection"
+        icon-only
         class="mr-2"
       />
       <v-btn

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -3,6 +3,12 @@
     <alert-dialog ref="alert" />
     <v-container class="d-flex">
       <v-spacer />
+      <copy-link-button
+        v-if="configuration"
+        :route-path="`/configuration/${configuration.id}`"
+        tooltip="Copy shareable link to this collection"
+        class="mr-2"
+      />
       <v-btn
         color="primary"
         class="mr-2"
@@ -196,6 +202,7 @@ import AlertDialog, { IAlert } from "@/components/AlertDialog.vue";
 import AddCollectionToProjectDialog from "@/components/AddCollectionToProjectDialog.vue";
 import SharingStatusDisplay from "@/components/SharingStatusDisplay.vue";
 import SharingStatusIcon from "@/components/SharingStatusIcon.vue";
+import CopyLinkButton from "@/components/CopyLinkButton.vue";
 import { fetchSharingInfo } from "@/utils/sharingInfo";
 
 // Suppress unused import warnings — auto-registered in <script setup>
@@ -205,6 +212,7 @@ void AlertDialog;
 void AddCollectionToProjectDialog;
 void SharingStatusDisplay;
 void SharingStatusIcon;
+void CopyLinkButton;
 
 const route = useRoute();
 const router = useRouter();

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -21,6 +21,7 @@
               v-if="dataset"
               :route-path="`/dataset/${dataset.id}`"
               tooltip="Copy shareable link to this dataset"
+              icon-only
               class="mr-2"
             />
             <v-btn
@@ -777,20 +778,14 @@ function onAddedToProject() {
 watch(dataset, () => {
   fetchCounts();
   fetchSharingInfoData();
+  updateDatasetViews();
+  fetchDatasetParentFolder();
 });
 
 watch(shareDatasetDialog, (open) => {
   if (!open) {
     fetchSharingInfoData();
   }
-});
-
-watch(dataset, () => {
-  updateDatasetViews();
-});
-
-watch(dataset, () => {
-  fetchDatasetParentFolder();
 });
 
 watch(datasetName, () => {

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -7,6 +7,23 @@
             <v-toolbar-title> Dataset </v-toolbar-title>
             <v-spacer></v-spacer>
             <v-btn
+              color="primary"
+              variant="outlined"
+              size="small"
+              class="mr-2"
+              @click="shareDatasetDialog = true"
+              :disabled="!dataset"
+            >
+              <v-icon start>mdi-share-variant</v-icon>
+              Share
+            </v-btn>
+            <copy-link-button
+              v-if="dataset"
+              :route-path="`/dataset/${dataset.id}`"
+              tooltip="Copy shareable link to this dataset"
+              class="mr-2"
+            />
+            <v-btn
               color="green"
               @click="goToDefaultView"
               :disabled="!dataset"
@@ -335,6 +352,9 @@
       :dataset-name="datasetName"
       @added="onAddedToProject"
     />
+
+    <!-- Share Dataset Dialog -->
+    <share-dataset v-model="shareDatasetDialog" :dataset="dataset" />
   </v-container>
 </template>
 <script setup lang="ts">
@@ -355,12 +375,16 @@ import GirderLocationChooser from "@/components/GirderLocationChooser.vue";
 import AddToProjectDialog from "@/components/AddToProjectDialog.vue";
 import SharingStatusDisplay from "@/components/SharingStatusDisplay.vue";
 import SharingStatusIcon from "@/components/SharingStatusIcon.vue";
+import ShareDataset from "@/components/ShareDataset.vue";
+import CopyLinkButton from "@/components/CopyLinkButton.vue";
 
 // Suppress unused import warnings — auto-registered in <script setup>
 void GirderLocationChooser;
 void AddToProjectDialog;
 void SharingStatusDisplay;
 void SharingStatusIcon;
+void ShareDataset;
+void CopyLinkButton;
 
 const route = useRoute();
 const router = useRouter();
@@ -376,6 +400,7 @@ const defaultConfigurationName = ref("");
 const showNewCollectionDialog = ref(false);
 const showNewCollectionNameDialog = ref(false);
 const showAddToProjectDialog = ref(false);
+const shareDatasetDialog = ref(false);
 const newCollectionName = ref("");
 const selectedFolderId = ref<string | null>(null);
 const datasetParentId = ref<string | null>(null);
@@ -754,6 +779,12 @@ watch(dataset, () => {
   fetchSharingInfoData();
 });
 
+watch(shareDatasetDialog, (open) => {
+  if (!open) {
+    fetchSharingInfoData();
+  }
+});
+
 watch(dataset, () => {
   updateDatasetViews();
 });
@@ -800,6 +831,7 @@ defineExpose({
   showNewCollectionDialog,
   showNewCollectionNameDialog,
   showAddToProjectDialog,
+  shareDatasetDialog,
   newCollectionName,
   selectedFolderId,
   datasetParentId,

--- a/src/views/project/ProjectInfo.vue
+++ b/src/views/project/ProjectInfo.vue
@@ -20,6 +20,13 @@
         {{ formatSize(totalProjectSize) }} total
       </v-chip>
       <v-spacer />
+      <copy-link-button
+        v-if="project"
+        :route-path="`/project/${project.id}`"
+        tooltip="Copy shareable link to this project"
+        icon-only
+        class="mr-2"
+      />
       <v-btn color="primary" class="mr-2" @click="shareDialog = true">
         <v-icon start>mdi-share-variant</v-icon>
         Share Project
@@ -470,6 +477,7 @@ import AddDatasetToProjectDialog from "@/components/AddDatasetToProjectDialog.vu
 import AddCollectionToProjectFilterDialog from "@/components/AddCollectionToProjectFilterDialog.vue";
 import ShareProject from "@/components/ShareProject.vue";
 import ZenodoPublish from "@/components/ZenodoPublish.vue";
+import CopyLinkButton from "@/components/CopyLinkButton.vue";
 import { formatSize } from "@/utils/conversion";
 
 // Suppress unused import warnings — auto-registered in <script setup>
@@ -478,6 +486,7 @@ void AddDatasetToProjectDialog;
 void AddCollectionToProjectFilterDialog;
 void ShareProject;
 void ZenodoPublish;
+void CopyLinkButton;
 
 const router = useRouter();
 


### PR DESCRIPTION
## Summary
This PR introduces a reusable `CopyLinkButton` component that allows users to quickly copy shareable links to datasets, projects, and configurations. The button is integrated across multiple info views and sharing dialogs throughout the application.

## Key Changes
- **New Component**: Created `CopyLinkButton.vue` - a reusable button component that:
  - Copies shareable links to the clipboard using the Clipboard API with fallback support for older browsers
  - Displays visual feedback with a success icon and "Copied!" tooltip for 2 seconds
  - Supports customizable styling (size, color, variant, icon-only mode)
  - Generates full URLs with hash-based routing (e.g., `#/dataset/{id}`)

- **DatasetInfo.vue**: 
  - Added Share button to open sharing dialog
  - Integrated `CopyLinkButton` in the toolbar
  - Added `ShareDataset` dialog component
  - Added watcher to refresh sharing info when dialog closes

- **ShareDataset.vue**:
  - Added `CopyLinkButton` to card actions
  - Enhanced to accept both `IGirderSelectAble` and `IDataset` types
  - Added `datasetId` computed property to handle both ID formats (`_id` and `id`)

- **ShareProject.vue**: Added `CopyLinkButton` to card actions for quick link sharing

- **ProjectInfo.vue**: Added icon-only `CopyLinkButton` in the toolbar

- **ConfigurationInfo.vue**: Added `CopyLinkButton` in the toolbar for configuration sharing

## Implementation Details
- The component uses Vue 3 Composition API with TypeScript
- Clipboard copying includes error handling with fallback to `document.execCommand('copy')` for browser compatibility
- The copied state automatically resets after 2 seconds
- Component exposes `copied`, `fullUrl`, and `copyLink` for testing and external control
- All integrations maintain consistent styling and positioning across the application

https://claude.ai/code/session_014SLAnsGSj1rPcKgZugodp8