### PR TITLE
Reduce Vue 3 reactive Proxy overhead on canvas + store hot paths

### DIFF
--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -209,14 +209,17 @@ const props = withDefaults(
 const isDragging = ref(false);
 const dragStartPosition = ref<IGeoJSPosition | null>(null);
 const draggedAnnotation = ref<IAnnotation | null>(null);
-const dragGhostAnnotation = ref<IGeoJSAnnotation | null>(null);
-const dragOriginalCoordinates = ref<IGeoJSPosition[] | null>(null);
-const pendingAnnotation = ref<IGeoJSAnnotation | null>(null);
-const selectionAnnotation = ref<IGeoJSAnnotation | null>(null);
-const samPromptAnnotations = ref<IGeoJSAnnotation[]>([]);
-const samUnsubmittedAnnotation = ref<IGeoJSAnnotation | null>(null);
-const samLivePreviewAnnotation = ref<IGeoJSAnnotation | null>(null);
-const cursorAnnotation = ref<IGeoJSAnnotation | null>(null);
+// IGeoJSAnnotation instances are heavy native objects whose internals must
+// not be Proxy-wrapped. shallowRef tracks identity (so swap/clear triggers
+// reactivity) but skips deep-walking the object graph.
+const dragGhostAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+const dragOriginalCoordinates = shallowRef<IGeoJSPosition[] | null>(null);
+const pendingAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+const selectionAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+const samPromptAnnotations = shallowRef<IGeoJSAnnotation[]>([]);
+const samUnsubmittedAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+const samLivePreviewAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+const cursorAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const lastCursorPosition = ref<{ x: number; y: number }>({ x: 0, y: 0 });
 const handlingPrimaryChange = ref(false);
 const showContextMenu = ref(false);
@@ -2559,17 +2562,18 @@ function drawRoiFilters() {
   });
 }
 
-function bindAnnotationEvents() {
-  props.annotationLayer.geoOn(
-    geojs.event.mouseclick,
-    (evt: IGeoJSMouseState) => {
-      if (evt.buttonsDown.right) {
-        handleAnnotationRightClick(evt);
-      }
-    },
-  );
+function handleAnnotationLayerMouseclick(evt: IGeoJSMouseState) {
+  if (evt.buttonsDown.right) {
+    handleAnnotationRightClick(evt);
+  }
+}
 
-  const map = props.annotationLayer.map();
+function bindAnnotationEvents(
+  layer: IGeoJSAnnotationLayer = props.annotationLayer,
+) {
+  layer.geoOn(geojs.event.mouseclick, handleAnnotationLayerMouseclick);
+
+  const map = layer.map();
   const interactorOpts = map.interactor().options();
   const actions = interactorOpts.actions || [];
 
@@ -2580,44 +2584,59 @@ function bindAnnotationEvents() {
 
   map.interactor().options({ ...interactorOpts, actions });
 
-  props.annotationLayer.geoOn(geojs.event.mousedown, handleDragStart);
-  props.annotationLayer.geoOn(geojs.event.mousemove, handleDragMove);
-  props.annotationLayer.geoOn(geojs.event.mouseup, handleDragEnd);
+  layer.geoOn(geojs.event.mousedown, handleDragStart);
+  layer.geoOn(geojs.event.mousemove, handleDragMove);
+  layer.geoOn(geojs.event.mouseup, handleDragEnd);
 
   drawAnnotationsAndTooltips();
 }
 
-function bindInteractionEvents() {
-  if (!props.interactionLayer) {
+function unbindAnnotationEvents(layer: IGeoJSAnnotationLayer | undefined) {
+  if (!layer) return;
+  layer.geoOff(geojs.event.mouseclick, handleAnnotationLayerMouseclick);
+  layer.geoOff(geojs.event.mousedown, handleDragStart);
+  layer.geoOff(geojs.event.mousemove, handleDragMove);
+  layer.geoOff(geojs.event.mouseup, handleDragEnd);
+  layer.geoOff(geojs.event.mousemove, handleValueOnMouseMove);
+}
+
+function bindInteractionEvents(
+  layer: IGeoJSAnnotationLayer | undefined = props.interactionLayer,
+) {
+  if (!layer) {
     return;
   }
-  props.interactionLayer.geoOn(
-    geojs.event.annotation.mode,
-    handleInteractionModeChange,
-  );
-  props.interactionLayer.geoOn(
-    geojs.event.annotation.add,
-    handleInteractionAnnotationChange,
-  );
-  props.interactionLayer.geoOn(
-    geojs.event.annotation.update,
-    handleInteractionAnnotationChange,
-  );
-  props.interactionLayer.geoOn(
-    geojs.event.annotation.state,
-    handleInteractionAnnotationChange,
-  );
+  layer.geoOn(geojs.event.annotation.mode, handleInteractionModeChange);
+  layer.geoOn(geojs.event.annotation.add, handleInteractionAnnotationChange);
+  layer.geoOn(geojs.event.annotation.update, handleInteractionAnnotationChange);
+  layer.geoOn(geojs.event.annotation.state, handleInteractionAnnotationChange);
   if (selectedToolConfiguration.value?.type === "tagging") {
-    props.interactionLayer.geoOn(geojs.event.mouseclick, handleTaggingClick);
+    layer.geoOn(geojs.event.mouseclick, handleTaggingClick);
   }
   refreshAnnotationMode();
 }
 
-function bindTimelapseEvents() {
-  props.timelapseLayer.geoOn(
-    geojs.event.mouseclick,
-    handleTimelapseAnnotationClick,
+function unbindInteractionEvents(layer: IGeoJSAnnotationLayer | undefined) {
+  if (!layer) return;
+  layer.geoOff(geojs.event.annotation.mode, handleInteractionModeChange);
+  layer.geoOff(geojs.event.annotation.add, handleInteractionAnnotationChange);
+  layer.geoOff(
+    geojs.event.annotation.update,
+    handleInteractionAnnotationChange,
   );
+  layer.geoOff(geojs.event.annotation.state, handleInteractionAnnotationChange);
+  layer.geoOff(geojs.event.mouseclick, handleTaggingClick);
+}
+
+function bindTimelapseEvents(
+  layer: IGeoJSAnnotationLayer = props.timelapseLayer,
+) {
+  layer.geoOn(geojs.event.mouseclick, handleTimelapseAnnotationClick);
+}
+
+function unbindTimelapseEvents(layer: IGeoJSAnnotationLayer | undefined) {
+  if (!layer) return;
+  layer.geoOff(geojs.event.mouseclick, handleTimelapseAnnotationClick);
 }
 
 function updateValueOnHover() {
@@ -3081,8 +3100,20 @@ watch(samLivePreviewOutput, () => {
   onSamLivePreviewOutputChanged();
 });
 
-// Captured mouse state
-watch(() => props.capturedMouseState, onMousePathChanged, { deep: true });
+// Captured mouse state — split into two cheap watchers instead of one
+// `{ deep: true }` watcher that recursively dirty-checks IMouseState (which
+// includes the entire IMapEntry → GeoJS map). Identity transitions handle
+// state→null (consume) and state-object swap (new preview); a length watcher
+// on `path` handles in-place vertex pushes during a drag.
+watch(() => props.capturedMouseState, onMousePathChanged);
+watch(
+  () => props.capturedMouseState?.path.length ?? 0,
+  () => {
+    if (props.capturedMouseState) {
+      previewMouseState(props.capturedMouseState);
+    }
+  },
+);
 
 // Worker preview
 watch([displayWorkerPreview, workerPreview], () => {
@@ -3099,11 +3130,13 @@ watch(selectedToolRadius, () => {
   updateCursorAnnotation();
 });
 
-// Annotation layer
+// Annotation layer — geoOff old layer before re-binding to prevent
+// handler accumulation across mapentry rebuilds (e.g., dataset reset).
 watch(
   () => props.annotationLayer,
-  () => {
-    bindAnnotationEvents();
+  (newLayer, oldLayer) => {
+    unbindAnnotationEvents(oldLayer);
+    bindAnnotationEvents(newLayer);
     addHoverCallback();
   },
 );
@@ -3116,16 +3149,18 @@ watch([() => props.annotationLayer, valueOnHover], () => {
 // Interaction layer
 watch(
   () => props.interactionLayer,
-  () => {
-    bindInteractionEvents();
+  (newLayer, oldLayer) => {
+    unbindInteractionEvents(oldLayer);
+    bindInteractionEvents(newLayer);
   },
 );
 
 // Timelapse layer
 watch(
   () => props.timelapseLayer,
-  () => {
-    bindTimelapseEvents();
+  (newLayer, oldLayer) => {
+    unbindTimelapseEvents(oldLayer);
+    bindTimelapseEvents(newLayer);
   },
 );
 
@@ -3141,11 +3176,9 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  if (props.annotationLayer) {
-    props.annotationLayer.geoOff(geojs.event.mousedown, handleDragStart);
-    props.annotationLayer.geoOff(geojs.event.mousemove, handleDragMove);
-    props.annotationLayer.geoOff(geojs.event.mouseup, handleDragEnd);
-  }
+  unbindAnnotationEvents(props.annotationLayer);
+  unbindInteractionEvents(props.interactionLayer);
+  unbindTimelapseEvents(props.timelapseLayer);
   if (spatialIndexRequestId !== null) {
     cancelIdleCallback(spatialIndexRequestId);
   }

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -210,16 +210,18 @@ const isDragging = ref(false);
 const dragStartPosition = ref<IGeoJSPosition | null>(null);
 const draggedAnnotation = ref<IAnnotation | null>(null);
 // IGeoJSAnnotation instances are heavy native objects whose internals must
-// not be Proxy-wrapped. shallowRef tracks identity (so swap/clear triggers
-// reactivity) but skips deep-walking the object graph.
+// not be Proxy-wrapped — shallowRef tracks identity (so swap/clear
+// triggers reactivity) but skips deep-walking the object graph.
 const dragGhostAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
-const dragOriginalCoordinates = shallowRef<IGeoJSPosition[] | null>(null);
 const pendingAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const selectionAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const samPromptAnnotations = shallowRef<IGeoJSAnnotation[]>([]);
 const samUnsubmittedAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const samLivePreviewAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const cursorAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+// Plain coordinate array, fully replaced on each set — shallowRef purely
+// because nothing reads its inner mutations, not because it's heavy.
+const dragOriginalCoordinates = shallowRef<IGeoJSPosition[] | null>(null);
 const lastCursorPosition = ref<{ x: number; y: number }>({ x: 0, y: 0 });
 const handlingPrimaryChange = ref(false);
 const showContextMenu = ref(false);
@@ -2597,6 +2599,11 @@ function unbindAnnotationEvents(layer: IGeoJSAnnotationLayer | undefined) {
   layer.geoOff(geojs.event.mousedown, handleDragStart);
   layer.geoOff(geojs.event.mousemove, handleDragMove);
   layer.geoOff(geojs.event.mouseup, handleDragEnd);
+  // handleValueOnMouseMove is bound elsewhere (updateValueOnHover) but
+  // detached here so layer-prop changes don't leak it onto the old layer.
+  // Mildly asymmetric — geoOff is a no-op when nothing matches, so safe.
+  // A symmetric refactor that pulls hover-handler ownership into
+  // updateValueOnHover broke initial render in testing; leaving as-is.
   layer.geoOff(geojs.event.mousemove, handleValueOnMouseMove);
 }
 
@@ -2625,6 +2632,8 @@ function unbindInteractionEvents(layer: IGeoJSAnnotationLayer | undefined) {
     handleInteractionAnnotationChange,
   );
   layer.geoOff(geojs.event.annotation.state, handleInteractionAnnotationChange);
+  // handleTaggingClick is conditionally bound based on tool type; geoOff
+  // is a no-op when nothing matches, so always-detach is safe.
   layer.geoOff(geojs.event.mouseclick, handleTaggingClick);
 }
 
@@ -3105,6 +3114,11 @@ watch(samLivePreviewOutput, () => {
 // includes the entire IMapEntry → GeoJS map). Identity transitions handle
 // state→null (consume) and state-object swap (new preview); a length watcher
 // on `path` handles in-place vertex pushes during a drag.
+//
+// Note: on a state-object swap (e.g., preview-A → fresh-B at mouseDown when
+// path lengths differ), both watchers fire and previewMouseState gets called
+// twice. Idempotent and rare, so we accept the duplicate over the complexity
+// of deduping.
 watch(() => props.capturedMouseState, onMousePathChanged);
 watch(
   () => props.capturedMouseState?.path.length ?? 0,

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -174,6 +174,7 @@
 //  $('.geojs-map').data('data-geojs-map')
 import {
   ref,
+  shallowRef,
   computed,
   watch,
   onMounted,
@@ -328,7 +329,9 @@ const samLoadingMessages = computed(() => {
   if (state?.type !== SamAnnotationToolStateSymbol) return [];
   return (state as { loadingMessages: string[] }).loadingMessages ?? [];
 });
-const samMapEntry = ref<IMapEntry | null>(null);
+// IMapEntry contains heavy GeoJS map + layers — shallowRef tracks identity
+// so the SAM watcher fires on swap, but skips deep-walking the GeoJS tree.
+const samMapEntry = shallowRef<IMapEntry | null>(null);
 const mouseState = ref<IMouseState | null>(null);
 let synchronisationEnabled = true;
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -47,6 +47,7 @@ import { AxiosRequestConfig, AxiosResponse, isAxiosError } from "axios";
 import { fetchAllPages } from "@/utils/fetch";
 import { stringify } from "qs";
 import { logError, logWarning } from "@/utils/log";
+import { markRaw } from "vue";
 
 // Modern browsers limit concurrency to a single domain at 6 requests (though
 // using HTML 2 might improve that slightly).  For a single layer, if we set
@@ -77,9 +78,17 @@ function itemsToResourceObject(items: IGirderSelectAble[]) {
 export default class GirderAPI {
   client: RestClientInstance;
 
-  private readonly imageCache = new Map<string, HTMLImageElement>();
-  private readonly histogramCache = new Map<string, Promise<ITileHistogram>>();
-  private readonly resolvedHistogramCache = new Map<string, ITileHistogram>();
+  // markRaw on each cache so Vue's reactive() doesn't intercept Map.get/set
+  // with track/trigger calls. Lookups happen on every tile fetch — the
+  // overhead adds up. The GirderAPI instance itself stays reactive so
+  // `histogramsLoaded` (and any future reactive fields) still work.
+  private readonly imageCache = markRaw(new Map<string, HTMLImageElement>());
+  private readonly histogramCache = markRaw(
+    new Map<string, Promise<ITileHistogram>>(),
+  );
+  private readonly resolvedHistogramCache = markRaw(
+    new Map<string, ITileHistogram>(),
+  );
 
   constructor(client: RestClientInstance) {
     this.client = client;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -101,46 +101,38 @@ function apiRootFromGirderUrl(girderUrl: string) {
 
 @Module({ dynamic: true, store, name: "main" })
 export class Main extends VuexModule {
-  // RestClient and the API class instances hold heavy non-Vue state — Axios
-  // clients, in-memory Maps used as caches, etc. Wrap them with `markRaw` so
-  // Vuex's reactive() doesn't deep-Proxy them and pay trap overhead on every
-  // method call. Each one is a stable reference; they're never replaced.
-  girderRest = markRaw(
-    new RestClient({
-      apiRoot: apiRootFromGirderUrl(
-        persister.get("girderUrl", defaultGirderUrl),
-      ),
-    }),
-  );
+  girderRest = new RestClient({
+    apiRoot: apiRootFromGirderUrl(persister.get("girderUrl", defaultGirderUrl)),
+  });
 
   // Use a proxy to dynamically resolve to the right girderRest client
-  girderRestProxy = markRaw(
-    new Proxy(this, {
-      get(obj: Main, prop: keyof RestClientInstance) {
-        return obj.girderRest[prop];
-      },
-      set(target: Main, p: keyof RestClientInstance, newValue: any) {
-        if (p != "token") {
-          throw "Can only set token to RestClient";
-        }
-        target.girderRest[p] = newValue;
-        return true;
-      },
-    }) as unknown as RestClientInstance,
-  );
+  girderRestProxy = new Proxy(this, {
+    get(obj: Main, prop: keyof RestClientInstance) {
+      return obj.girderRest[prop];
+    },
+    set(target: Main, p: keyof RestClientInstance, newValue: any) {
+      if (p != "token") {
+        throw "Can only set token to RestClient";
+      }
+      target.girderRest[p] = newValue;
+      return true;
+    },
+  }) as unknown as RestClientInstance;
 
-  // GirderAPI exposes `histogramsLoaded` as a reactive field that
-  // `layerStackImages` getter depends on (see line ~2224). markRaw'ing it
-  // would break that reactivity and leave the layer list empty forever.
-  // The other API classes have no externally-read reactive state, so
-  // markRaw'ing them avoids the per-method-call Proxy.get cost.
+  // The API instances stay reactive: GirderAPI exposes `histogramsLoaded`
+  // that `layerStackImages` depends on; the others may grow similar
+  // reactive fields. The actual Proxy-overhead concern from the diagnostic
+  // was the heavy Maps inside GirderAPI (imageCache, histogramCache,
+  // resolvedHistogramCache) — those are markRaw'd at their declaration in
+  // GirderAPI.ts, which keeps Map.get/set out of Vue's reactive interceptor
+  // without breaking field-level reactivity on the API instance itself.
   api = new GirderAPI(this.girderRestProxy);
-  annotationsAPI = markRaw(new AnnotationsAPI(this.girderRestProxy));
-  propertiesAPI = markRaw(new PropertiesAPI(this.girderRestProxy));
-  chatAPI = markRaw(new ChatAPI(this.girderRestProxy));
-  exportAPI = markRaw(new ExportAPI(this.girderRestProxy));
-  projectsAPI = markRaw(new ProjectsAPI(this.girderRestProxy));
-  zenodoAPI = markRaw(new ZenodoAPI(this.girderRestProxy));
+  annotationsAPI = new AnnotationsAPI(this.girderRestProxy);
+  propertiesAPI = new PropertiesAPI(this.girderRestProxy);
+  chatAPI = new ChatAPI(this.girderRestProxy);
+  exportAPI = new ExportAPI(this.girderRestProxy);
+  projectsAPI = new ProjectsAPI(this.girderRestProxy);
+  zenodoAPI = new ZenodoAPI(this.girderRestProxy);
 
   readonly girderResources = girderResources;
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -129,7 +129,12 @@ export class Main extends VuexModule {
     }) as unknown as RestClientInstance,
   );
 
-  api = markRaw(new GirderAPI(this.girderRestProxy));
+  // GirderAPI exposes `histogramsLoaded` as a reactive field that
+  // `layerStackImages` getter depends on (see line ~2224). markRaw'ing it
+  // would break that reactivity and leave the layer list empty forever.
+  // The other API classes have no externally-read reactive state, so
+  // markRaw'ing them avoids the per-method-call Proxy.get cost.
+  api = new GirderAPI(this.girderRestProxy);
   annotationsAPI = markRaw(new AnnotationsAPI(this.girderRestProxy));
   propertiesAPI = markRaw(new PropertiesAPI(this.girderRestProxy));
   chatAPI = markRaw(new ChatAPI(this.girderRestProxy));

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -527,6 +527,11 @@ export class Main extends VuexModule {
     // every map-access in the canvas hot path is a Proxy.get otherwise.
     // The outer array stays reactive so push/pop and length changes still
     // trigger watchers (ImageViewer mutates maps.value.pop() in place).
+    //
+    // Note: markRaw(m) tags `m` itself by setting `__v_skip` — i.e., it
+    // mutates the elements of the input array. In-practice unobservable
+    // since the only caller (_setupMap) discards its array reference
+    // immediately after, but worth knowing if a future caller reuses it.
     this.maps = maps.map((m) => markRaw(m));
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,7 @@ import {
   Mutation,
   VuexModule,
 } from "vuex-module-decorators";
+import { markRaw } from "vue";
 
 import AnnotationsAPI from "./AnnotationsAPI";
 import PropertiesAPI from "./PropertiesAPI";
@@ -100,31 +101,41 @@ function apiRootFromGirderUrl(girderUrl: string) {
 
 @Module({ dynamic: true, store, name: "main" })
 export class Main extends VuexModule {
-  girderRest = new RestClient({
-    apiRoot: apiRootFromGirderUrl(persister.get("girderUrl", defaultGirderUrl)),
-  });
+  // RestClient and the API class instances hold heavy non-Vue state — Axios
+  // clients, in-memory Maps used as caches, etc. Wrap them with `markRaw` so
+  // Vuex's reactive() doesn't deep-Proxy them and pay trap overhead on every
+  // method call. Each one is a stable reference; they're never replaced.
+  girderRest = markRaw(
+    new RestClient({
+      apiRoot: apiRootFromGirderUrl(
+        persister.get("girderUrl", defaultGirderUrl),
+      ),
+    }),
+  );
 
   // Use a proxy to dynamically resolve to the right girderRest client
-  girderRestProxy = new Proxy(this, {
-    get(obj: Main, prop: keyof RestClientInstance) {
-      return obj.girderRest[prop];
-    },
-    set(target: Main, p: keyof RestClientInstance, newValue: any) {
-      if (p != "token") {
-        throw "Can only set token to RestClient";
-      }
-      target.girderRest[p] = newValue;
-      return true;
-    },
-  }) as unknown as RestClientInstance;
+  girderRestProxy = markRaw(
+    new Proxy(this, {
+      get(obj: Main, prop: keyof RestClientInstance) {
+        return obj.girderRest[prop];
+      },
+      set(target: Main, p: keyof RestClientInstance, newValue: any) {
+        if (p != "token") {
+          throw "Can only set token to RestClient";
+        }
+        target.girderRest[p] = newValue;
+        return true;
+      },
+    }) as unknown as RestClientInstance,
+  );
 
-  api = new GirderAPI(this.girderRestProxy);
-  annotationsAPI = new AnnotationsAPI(this.girderRestProxy);
-  propertiesAPI = new PropertiesAPI(this.girderRestProxy);
-  chatAPI = new ChatAPI(this.girderRestProxy);
-  exportAPI = new ExportAPI(this.girderRestProxy);
-  projectsAPI = new ProjectsAPI(this.girderRestProxy);
-  zenodoAPI = new ZenodoAPI(this.girderRestProxy);
+  api = markRaw(new GirderAPI(this.girderRestProxy));
+  annotationsAPI = markRaw(new AnnotationsAPI(this.girderRestProxy));
+  propertiesAPI = markRaw(new PropertiesAPI(this.girderRestProxy));
+  chatAPI = markRaw(new ChatAPI(this.girderRestProxy));
+  exportAPI = markRaw(new ExportAPI(this.girderRestProxy));
+  projectsAPI = markRaw(new ProjectsAPI(this.girderRestProxy));
+  zenodoAPI = markRaw(new ZenodoAPI(this.girderRestProxy));
 
   readonly girderResources = girderResources;
 
@@ -514,7 +525,12 @@ export class Main extends VuexModule {
 
   @Mutation
   public setMaps(maps: IMapEntry[]) {
-    this.maps = maps;
+    // Each entry already markRaws its inner GeoJS layers, but the IMapEntry
+    // wrapper itself would still be Proxy-wrapped on assignment. Skip that —
+    // every map-access in the canvas hot path is a Proxy.get otherwise.
+    // The outer array stays reactive so push/pop and length changes still
+    // trigger watchers (ImageViewer mutates maps.value.pop() in place).
+    this.maps = maps.map((m) => markRaw(m));
   }
 
   @Mutation

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -64,7 +64,12 @@ export class Properties extends VuexModule {
 
   displayedPropertyPaths: string[][] = [];
 
-  propertyValues: IAnnotationPropertyValues = {};
+  // Largest mutable structure in the app (annotations × properties). The
+  // mutation that replaces it already wraps with markRaw, but the initial
+  // empty object would still go through Vuex's reactive() at module init.
+  // Mark it raw at declaration so first-load assignment doesn't proxy-walk
+  // the whole tree.
+  propertyValues: IAnnotationPropertyValues = markRaw({});
 
   propertyStatuses: {
     [propertyId: string]: IPropertyStatus;


### PR DESCRIPTION
## Summary

Targets the structural reactivity overhead from vuex-module-decorators wrapping every state field in a deep Proxy, plus a deep watcher and a GeoJS handler-accumulation issue surfaced in an external perf diagnostic.

- **`markRaw` the heavy GirderAPI caches** (`imageCache`, `histogramCache`, `resolvedHistogramCache`) at their declaration so Vue's reactive Map interceptor doesn't track every `.get` / `.set` on the per-tile-fetch hot path. The API instances themselves stay reactive (`histogramsLoaded` gates the `layerStackImages` getter — the v1 attempt to markRaw the whole instance broke initial render).
- **`markRaw` each `IMapEntry` in `setMaps`** so the canvas hot path (every read of `mapentry.map` / `.annotationLayer`) doesn't go through a Proxy. The outer maps array stays reactive so push/pop still trigger watchers.
- **`markRaw` `propertyValues` at declaration** in the properties store — largest mutable structure in the app, was getting proxy-walked at module init before the first mutation reassigned it.
- **Replace `{ deep: true }` watcher on `capturedMouseState`** with two cheap watchers (identity transitions + `path.length` growth). The deep version recursively dirty-checked the whole `IMouseState` graph (which includes the entire `IMapEntry` → GeoJS map) on every mouse event.
- **`shallowRef` the eight `IGeoJSAnnotation` refs in `AnnotationViewer`** plus `samMapEntry` in `ImageViewer`. They hold heavy native GeoJS objects whose internals must not be Proxy-wrapped.
- **`geoOff` cleanup before `geoOn` rebinds** in `bindAnnotationEvents` / `bindInteractionEvents` / `bindTimelapseEvents`, so handlers don't accumulate across layer-prop rebuilds (e.g., dataset reset). Extracted the inline mouseclick handler so it has a stable reference for `geoOff`.
- Comments on the trade-offs flagged during code review (asymmetric bind/unbind, two-watcher swap double-fire, `setMaps` mutating its input array elements).

## Out of scope (filed as follow-ups)

- #1134 — `maps.value.pop()` / `maps.value = []` mutating Vuex state in place.
- #1135 — Stale `histogramsLoaded` fields on `AnnotationsAPI` / `PropertiesAPI`.
- #1136 — Per-annotation `structuredClone` in multi-update is slow.

Per-the-original-diagnostic, intentionally **not addressed here**: ONNX runtime CPU fallback, plain `v-data-table` → `v-data-table-virtual`.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint:ci` clean (zero warnings)
- [x] `pnpm test` — 2118/2118 pass (1 pre-existing unrelated rejection in `NewDataset.test.ts`, also present on master)
- [x] Manual: image renders on initial page load on `/datasetView/:id/view`
- [x] Manual: time-slider scrub works
- [ ] Manual: 20-minute session to confirm the GeoJS handler-accumulation fix actually relieves the long-session sluggishness reported in the diagnostic
- [ ] Manual: dataset switch (triggers layer-prop watchers and the new unbind-old / bind-new path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)