### PR TITLE
Fix Recent Jobs dialog layout regressed by Vuetify 4 migration

### DIFF
--- a/src/components/JobsLogs.test.ts
+++ b/src/components/JobsLogs.test.ts
@@ -68,18 +68,6 @@ describe("JobsLogs", () => {
     expect((wrapper.vm as any).getStatusText(999)).toBe("Unknown");
   });
 
-  it("getFirstArg returns first arg", () => {
-    const wrapper = mountComponent();
-    expect((wrapper.vm as any).getFirstArg({ args: ["image1", "arg2"] })).toBe(
-      "image1",
-    );
-  });
-
-  it("getFirstArg returns empty for no args", () => {
-    const wrapper = mountComponent();
-    expect((wrapper.vm as any).getFirstArg({ args: [] })).toBe("");
-  });
-
   it("getDuration calculates from timestamps", () => {
     const wrapper = mountComponent();
     const result = (wrapper.vm as any).getDuration({
@@ -102,7 +90,7 @@ describe("JobsLogs", () => {
 
   it("headers has expected columns", () => {
     const wrapper = mountComponent();
-    expect((wrapper.vm as any).headers).toHaveLength(8);
+    expect((wrapper.vm as any).headers).toHaveLength(7);
     expect((wrapper.vm as any).headers[0].title).toBe("Title");
   });
 });

--- a/src/components/JobsLogs.vue
+++ b/src/components/JobsLogs.vue
@@ -17,31 +17,35 @@
 
         <v-dialog
           v-model="showJobsDialog"
-          min-width="800px"
-          max-width="1200px"
-          width="90%"
+          width="90vw"
+          max-width="1400px"
+          class="jobs-logs-dialog"
         >
           <v-card>
-            <v-card-title class="headline">
-              Recent Jobs
+            <v-toolbar density="compact" color="transparent">
+              <v-toolbar-title>Recent Jobs</v-toolbar-title>
               <v-spacer></v-spacer>
               <v-tooltip location="bottom">
                 <template #activator="{ props: activatorProps }">
                   <v-btn
-                    icon
+                    icon="mdi-refresh"
+                    variant="text"
+                    size="small"
                     v-bind="activatorProps"
                     @click="fetchJobs"
                     :loading="loading"
-                  >
-                    <v-icon>mdi-refresh</v-icon>
-                  </v-btn>
+                  />
                 </template>
                 <span>Refresh jobs</span>
               </v-tooltip>
-              <v-btn icon @click="showJobsDialog = false">
-                <v-icon>mdi-close</v-icon>
-              </v-btn>
-            </v-card-title>
+              <v-btn
+                icon="mdi-close"
+                variant="text"
+                size="small"
+                class="mr-2"
+                @click="showJobsDialog = false"
+              />
+            </v-toolbar>
             <v-card-text>
               <v-data-table
                 :headers="headers"
@@ -61,9 +65,6 @@
                 </template>
                 <template #[`item.created`]="{ item }">
                   {{ formatDateString(item.created) }}
-                </template>
-                <template #[`item.firstArg`]="{ item }">
-                  {{ getFirstArg(item) }}
                 </template>
                 <template #[`item.endTime`]="{ item }">
                   {{ getEndTime(item) }}
@@ -88,40 +89,51 @@
         </v-dialog>
 
         <!-- Job Log Dialog -->
-        <v-dialog v-model="showLogDialog" max-width="800px">
+        <v-dialog
+          v-model="showLogDialog"
+          width="80vw"
+          max-width="1000px"
+          class="jobs-logs-dialog"
+        >
           <v-card>
-            <v-card-title class="headline">
-              Job Log: {{ selectedJob ? selectedJob.title : "" }}
+            <v-toolbar density="compact" color="transparent">
+              <v-toolbar-title>
+                Job Log: {{ selectedJob ? selectedJob.title : "" }}
+              </v-toolbar-title>
               <v-spacer></v-spacer>
               <v-tooltip location="bottom">
                 <template #activator="{ props: activatorProps }">
                   <v-btn
-                    icon
+                    icon="mdi-content-copy"
+                    variant="text"
+                    size="small"
                     v-bind="activatorProps"
                     @click="copyLogToClipboard"
-                  >
-                    <v-icon>mdi-content-copy</v-icon>
-                  </v-btn>
+                  />
                 </template>
                 <span>Copy to clipboard</span>
               </v-tooltip>
               <v-tooltip location="bottom">
                 <template #activator="{ props: activatorProps }">
                   <v-btn
-                    icon
+                    icon="mdi-refresh"
+                    variant="text"
+                    size="small"
                     v-bind="activatorProps"
                     @click="refreshLog"
                     :loading="refreshingLog"
-                  >
-                    <v-icon>mdi-refresh</v-icon>
-                  </v-btn>
+                  />
                 </template>
                 <span>Refresh log</span>
               </v-tooltip>
-              <v-btn icon @click="showLogDialog = false">
-                <v-icon>mdi-close</v-icon>
-              </v-btn>
-            </v-card-title>
+              <v-btn
+                icon="mdi-close"
+                variant="text"
+                size="small"
+                class="mr-2"
+                @click="showLogDialog = false"
+              />
+            </v-toolbar>
             <v-card-text>
               <pre class="job-log">{{ currentJobLog }}</pre>
             </v-card-text>
@@ -205,7 +217,6 @@ const refreshingLog = ref(false);
 
 const headers = [
   { title: "Title", key: "title" },
-  { title: "Image", key: "firstArg" },
   { title: "Type", key: "type" },
   { title: "Status", key: "status" },
   { title: "Started", key: "created" },
@@ -249,10 +260,6 @@ function getJobState(status: number): string {
     return jobLogStatus[status].stateText;
   }
   return "Job status: " + getStatusText(status);
-}
-
-function getFirstArg(job: IJob): string {
-  return job.args && job.args.length > 0 ? job.args[0] : "";
 }
 
 function getEndTime(job: any): string {
@@ -376,7 +383,6 @@ defineExpose({
   showJobsDialog,
   getStatusColor,
   getStatusText,
-  getFirstArg,
   getDuration,
   headers,
 });
@@ -395,5 +401,13 @@ defineExpose({
   border-radius: 4px;
   width: 100%;
   color: rgba(255, 255, 255, 0.85);
+}
+</style>
+<style>
+/* Unscoped: v-dialog teleports to body-level overlay container.
+   Vuetify 4 defaults .v-dialog { width: 50% } on the outer overlay,
+   so the `width` prop only applies within that 50% box. (See VUE3_STEPS.md P14) */
+.jobs-logs-dialog.v-dialog {
+  width: auto;
 }
 </style>


### PR DESCRIPTION
## Summary
- Replace `v-card-title` flex hack with `v-toolbar density="compact"` so the title and refresh/close icon buttons sit inline at the top right (Vuetify 4 stopped auto-flexing `v-card-title` children, which caused buttons to wrap below the title)
- Shrink the header icon buttons via `icon="mdi-..." variant="text" size="small"` so they aren't comically large
- Widen both dialogs (`90vw` / `80vw` with `max-width` caps) and add the documented `.v-dialog { width: auto }` unscoped override (VUE3_STEPS.md P14) — without it Vuetify 4's default `.v-dialog { width: 50% }` makes the `width` prop apply only inside a half-viewport box
- Drop the always-empty "Image" column from the data table (`args[0]` isn't populated for `large_image_*` jobs, which dominate the list)

## Test plan
- [ ] Open Settings → Jobs and Logs → "Show Jobs and Logs"; dialog spans ~90vw on a wide viewport, columns aren't clipped
- [ ] Header shows "Recent Jobs" with small refresh + close icon buttons aligned top-right
- [ ] Click refresh; jobs reload, button shows loading spinner
- [ ] Click "Log" on a row; Job Log dialog opens at ~80vw with copy/refresh/close icon buttons in the toolbar
- [ ] `pnpm tsc` clean, `pnpm vitest run src/components/JobsLogs.test.ts` passes (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)