### PR TITLE
Increase worker progress bar min-height so text isn't clipped

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationProperties/Property.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/Property.vue
@@ -147,8 +147,8 @@ defineExpose({ status, uncomputed, filteredErrors, filteredWarnings, compute });
 <style lang="scss">
 .text-progress {
   height: fit-content;
-  min-height: 10px;
-  padding: 4px;
+  min-height: 28px;
+  padding: 4px 8px;
 }
 
 .text-progress .v-progress-linear__content {

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -159,7 +159,7 @@
             <v-progress-linear
               :model-value="batchProgressPercent"
               color="primary"
-              height="20"
+              height="28"
               striped
             >
               <template v-slot:default>


### PR DESCRIPTION
## Summary
- Bump `.text-progress` `min-height` from `10px` to `28px` (and widen padding to `4px 8px`) in `Property.vue` so the title/info text rendered inside the bar isn't obscured. The class is unscoped, so this also fixes the running-progress bar in `AnnotationWorkerMenu.vue` that reuses it.
- Bump the batch progress bar in `AnnotationWorkerMenu.vue` from `height="20"` to `height="28"` to match.
- `height: fit-content` was already on `.text-progress`, so the bar still grows when text wraps — `min-height` only sets the floor.

## Test plan
- [ ] Run a worker tool from `AnnotationWorkerMenu` and confirm the progress bar shows the title and info text without clipping.
- [ ] Run a property computation from `AnalyzePanel` (Property row) and confirm the progress bar text is fully visible.
- [ ] Run a batch (apply-to-all-datasets) job and confirm the batch progress bar shows the percentage clearly.
- [ ] `pnpm tsc` and `pnpm lint` pass (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)