### PR TITLE
[codex] Remove stale histogramsLoaded fields

### DIFF
--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -23,8 +23,6 @@ export default class AnnotationsAPI {
     this.client = client;
   }
 
-  histogramsLoaded = 0;
-
   undo(datasetId: string) {
     return this.client.put("history/undo", undefined, {
       params: { datasetId },

--- a/src/store/PropertiesAPI.ts
+++ b/src/store/PropertiesAPI.ts
@@ -29,8 +29,6 @@ export default class PropertiesAPI {
     this.client = client;
   }
 
-  histogramsLoaded = 0;
-
   async createProperty(
     property: IAnnotationPropertyConfiguration,
   ): Promise<IAnnotationProperty> {


### PR DESCRIPTION
## Summary

Removes the stale `histogramsLoaded` public fields from `AnnotationsAPI` and `PropertiesAPI`. These fields were copy-paste residue from `GirderAPI`; the remaining `histogramsLoaded` references are the real reactive state used by `GirderAPI` and the layer stack getters.

Closes #1135.

## Validation

- `rg -n "histogramsLoaded" src`
- `pnpm tsc`