### PR TITLE
Fix findCommonPrefix to handle filenames without delimiters

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -420,13 +420,14 @@ function findCommonPrefix(strings: string[]): string {
   }
 
   // For non-numeric prefixes:
-  // Extract the non-metadata prefix of each filename. Note that because of the
-  // way the regex is constructed, the first match group will never be `null`.
+  // Extract the non-metadata prefix of each filename. If a filename contains
+  // none of the delimiters or trigger patterns, fall back to the whole string
+  // so the character-by-character comparison below still runs.
   const triggerAndDigit = allTriggers.map(
     (trigger) => `\\d${trigger}|${trigger}\\d`,
   );
   const re = new RegExp(`(.*?)(?:_|-|${triggerAndDigit.join("|")})`);
-  const matches = strings.map((s) => s.match(re)![1]);
+  const matches = strings.map((s) => s.match(re)?.[1] ?? s);
 
   // Get the minimum length of all the strings; the common prefix cannot be
   // longer than this.

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -402,7 +402,7 @@ function findCommonPrefix(strings: string[]): string {
     (trigger) => `\\d${trigger}|${trigger}\\d`,
   );
   const re = new RegExp(`(.*?)(?:_|-|${triggerAndDigit.join("|")})`);
-  const matches = strings.map((s) => s.match(re)![1]);
+  const matches = strings.map((s) => s.match(re)?.[1] ?? s);
 
   const minLength = matches.reduce(
     (acc, cur) => Math.min(acc, cur.length),


### PR DESCRIPTION
## Summary
Fixed a bug in the `findCommonPrefix` function where filenames without delimiters or trigger patterns would cause the function to fail with a runtime error.

## Changes
- Updated regex matching logic in `findCommonPrefix` to use optional chaining (`?.`) and nullish coalescing (`??`) operators
- When a filename doesn't match the delimiter/trigger pattern regex, the function now falls back to using the entire filename string instead of attempting to access a null match group
- Applied fix to both `src/views/Home.vue` and `src/views/dataset/NewDataset.vue` where the function is defined

## Implementation Details
The original code used non-null assertion (`![1]`) which would crash if `s.match(re)` returned `null`. The updated code:
- Uses optional chaining to safely access the first capture group: `s.match(re)?.[1]`
- Falls back to the whole string if no match is found: `?? s`
- This allows the character-by-character comparison logic to still execute for filenames that don't contain any delimiters or trigger patterns

https://claude.ai/code/session_017JrkxSnTPMTXfX9rH7CFyL