### PR TITLE
Fix unselectable checkboxes; polish JSON import dialog

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationImport.vue
+++ b/src/components/AnnotationBrowser/AnnotationImport.vue
@@ -4,6 +4,7 @@
       <v-btn
         v-bind="{ ...activatorProps, ...$attrs }"
         :disabled="!isLoggedIn"
+        :color="showSuccess ? 'success' : undefined"
         v-description="{
           section: 'Object list actions',
           title: 'Import from JSON',
@@ -11,8 +12,20 @@
             'Import a set of annotations and connections from a JSON file',
         }"
       >
-        <v-icon>mdi-import</v-icon>
-        Import from JSON
+        <v-fade-transition leave-absolute>
+          <span
+            v-if="showSuccess"
+            key="success"
+            class="d-inline-flex align-center"
+          >
+            <v-icon class="mr-1">mdi-check-circle</v-icon>
+            Imported
+          </span>
+          <span v-else key="default" class="d-inline-flex align-center">
+            <v-icon class="mr-1">mdi-import</v-icon>
+            Import from JSON
+          </span>
+        </v-fade-transition>
       </v-btn>
     </template>
     <v-card class="pa-2" :disabled="!canImport">
@@ -20,8 +33,11 @@
       <v-card-text class="pt-5 pb-0">
         <v-file-input
           accept="application/JSON"
-          prepend-icon="mdi-code-json"
-          label="JSON file"
+          prepend-icon=""
+          prepend-inner-icon="mdi-file-upload-outline"
+          variant="outlined"
+          label="Click to upload a JSON file"
+          show-size
           v-model="jsonFile"
         />
         <v-progress-circular v-if="isLoadingFile" indeterminate />
@@ -136,7 +152,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, onBeforeUnmount } from "vue";
 import store from "@/store";
 import annotationStore from "@/store/annotation";
 import propertyStore from "@/store/properties";
@@ -175,6 +191,26 @@ const overwriteAnnotationsDialog = ref(false);
 
 const overwriteProperties = ref(false);
 const overwritePropertiesDialog = ref(false);
+
+const showSuccess = ref(false);
+let successTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flashSuccess() {
+  showSuccess.value = true;
+  if (successTimer) {
+    clearTimeout(successTimer);
+  }
+  successTimer = setTimeout(() => {
+    showSuccess.value = false;
+    successTimer = null;
+  }, 2500);
+}
+
+onBeforeUnmount(() => {
+  if (successTimer) {
+    clearTimeout(successTimer);
+  }
+});
 
 const canImport = computed(() => !!store.dataset);
 const isLoggedIn = computed(() => store.isLoggedIn);
@@ -252,6 +288,7 @@ async function submit() {
   try {
     await importAnnotationsFromData(serializedData, options);
     reset();
+    flashSuccess();
   } catch (error) {
     logError("Error importing annotations:", error);
   } finally {


### PR DESCRIPTION
## Summary
- Fix tool-configuration checkboxes that appeared visually selectable but never toggled. The template-level `meta.value` (a default-value seed consumed by `setDefaultValues`) was falling through onto the rendered component; on `VCheckbox`/`VSelectionControl` a `value` prop redefines `trueValue`/`falseValue` and breaks the checked toggle. `ToolConfigurationItem.vue` now strips `value` out of `meta` before binding.
- Clean up the "Import from JSON" dialog: replace the floating `mdi-code-json` glyph + generic "JSON file" label with an outlined file input, an `mdi-file-upload-outline` icon inside the field, and a clearer "Click to upload a JSON file" label (with file-size readout).
- After a successful import, the activator button briefly turns green with a check icon so the action has visible feedback before the dialog closes; the timer is cleared on unmount.

## Test plan
- [ ] Open a tool whose template defines a checkbox interface element with a default `meta.value` (e.g., a worker tool with a boolean option). Verify the checkbox toggles when clicked.
- [ ] Open the annotation browser → Actions → Import from JSON. Confirm the dialog shows an outlined input with an upload icon inside, no `{...}` glyph next to the field.
- [ ] Pick a valid JSON export and import it. After the dialog closes, the "Import from JSON" button briefly shows a green check + "Imported" before reverting.
- [ ] `pnpm tsc` and `pnpm test src/components/AnnotationBrowser/AnnotationImport.test.ts` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)