### PR TITLE
Fix unselectable checkboxes in tool configuration

### DIFF
--- a/src/tools/creation/ToolConfigurationItem.vue
+++ b/src/tools/creation/ToolConfigurationItem.vue
@@ -11,7 +11,7 @@
             <component
               :is="typeToComponentName[item.type]"
               :advanced="advanced"
-              v-bind="item.meta"
+              v-bind="boundMeta"
               v-model="componentValue"
               ref="innerComponent"
               return-object
@@ -85,6 +85,17 @@ const componentValue = computed({
   set(newValue: any) {
     emit("update:modelValue", newValue);
   },
+});
+
+// `meta.value` is the default-value seed consumed by ToolConfiguration's
+// setDefaultValues — it must not fall through to the rendered component.
+// On VCheckbox (VSelectionControl), a `value` prop redefines trueValue/falseValue
+// and breaks the checked-state toggle.
+const boundMeta = computed(() => {
+  if (!props.item.meta) return {};
+  return Object.fromEntries(
+    Object.entries(props.item.meta).filter(([key]) => key !== "value"),
+  );
 });
 
 const innerComponent = ref<any>(null);


### PR DESCRIPTION
## Summary
- `ToolConfigurationItem.vue` was spreading `item.meta` directly onto the rendered component via `v-bind`. For checkboxes whose template metadata includes a default `value` (e.g. the "Add job date tag" option in the Automated tools template), Vuetify's `VSelectionControl` interpreted that `value` as the value-when-checked: `trueValue` and `falseValue` both collapsed to `false`, so the box rendered permanently checked and clicks couldn't toggle it.
- `meta.value` is meant only as a default-value seed for `setDefaultValues` in `ToolConfiguration.vue` — strip it before binding so it never falls through as a prop.
- Same class of prop-fallthrough bug as P13 in `codebaseDocumentation/VUE3_STEPS.md` (`size="small"` on VCheckbox).

## Test plan
- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm test -- --run src/tools/creation/ToolConfiguration.test.ts` (18/18 pass)
- [x] Manually verify the "Add job date tag" checkbox in the Automated tools dialog toggles on/off
- [x] Verify other checkboxes (turbo mode, override connections, remove existing tags) still toggle correctly and pick up their default values

🤖 Generated with [Claude Code](https://claude.com/claude-code)