### PR TITLE
Fix memory leaks on dataset switch + add console memory diagnostics

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -278,21 +278,11 @@ logError("An error occurred", error);
 
 ## Memory Diagnostics
 
-`window.__nimbusMem` is registered globally (from `src/utils/memoryDiagnostics.ts`) for browser-console memory monitoring. **Zero overhead unless enabled** — the hook in `setSelectedDataset` short-circuits on `if (!enabled) return;`.
+`window.__nimbusMem` is registered globally for browser-console memory monitoring (zero overhead unless enabled via `__nimbusMem.enable()`). Useful when investigating memory leaks, comparing memory pressure across changes, or sanity-checking a new cache.
 
-Use it when investigating memory leaks, comparing memory pressure across changes, or sanity-checking a new cache:
+Quick API: `__nimbusMem.enable()`, `snapshot('label')`, `print()`, `compare('a','b')`, `export()`.
 
-```
-__nimbusMem.enable()         // auto-snapshot on each dataset switch (persists in localStorage)
-__nimbusMem.snapshot('lbl')  // manual snapshot at any moment
-__nimbusMem.print()          // table of snapshots with heap deltas
-__nimbusMem.compare('a','b') // diff two labeled snapshots
-__nimbusMem.export()         // copy raw JSON to clipboard
-```
-
-Each snapshot records `performance.memory` heap (Chrome) plus live cache/store sizes from `GirderAPI`, `girderResources`, `annotation`, and `properties` modules.
-
-**Important:** `memoryDiagnostics.ts` must not import store modules at top level — that creates a load-order cycle with `index.ts`. The provider is registered from `main.ts` after stores have initialized. To extend with a new counter, add the field to `MemoryCounts` and update the provider closure in `main.ts`. To add an auto-snapshot point in another action, call `memDiag.autoSnapshot('label')` — it no-ops when disabled.
+For the full API, recorded fields, the load-order constraint (don't import stores at top level — register from `main.ts`), instructions for adding new counters or auto-snapshot points, and the cherry-pick procedure for cross-branch comparison: read `codebaseDocumentation/MEMORY_DEBUGGING.md`.
 
 ## Style Guidelines
 

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -276,6 +276,24 @@ logError("An error occurred", error);
 </v-btn>
 ```
 
+## Memory Diagnostics
+
+`window.__nimbusMem` is registered globally (from `src/utils/memoryDiagnostics.ts`) for browser-console memory monitoring. **Zero overhead unless enabled** — the hook in `setSelectedDataset` short-circuits on `if (!enabled) return;`.
+
+Use it when investigating memory leaks, comparing memory pressure across changes, or sanity-checking a new cache:
+
+```
+__nimbusMem.enable()         // auto-snapshot on each dataset switch (persists in localStorage)
+__nimbusMem.snapshot('lbl')  // manual snapshot at any moment
+__nimbusMem.print()          // table of snapshots with heap deltas
+__nimbusMem.compare('a','b') // diff two labeled snapshots
+__nimbusMem.export()         // copy raw JSON to clipboard
+```
+
+Each snapshot records `performance.memory` heap (Chrome) plus live cache/store sizes from `GirderAPI`, `girderResources`, `annotation`, and `properties` modules.
+
+**Important:** `memoryDiagnostics.ts` must not import store modules at top level — that creates a load-order cycle with `index.ts`. The provider is registered from `main.ts` after stores have initialized. To extend with a new counter, add the field to `MemoryCounts` and update the provider closure in `main.ts`. To add an auto-snapshot point in another action, call `memDiag.autoSnapshot('label')` — it no-ops when disabled.
+
 ## Style Guidelines
 
 - Use scoped SCSS: `<style lang="scss" scoped>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,21 +564,9 @@ Look for opportunities to simplify code:
 
 ## Memory Diagnostics
 
-A browser-console memory monitoring tool is registered globally as `window.__nimbusMem` (implementation in `src/utils/memoryDiagnostics.ts`). Auto-tracking is **opt-in** via `__nimbusMem.enable()` and adds zero overhead otherwise — the hook in `setSelectedDataset` short-circuits on a single boolean check when disabled.
+A browser-console memory monitoring tool is registered globally as `window.__nimbusMem` (implementation in `src/utils/memoryDiagnostics.ts`). Auto-tracking is opt-in via `__nimbusMem.enable()` and adds zero overhead otherwise. Use it for live heap/cache/store inspection or for cross-branch memory comparisons.
 
-**Console API:**
-- `__nimbusMem.enable()` / `disable()` — toggle auto-snapshots on dataset switch (persists in localStorage)
-- `__nimbusMem.snapshot('label')` — manual snapshot at any moment
-- `__nimbusMem.print()` — `console.table` of all snapshots with heap deltas
-- `__nimbusMem.compare('labelA', 'labelB')` — diff two labels
-- `__nimbusMem.export()` — copy raw JSON of all snapshots to clipboard
-- `__nimbusMem.clear()` — reset history
-
-Each snapshot records `performance.memory` (Chrome only — `usedJSHeapSize`, `totalJSHeapSize`, `jsHeapSizeLimit`) plus live cache/store sizes for things that have historically leaked: `resourcesCache`, `imageCache`, `histogramCache`, annotation arrays, `propertyStatuses`, `workerPreviews`, `pendingWorkerPreviewTimeouts`, etc.
-
-**Architecture:** `memoryDiagnostics.ts` does NOT import any store modules at the top level — that would create a load-order cycle with `index.ts`, breaking class-field initializers in `annotation.ts`/`properties.ts`. Instead, `main.ts` calls `memDiag.register(provider)` with a closure that reads live counts. To add a new tracked counter, add the field to `MemoryCounts` in `memoryDiagnostics.ts` and update the provider closure in `main.ts`. To add a new auto-snapshot point, call `memDiag.autoSnapshot('label')` in the relevant action — it no-ops when disabled.
-
-**Comparing branches:** the file is self-contained. Cherry-pick `memoryDiagnostics.ts`, the `getCacheSizes()` accessor on `GirderAPI.ts`, the `setSelectedDataset` hook in `index.ts`, and the `main.ts` registration onto the comparison branch. Run the same workflow on each, `__nimbusMem.export()` to grab JSON, diff externally.
+For the full console API, what gets recorded, the load-order constraint, and how to compare branches via cherry-pick, see `codebaseDocumentation/MEMORY_DEBUGGING.md`.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,24 @@ Look for opportunities to simplify code:
 - Question whether custom implementations can be replaced with library functions (e.g., `orjson.dumps()` instead of manual JSON streaming)
 - Before adding new functionality, ask: **is this change actually necessary?** Challenge assumptions about what needs to change. Unnecessary complexity is a liability.
 
+## Memory Diagnostics
+
+A browser-console memory monitoring tool is registered globally as `window.__nimbusMem` (implementation in `src/utils/memoryDiagnostics.ts`). Auto-tracking is **opt-in** via `__nimbusMem.enable()` and adds zero overhead otherwise — the hook in `setSelectedDataset` short-circuits on a single boolean check when disabled.
+
+**Console API:**
+- `__nimbusMem.enable()` / `disable()` — toggle auto-snapshots on dataset switch (persists in localStorage)
+- `__nimbusMem.snapshot('label')` — manual snapshot at any moment
+- `__nimbusMem.print()` — `console.table` of all snapshots with heap deltas
+- `__nimbusMem.compare('labelA', 'labelB')` — diff two labels
+- `__nimbusMem.export()` — copy raw JSON of all snapshots to clipboard
+- `__nimbusMem.clear()` — reset history
+
+Each snapshot records `performance.memory` (Chrome only — `usedJSHeapSize`, `totalJSHeapSize`, `jsHeapSizeLimit`) plus live cache/store sizes for things that have historically leaked: `resourcesCache`, `imageCache`, `histogramCache`, annotation arrays, `propertyStatuses`, `workerPreviews`, `pendingWorkerPreviewTimeouts`, etc.
+
+**Architecture:** `memoryDiagnostics.ts` does NOT import any store modules at the top level — that would create a load-order cycle with `index.ts`, breaking class-field initializers in `annotation.ts`/`properties.ts`. Instead, `main.ts` calls `memDiag.register(provider)` with a closure that reads live counts. To add a new tracked counter, add the field to `MemoryCounts` in `memoryDiagnostics.ts` and update the provider closure in `main.ts`. To add a new auto-snapshot point, call `memDiag.autoSnapshot('label')` in the relevant action — it no-ops when disabled.
+
+**Comparing branches:** the file is self-contained. Cherry-pick `memoryDiagnostics.ts`, the `getCacheSizes()` accessor on `GirderAPI.ts`, the `setSelectedDataset` hook in `index.ts`, and the `main.ts` registration onto the comparison branch. Run the same workflow on each, `__nimbusMem.export()` to grab JSON, diff externally.
+
 ## Testing
 
 ### Frontend Tests

--- a/codebaseDocumentation/MEMORY_DEBUGGING.md
+++ b/codebaseDocumentation/MEMORY_DEBUGGING.md
@@ -1,0 +1,75 @@
+# Memory Debugging
+
+A browser-console memory monitoring tool is registered globally as `window.__nimbusMem` (implementation in `src/utils/memoryDiagnostics.ts`). Auto-tracking is **opt-in** via `__nimbusMem.enable()` and adds zero overhead otherwise — the hook in `setSelectedDataset` short-circuits on a single boolean check when disabled.
+
+## Console API
+
+```js
+__nimbusMem.enable()           // auto-snapshots on dataset switch (persists in localStorage)
+__nimbusMem.disable()
+__nimbusMem.snapshot('label')  // manual snapshot at any moment
+__nimbusMem.print()            // console.table of all snapshots with heap deltas
+__nimbusMem.compare('a', 'b')  // diff two labeled snapshots
+__nimbusMem.export()           // copy raw JSON of all snapshots to clipboard
+__nimbusMem.clear()            // reset history
+```
+
+## What gets recorded
+
+Each snapshot includes:
+
+- **Heap (Chrome only)** — `performance.memory`: `usedJSHeapSize`, `totalJSHeapSize`, `jsHeapSizeLimit`
+- **Cache sizes** — `resourcesCache`, `imageCache`, `histogramCache`, `resolvedHistogramCache`
+- **Annotation store** — `annotations`, `annotationConnections`, `annotationCentroids`, `selectedAnnotationIds`, `activeAnnotationIds`, `copiedAnnotations`, `pendingAnnotation`, `submitPendingAnnotation`
+- **Properties store** — `propertyValues`, `propertyStatuses`, `workerImageList`, `workerInterfaces`, `workerPreviews`, `pendingWorkerPreviewTimeouts`
+
+History is capped at 500 snapshots (FIFO eviction).
+
+## Architecture
+
+`memoryDiagnostics.ts` does NOT import any store modules at the top level — that would create a load-order cycle with `index.ts`, breaking class-field initializers in `annotation.ts`/`properties.ts`. The integration is pull-based:
+
+1. `index.ts` imports `memDiag` and calls `autoSnapshot('label')` at boundaries (currently in `setSelectedDataset`)
+2. `main.ts` (which runs after all stores have initialized) calls `memDiag.register(provider)` with a closure that reads live counts from each store
+
+Snapshots taken before `register()` runs return zero counts but won't crash.
+
+## Extending
+
+**To add a new tracked counter:**
+
+1. Add the field to the `MemoryCounts` interface and `ZERO_COUNTS` in `src/utils/memoryDiagnostics.ts`
+2. Add a column to the `print()` `console.table` output
+3. Update the provider closure in `src/main.ts` to read the live count
+
+**To add a new auto-snapshot point:**
+
+Call `memDiag.autoSnapshot('label')` in the relevant Vuex action. It no-ops when auto-tracking is disabled, so the call site has no overhead in normal use.
+
+## Comparing branches
+
+The diagnostic file is intentionally self-contained so it can be cherry-picked onto a comparison branch (e.g. master) for before/after measurements. To set up a comparison:
+
+1. **In a worktree on the comparison branch**, copy these four pieces of integration:
+   - `src/utils/memoryDiagnostics.ts` (whole file, no edits)
+   - `getCacheSizes()` accessor on `src/store/GirderAPI.ts`
+   - The three `memDiag.autoSnapshot(...)` calls in `setSelectedDataset` in `src/store/index.ts` (and the `import { memDiag } from "@/utils/memoryDiagnostics"`)
+   - The `memDiag.register(...)` block in `src/main.ts` (along with the three store imports)
+2. Run a Vite dev server on a different port (e.g. `pnpm exec vite --port 5174`). Note that you will need to log in fresh on the new port since localStorage is per-origin.
+3. On both branches: `__nimbusMem.enable()` → reload → run the same workflow → `__nimbusMem.export()` to copy the JSON.
+4. Diff the two JSON dumps to identify which counters grow on the leaky branch and stay bounded on the fixed branch.
+
+When cherry-picking, fields that exist only on the fix branch (e.g. `pendingWorkerPreviewTimeouts`) need to be guarded in the provider closure so the comparison branch can read them as `undefined`. Example:
+
+```typescript
+const tmoutMap = (propertiesStore as unknown as Record<string, unknown>)
+  .pendingWorkerPreviewTimeouts as { size: number } | undefined;
+// ...
+pendingWorkerPreviewTimeouts: tmoutMap ? tmoutMap.size : 0,
+```
+
+## Limitations
+
+- `performance.memory` is **Chrome-only**. Firefox and Safari return `undefined` for the heap fields; the cache/store counts still work.
+- Heap reporting is noisy without forced GC. Single-sample numbers can wobble ±10–20 MB. For reliable signal, take multiple snapshots across an action and look at trend, not a single value. Use Chrome DevTools' Memory panel for definitive answers.
+- The tool measures **Vuex store and JS-cache sizes**, not DOM detached nodes, observers, or WeakMap leaks. For those, use the Memory panel's heap snapshot diff feature.

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,9 +63,8 @@ memDiag.register(() => {
     workerImageList: Object.keys(propertiesStore.workerImageList).length,
     workerInterfaces: Object.keys(propertiesStore.workerInterfaces).length,
     workerPreviews: Object.keys(propertiesStore.workerPreviews).length,
-    pendingWorkerPreviewTimeouts: propertiesStore.pendingWorkerPreviewTimeouts
-      ? propertiesStore.pendingWorkerPreviewTimeouts.size
-      : 0,
+    pendingWorkerPreviewTimeouts:
+      propertiesStore.pendingWorkerPreviewTimeouts.size,
   };
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,48 @@ import chat from "./store/chat";
 import { installTour } from "./plugins/tour";
 import { tourTriggerDirective } from "./plugins/tour-trigger.directive";
 
+// Registers `window.__nimbusMem` for browser-console memory diagnostics.
+// Auto-tracking is opt-in via `__nimbusMem.enable()` and adds no overhead
+// otherwise.
+import { memDiag } from "@/utils/memoryDiagnostics";
+import annotationStore from "./store/annotation";
+import propertiesStore from "./store/properties";
+import girderResourcesStore from "./store/girderResources";
+
 main.initialize();
 main.setupWatchers();
 chat.initializeChatDatabase();
+
+// Wire up live store/cache counts now that all store modules have finished
+// initializing. memDiag does not import these stores itself to avoid a
+// load-order cycle with index.ts.
+memDiag.register(() => {
+  const apiSizes = main.api.getCacheSizes();
+  return {
+    resourcesCache: Object.keys(girderResourcesStore.resources).length,
+    resourcesLocks: Object.keys(girderResourcesStore.resourcesLocks).length,
+    imageCache: apiSizes.imageCache,
+    histogramCache: apiSizes.histogramCache,
+    resolvedHistogramCache: apiSizes.resolvedHistogramCache,
+    annotations: annotationStore.annotations.length,
+    annotationConnections: annotationStore.annotationConnections.length,
+    annotationCentroids: Object.keys(annotationStore.annotationCentroids)
+      .length,
+    selectedAnnotationIds: annotationStore.selectedAnnotationIds.size,
+    activeAnnotationIds: annotationStore.activeAnnotationIds.length,
+    copiedAnnotations: annotationStore.copiedAnnotations.length,
+    pendingAnnotation: annotationStore.pendingAnnotation ? 1 : 0,
+    submitPendingAnnotation: annotationStore.submitPendingAnnotation ? 1 : 0,
+    propertyValues: Object.keys(propertiesStore.propertyValues).length,
+    propertyStatuses: Object.keys(propertiesStore.propertyStatuses).length,
+    workerImageList: Object.keys(propertiesStore.workerImageList).length,
+    workerInterfaces: Object.keys(propertiesStore.workerInterfaces).length,
+    workerPreviews: Object.keys(propertiesStore.workerPreviews).length,
+    pendingWorkerPreviewTimeouts: propertiesStore.pendingWorkerPreviewTimeouts
+      ? propertiesStore.pendingWorkerPreviewTimeouts.size
+      : 0,
+  };
+});
 
 const app = createApp(App);
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -871,6 +871,15 @@ export default class GirderAPI {
     this.resolvedHistogramCache.clear();
   }
 
+  // Read-only snapshot of cache sizes for memory diagnostics.
+  getCacheSizes() {
+    return {
+      imageCache: this.imageCache.size,
+      histogramCache: this.histogramCache.size,
+      resolvedHistogramCache: this.resolvedHistogramCache.size,
+    };
+  }
+
   scheduleTileFramesComputation(datasetId: string) {
     return this.getImages(datasetId).then((items: IGirderItem[]) => {
       return items.map((item: IGirderItem) => {

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -222,6 +222,24 @@ export class Annotations extends VuexModule {
   }
 
   @Mutation
+  protected resetAnnotationStateImpl() {
+    this.selectedAnnotationIds = markRaw(new Set());
+    this.activeAnnotationIds = [];
+    this.copiedAnnotations = [];
+    this.hoveredAnnotationId = null;
+    this.pendingAnnotation = null;
+    this.submitPendingAnnotation = null;
+  }
+
+  // Clear per-dataset annotation state. Call when switching datasets so
+  // stale references (selection, active set, copied annotations, hover,
+  // pending) don't pin objects from the previous view.
+  @Action
+  public resetAnnotationState() {
+    this.resetAnnotationStateImpl();
+  }
+
+  @Mutation
   public activateAnnotations(ids: string[]) {
     const activeIds = new Set(this.activeAnnotationIds);
     const idsToAdd = ids.filter((id: string) => !activeIds.has(id));

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -229,6 +229,14 @@ export class Annotations extends VuexModule {
     this.hoveredAnnotationId = null;
     this.pendingAnnotation = null;
     this.submitPendingAnnotation = null;
+    // Drop the previous dataset's annotations and connections. Without this,
+    // navigating away from a viewer (e.g. on logout, or to a non-viewer
+    // route) leaves the full array pinned on the heap until the next viewer
+    // entry calls fetchAnnotations.
+    this.annotations = [];
+    this.annotationConnections = [];
+    this.annotationCentroids = markRaw({});
+    this.annotationIdToIdx = markRaw({});
   }
 
   // Clear per-dataset annotation state. Call when switching datasets so

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -244,6 +244,16 @@ export class Annotations extends VuexModule {
   // pending) don't pin objects from the previous view.
   @Action
   public resetAnnotationState() {
+    // If a submission is pending, cancel it so the awaiting Promise inside
+    // getAnnotationSubmission resolves (with `false`) and its timer is
+    // cleared. Otherwise nulling submitPendingAnnotation in the mutation
+    // below would orphan the Promise — the timer's
+    // `submitPendingAnnotation?.(true)` would no-op, and createAnnotation
+    // would await indefinitely. The callback itself nulls
+    // submitPendingAnnotation and pendingAnnotation via their setters.
+    if (this.submitPendingAnnotation) {
+      this.submitPendingAnnotation(false);
+    }
     this.resetAnnotationStateImpl();
   }
 

--- a/src/store/girderResources.ts
+++ b/src/store/girderResources.ts
@@ -18,6 +18,12 @@ import {
 import { IDataset, IDatasetConfiguration } from "./model";
 import { setBaseCollectionValues, asDataset, parseTiles } from "./GirderAPI";
 import { logError } from "@/utils/log";
+import { markRaw } from "vue";
+
+// Hard cap on the resource cache. Browsing many datasets/folders within a
+// session previously caused this map to grow without bound. The cap is high
+// enough that normal navigation stays fully cached.
+const MAX_CACHED_RESOURCES = 1000;
 
 /**
  * Store to cache requests to resources, mostly items and folders
@@ -27,6 +33,10 @@ export class GirderResources extends VuexModule {
   resources: { [resourceId: string]: IGirderSelectAble | null } = {};
   resourcesLocks: { [resourceId: string]: Promise<void> } = {};
 
+  // Insertion-order tracker for FIFO eviction. markRaw avoids reactive
+  // overhead since the order has no UI consumers.
+  private resourceInsertionOrder: Set<string> = markRaw(new Set());
+
   @Mutation
   public setResource({
     id,
@@ -35,7 +45,23 @@ export class GirderResources extends VuexModule {
     id: string;
     resource: IGirderSelectAble | null;
   }) {
+    // Bump existing entry to most-recent slot.
+    if (this.resourceInsertionOrder.has(id)) {
+      this.resourceInsertionOrder.delete(id);
+    }
+    this.resourceInsertionOrder.add(id);
     this.resources[id] = resource;
+
+    // Evict oldest entries once the cap is exceeded.
+    while (this.resourceInsertionOrder.size > MAX_CACHED_RESOURCES) {
+      const oldest = this.resourceInsertionOrder.values().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.resourceInsertionOrder.delete(oldest);
+      delete this.resources[oldest];
+      delete this.resourcesLocks[oldest];
+    }
   }
 
   @Action
@@ -154,6 +180,7 @@ export class GirderResources extends VuexModule {
   private resetResource(id: string) {
     delete this.resources[id];
     delete this.resourcesLocks[id];
+    this.resourceInsertionOrder.delete(id);
   }
 
   @Action

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1232,6 +1232,8 @@ export class Main extends VuexModule {
   @Action
   async setSelectedDataset(id: string | null) {
     this.api.flushCaches();
+    this.context.dispatch("resetAnnotationState");
+    this.context.dispatch("resetPropertyState");
     if (!id) {
       this.setDataset({ id, data: null });
       return;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -78,6 +78,7 @@ export { default as store } from "./root";
 // NOTE: router is imported lazily where needed to avoid circular dependency with main.ts
 
 import { Debounce } from "@/utils/debounce";
+import { memDiag } from "@/utils/memoryDiagnostics";
 import { TCompositionMode } from "@/utils/compositionModes";
 import { createSamToolStateFromToolConfiguration } from "@/pipelines/samPipeline";
 import { isEqual } from "lodash";
@@ -1231,11 +1232,13 @@ export class Main extends VuexModule {
 
   @Action
   async setSelectedDataset(id: string | null) {
+    memDiag.autoSnapshot(`setSelectedDataset:enter id=${id ?? "null"}`);
     this.api.flushCaches();
     this.context.dispatch("resetAnnotationState");
     this.context.dispatch("resetPropertyState");
     if (!id) {
       this.setDataset({ id, data: null });
+      memDiag.autoSnapshot("setSelectedDataset:exit (null)");
       return;
     }
     try {
@@ -1255,6 +1258,7 @@ export class Main extends VuexModule {
       sync.setLoading(error as Error);
       sync.setDatasetLoading(false);
     }
+    memDiag.autoSnapshot(`setSelectedDataset:exit id=${id}`);
   }
 
   @Action

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -8,6 +8,8 @@ import {
 import store from "./root";
 import { markRaw } from "vue";
 
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
 import {
   IAnnotationProperty,
   IWorkerInterface,
@@ -75,6 +77,11 @@ export class Properties extends VuexModule {
   workerPreviews: { [image: string]: { text: string; image: string } } = {};
   displayWorkerPreview = true;
 
+  // Pending fallback timers from requestWorkerPreview, keyed by image so a
+  // new request supersedes the previous one. Held in markRaw to keep Vue
+  // from making the timer handles reactive.
+  pendingWorkerPreviewTimeouts: Map<string, TimeoutHandle> = markRaw(new Map());
+
   get getStatus() {
     return (propertyId: string) => {
       return this.propertyStatuses[propertyId] || defaultStatus();
@@ -132,6 +139,47 @@ export class Properties extends VuexModule {
   @Mutation
   setDisplayWorkerPreview(value: boolean) {
     this.displayWorkerPreview = value;
+  }
+
+  @Mutation
+  setPendingWorkerPreviewTimeout({
+    image,
+    handle,
+  }: {
+    image: string;
+    handle: TimeoutHandle;
+  }) {
+    const previous = this.pendingWorkerPreviewTimeouts.get(image);
+    if (previous !== undefined) {
+      clearTimeout(previous);
+    }
+    this.pendingWorkerPreviewTimeouts.set(image, handle);
+  }
+
+  @Mutation
+  clearPendingWorkerPreviewTimeout(image: string) {
+    const handle = this.pendingWorkerPreviewTimeouts.get(image);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      this.pendingWorkerPreviewTimeouts.delete(image);
+    }
+  }
+
+  @Mutation
+  protected resetPropertyStateImpl() {
+    this.propertyStatuses = {};
+    this.workerPreviews = {};
+    for (const handle of this.pendingWorkerPreviewTimeouts.values()) {
+      clearTimeout(handle);
+    }
+    this.pendingWorkerPreviewTimeouts.clear();
+  }
+
+  // Clear per-dataset property state. Worker interfaces and the worker
+  // image list are intentionally preserved since they are not dataset-scoped.
+  @Action
+  public resetPropertyState() {
+    this.resetPropertyStateImpl();
   }
 
   @Action
@@ -730,12 +778,15 @@ export class Properties extends VuexModule {
             })
             .then((success: boolean) => {
               if (success) {
+                this.clearPendingWorkerPreviewTimeout(image);
                 this.fetchWorkerPreview(image);
               }
             });
-          setTimeout(() => {
+          const handle = setTimeout(() => {
+            this.clearPendingWorkerPreviewTimeout(image);
             this.fetchWorkerPreview(image);
           }, 5000);
+          this.setPendingWorkerPreviewTimeout({ image, handle });
         }
       });
   }

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -169,6 +169,11 @@ export class Properties extends VuexModule {
   protected resetPropertyStateImpl() {
     this.propertyStatuses = {};
     this.workerPreviews = {};
+    // Property paths reference the previous dataset's property IDs and are
+    // not meaningful in the new dataset. updateDisplayedFromComputedProperties
+    // would prune them once new property values arrive, but resetting here
+    // releases the references immediately and avoids a UI flash.
+    this.displayedPropertyPaths = [];
     for (const handle of this.pendingWorkerPreviewTimeouts.values()) {
       clearTimeout(handle);
     }

--- a/src/utils/memoryDiagnostics.ts
+++ b/src/utils/memoryDiagnostics.ts
@@ -1,0 +1,299 @@
+/* eslint-disable no-console */
+// Lightweight memory monitoring instrumentation. Intended for comparing
+// memory pressure on the master branch vs. the memory-leak-fix branch.
+//
+// Usage from the browser console:
+//   __nimbusMem.enable()         // turn on auto-snapshots on dataset switch
+//   __nimbusMem.snapshot('label')// take a manual snapshot
+//   __nimbusMem.print()          // print all snapshots with deltas
+//   __nimbusMem.compare('a','b') // diff two labels
+//   __nimbusMem.export()         // copy a JSON dump to clipboard
+//   __nimbusMem.clear()
+//   __nimbusMem.disable()
+//
+// To compare branches, cherry-pick this file (and the small hook in
+// `setSelectedDataset`) onto master, run the same workflow on each branch,
+// and `__nimbusMem.export()` to copy the JSON for each.
+
+// NOTE: this file intentionally does NOT import any Vuex store modules at
+// the top level. Doing so would create a load-order cycle with index.ts
+// (which imports memDiag), causing class-field initializers in
+// annotation.ts/properties.ts to read `main` before it is defined.
+// The integration is instead pull-based: main.ts (after stores are loaded)
+// calls memDiag.register(provider) with a function that returns the live
+// counts. Until registration completes, snapshots fall back to zeros.
+
+interface MemoryCounts {
+  resourcesCache: number;
+  resourcesLocks: number;
+  imageCache: number;
+  histogramCache: number;
+  resolvedHistogramCache: number;
+  annotations: number;
+  annotationConnections: number;
+  annotationCentroids: number;
+  selectedAnnotationIds: number;
+  activeAnnotationIds: number;
+  copiedAnnotations: number;
+  pendingAnnotation: number;
+  submitPendingAnnotation: number;
+  propertyValues: number;
+  propertyStatuses: number;
+  workerImageList: number;
+  workerInterfaces: number;
+  workerPreviews: number;
+  pendingWorkerPreviewTimeouts: number;
+}
+
+interface MemorySnapshot extends MemoryCounts {
+  label: string;
+  timestamp: number;
+  jsHeapUsed?: number;
+  jsHeapTotal?: number;
+  jsHeapLimit?: number;
+}
+
+type MemoryCountsProvider = () => MemoryCounts;
+
+const ZERO_COUNTS: MemoryCounts = {
+  resourcesCache: 0,
+  resourcesLocks: 0,
+  imageCache: 0,
+  histogramCache: 0,
+  resolvedHistogramCache: 0,
+  annotations: 0,
+  annotationConnections: 0,
+  annotationCentroids: 0,
+  selectedAnnotationIds: 0,
+  activeAnnotationIds: 0,
+  copiedAnnotations: 0,
+  pendingAnnotation: 0,
+  submitPendingAnnotation: 0,
+  propertyValues: 0,
+  propertyStatuses: 0,
+  workerImageList: 0,
+  workerInterfaces: 0,
+  workerPreviews: 0,
+  pendingWorkerPreviewTimeouts: 0,
+};
+
+let countsProvider: MemoryCountsProvider | null = null;
+
+function register(provider: MemoryCountsProvider) {
+  countsProvider = provider;
+}
+
+const STORAGE_KEY = "nimbusMemDiagEnabled";
+const HISTORY: MemorySnapshot[] = [];
+const HISTORY_CAP = 500;
+
+function readEnabled(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+let enabled = readEnabled();
+
+function readPerfMemory() {
+  const mem = (performance as unknown as { memory?: Record<string, number> })
+    .memory;
+  if (mem && typeof mem.usedJSHeapSize === "number") {
+    return {
+      jsHeapUsed: mem.usedJSHeapSize,
+      jsHeapTotal: mem.totalJSHeapSize,
+      jsHeapLimit: mem.jsHeapSizeLimit,
+    };
+  }
+  return {};
+}
+
+function takeSnapshot(label: string): MemorySnapshot {
+  const counts = countsProvider ? countsProvider() : ZERO_COUNTS;
+  return {
+    label,
+    timestamp: Date.now(),
+    ...readPerfMemory(),
+    ...counts,
+  };
+}
+
+function pushSnapshot(snap: MemorySnapshot) {
+  HISTORY.push(snap);
+  while (HISTORY.length > HISTORY_CAP) {
+    HISTORY.shift();
+  }
+}
+
+function snapshot(label: string = "manual") {
+  const snap = takeSnapshot(label);
+  pushSnapshot(snap);
+  return snap;
+}
+
+// Take a snapshot only when auto-tracking is enabled. Used by store hooks.
+function autoSnapshot(label: string) {
+  if (!enabled) {
+    return;
+  }
+  pushSnapshot(takeSnapshot(label));
+}
+
+function fmtBytes(n?: number): string {
+  if (n === undefined) {
+    return "—";
+  }
+  if (n < 1024) {
+    return `${n} B`;
+  }
+  if (n < 1024 * 1024) {
+    return `${(n / 1024).toFixed(1)} KB`;
+  }
+  if (n < 1024 * 1024 * 1024) {
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function print() {
+  if (HISTORY.length === 0) {
+    console.log("[memDiag] no snapshots yet");
+    return;
+  }
+  const rows = HISTORY.map((s, i) => {
+    const prev = i > 0 ? HISTORY[i - 1] : undefined;
+    const heapDelta =
+      prev && s.jsHeapUsed !== undefined && prev.jsHeapUsed !== undefined
+        ? fmtBytes(s.jsHeapUsed - prev.jsHeapUsed)
+        : "—";
+    return {
+      "#": i,
+      label: s.label,
+      "t (ms)": prev ? s.timestamp - prev.timestamp : 0,
+      "heap used": fmtBytes(s.jsHeapUsed),
+      "Δ heap": heapDelta,
+      resources: s.resourcesCache,
+      imgCache: s.imageCache,
+      histCache: s.histogramCache,
+      annot: s.annotations,
+      "annot conn": s.annotationConnections,
+      centroids: s.annotationCentroids,
+      "sel ids": s.selectedAnnotationIds,
+      "prop vals": s.propertyValues,
+      "prop stat": s.propertyStatuses,
+      "wkr prev": s.workerPreviews,
+      "wkr if": s.workerInterfaces,
+      tmout: s.pendingWorkerPreviewTimeouts,
+    };
+  });
+  console.table(rows);
+  console.log(
+    `[memDiag] ${HISTORY.length} snapshots. Use __nimbusMem.export() to copy raw JSON.`,
+  );
+}
+
+function compare(labelA: string, labelB: string) {
+  const a = HISTORY.findLast?.((s) => s.label === labelA) ?? findLast(labelA);
+  const b = HISTORY.findLast?.((s) => s.label === labelB) ?? findLast(labelB);
+  if (!a || !b) {
+    console.log(
+      `[memDiag] could not find snapshots for "${labelA}" and "${labelB}"`,
+    );
+    return;
+  }
+  const numericKeys = (Object.keys(a) as (keyof MemorySnapshot)[]).filter(
+    (k) => typeof a[k] === "number" && k !== "timestamp",
+  );
+  const rows = numericKeys.map((k) => {
+    const av = a[k] as number;
+    const bv = b[k] as number;
+    return {
+      field: k,
+      [labelA]: k.startsWith("jsHeap") ? fmtBytes(av) : av,
+      [labelB]: k.startsWith("jsHeap") ? fmtBytes(bv) : bv,
+      delta: k.startsWith("jsHeap") ? fmtBytes(bv - av) : bv - av,
+    };
+  });
+  console.table(rows);
+}
+
+function findLast(label: string): MemorySnapshot | undefined {
+  for (let i = HISTORY.length - 1; i >= 0; --i) {
+    if (HISTORY[i].label === label) {
+      return HISTORY[i];
+    }
+  }
+  return undefined;
+}
+
+function exportJson() {
+  const json = JSON.stringify(HISTORY, null, 2);
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(json).then(
+      () => console.log("[memDiag] copied JSON to clipboard"),
+      () => console.log(json),
+    );
+  } else {
+    console.log(json);
+  }
+  return json;
+}
+
+function clear() {
+  HISTORY.length = 0;
+  console.log("[memDiag] history cleared");
+}
+
+function enable() {
+  enabled = true;
+  try {
+    localStorage.setItem(STORAGE_KEY, "1");
+  } catch {
+    /* ignore */
+  }
+  console.log(
+    "[memDiag] auto-snapshots on dataset switch ENABLED (persists in localStorage)",
+  );
+}
+
+function disable() {
+  enabled = false;
+  try {
+    localStorage.setItem(STORAGE_KEY, "0");
+  } catch {
+    /* ignore */
+  }
+  console.log("[memDiag] auto-snapshots DISABLED");
+}
+
+function isEnabled() {
+  return enabled;
+}
+
+export const memDiag = {
+  snapshot,
+  print,
+  compare,
+  export: exportJson,
+  clear,
+  enable,
+  disable,
+  isEnabled,
+  // Internal: used by store hooks. No-op if not enabled.
+  autoSnapshot,
+  // Internal: used by main.ts to wire up the live count provider once
+  // stores have finished loading.
+  register,
+};
+
+declare global {
+  interface Window {
+    __nimbusMem?: typeof memDiag;
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.__nimbusMem = memDiag;
+}


### PR DESCRIPTION
## Summary

- **Memory-leak fixes** in three Vuex stores so that switching datasets no longer pins state from the previous one:
  - `annotation.ts`: new `resetAnnotationState` action clears selection, active set, copied annotations, hover, pending annotation/submission callback, and the large per-dataset arrays (annotations, connections, centroids, id-to-idx).
  - `properties.ts`: new `resetPropertyState` action clears `propertyStatuses`, `workerPreviews`, `displayedPropertyPaths`, and tracked `pendingWorkerPreviewTimeouts` (also cancels in-flight timers). Worker interfaces and the worker image list are intentionally preserved (not dataset-scoped).
  - `girderResources.ts`: hard FIFO cap of 1000 entries on the resource cache, with eviction of the matching `resourcesLocks` entry. Previously the cache grew without bound.
  - `index.ts`: `setSelectedDataset` now dispatches the two reset actions on every switch.
- **Browser-console memory diagnostics tool** (`window.__nimbusMem`, source in `src/utils/memoryDiagnostics.ts`) for live heap / cache / store inspection. Auto-tracking is opt-in via `__nimbusMem.enable()` and adds zero overhead otherwise. Documented in `codebaseDocumentation/MEMORY_DEBUGGING.md` (CLAUDE.md and the nimbus-frontend skill point at it).

## Verified end-to-end

Ran a master-vs-branch comparison via the diagnostic tool (master pulled into a sibling worktree on a separate Vite port). After triggering a property computation on each, the smoking-gun signal showed up clearly:

- **post-compute on branch**: `propertyStatuses=1`
- **after dataset switch**: `propertyStatuses=0` ← reset fired
- **post-compute on master**: `propertyStatuses=1`
- **after dataset switch on master**: `propertyStatuses` still 1 (leak)

`histogramCache` resets via the existing `flushCaches()` on both branches; `workerInterfaces` correctly persists across switches as designed. Heap deltas across 14+ navigations stay bounded on the branch (118–173 MB band) where master shows trajectory growth on revisits.

## Related

Discovered while running diagnostics: `setSelectedDataset` fires twice per single navigation. Filed as #1131 — out of scope for this PR.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint:ci` clean (zero warnings)
- [x] `pnpm test` — 2118/2118 passing (one pre-existing unrelated unhandled rejection in `NewDataset.test.ts`)
- [ ] Manual: load a dataset with annotations and computed properties; switch datasets; confirm `propertyStatuses` and `workerPreviews` clear (visible via `__nimbusMem.snapshot('after')` then `__nimbusMem.print()`).
- [ ] Manual: log out / re-login; confirm previous dataset's annotations no longer occupy heap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)