### PR TITLE
Move Add layer button inline with Layers header

### DIFF
--- a/src/components/DisplayLayers.test.ts
+++ b/src/components/DisplayLayers.test.ts
@@ -120,13 +120,6 @@ describe("DisplayLayers", () => {
     expect(arr[3][1]).toBeTruthy();
   });
 
-  it("addLayer calls store.addLayer", () => {
-    mockStore.addLayer.mockClear();
-    const wrapper = mountComponent();
-    (wrapper.vm as any).addLayer();
-    expect(mockStore.addLayer).toHaveBeenCalledOnce();
-  });
-
   it("createGroupFromLayer calls store.changeLayer with a new layerGroup", () => {
     mockStore.changeLayer.mockClear();
     const wrapper = mountComponent();

--- a/src/components/DisplayLayers.vue
+++ b/src/components/DisplayLayers.vue
@@ -73,11 +73,6 @@
         </draggable>
       </template>
     </draggable>
-    <div class="add-layer">
-      <v-btn @click="addLayer" icon title="Add new layer">
-        <v-icon>mdi-plus-circle</v-icon>
-      </v-btn>
-    </div>
   </div>
 </template>
 <script setup lang="ts">
@@ -307,10 +302,6 @@ function createGroupFromLayer(combinedLayer: ICombinedLayer) {
   });
 }
 
-function addLayer() {
-  store.addLayer();
-}
-
 // Mousetrap bindings
 const mousetrapGlobalToggles: IHotkey[] = [
   {
@@ -341,19 +332,12 @@ defineExpose({
   spacerUpdate,
   changeLayersInGroup,
   createGroupFromLayer,
-  addLayer,
   mousetrapGlobalToggles,
   singleLayerPrefix,
 });
 </script>
 
 <style lang="scss" scoped>
-.add-layer {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
 .layer-title-row {
   display: flex;
   align-items: center;

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -105,19 +105,30 @@
       </div>
     </div>
     <toolset></toolset>
-    <v-radio-group
-      v-model="layerMode"
-      label="Layers: "
-      mandatory
-      density="compact"
-      inline
-      hide-details
-      class="layer-mode-controls"
-    >
-      <v-radio value="single" label="Single" class="smaller" />
-      <v-radio value="multiple" label="Multiple" class="smaller" />
-      <v-radio value="unroll" label="Unroll" class="smaller" />
-    </v-radio-group>
+    <div class="layer-mode-wrapper">
+      <v-radio-group
+        v-model="layerMode"
+        label="Layers: "
+        mandatory
+        density="compact"
+        inline
+        hide-details
+        class="layer-mode-controls"
+      >
+        <v-radio value="single" label="Single" class="smaller" />
+        <v-radio value="multiple" label="Multiple" class="smaller" />
+        <v-radio value="unroll" label="Unroll" class="smaller" />
+      </v-radio-group>
+      <v-btn
+        class="add-layer-btn"
+        variant="outlined"
+        color="primary"
+        size="x-small"
+        @click="store.addLayer"
+      >
+        Add layer
+      </v-btn>
+    </div>
     <div>
       <slot></slot>
     </div>
@@ -148,6 +159,16 @@
       margin-right: 0;
     }
   }
+}
+.layer-mode-wrapper {
+  position: relative;
+}
+.add-layer-btn {
+  position: absolute;
+  top: 10px;
+  right: 0;
+  text-transform: none;
+  letter-spacing: normal;
 }
 </style>
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- Replace the standalone plus-circle icon button at the bottom of the layer list with a small outlined "Add layer" button next to the "Layers:" label.
- The new button is absolutely positioned within a wrapper around the existing `v-radio-group`, so the radio group's vertical layout is byte-identical to master (no spacing changes between the radios and the layer list below).
- Removes the now-dead `addLayer` function, `defineExpose` entry, and corresponding test in `DisplayLayers.vue`.

## Test plan
- [ ] Open a dataset and confirm the "Add layer" button appears at the top-right of the Layers section, aligned with the "Layers:" label.
- [ ] Click the button and confirm a new layer is added (same behavior as the previous + button).
- [ ] Verify there is no extra vertical gap between the Single/Multiple/Unroll radios and the layer list below.
- [ ] `pnpm tsc` passes.
- [ ] `pnpm exec vitest run src/components/DisplayLayers.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)