### PR TITLE
[codex] Fix ImageViewer map mutations

### DIFF
--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -112,6 +112,7 @@ vi.mock("@/store", () => {
       drawAnnotations: true,
       showTooltips: false,
       setMaps: vi.fn(),
+      setMapAt: vi.fn(),
       popMap: vi.fn(),
       clearMaps: vi.fn(),
       setCameraInfo: vi.fn(),
@@ -304,6 +305,13 @@ describe("ImageViewer", () => {
     (mockedStore.setMaps as any).mockImplementation((v: any) => {
       mockedStore.maps = v;
     });
+    (mockedStore.setMapAt as any).mockImplementation(
+      ({ index, mapEntry }: any) => {
+        const maps = [...mockedStore.maps];
+        maps[index] = mapEntry;
+        mockedStore.maps = maps;
+      },
+    );
     (mockedStore.popMap as any).mockImplementation(() => {
       mockedStore.maps = mockedStore.maps.slice(0, -1);
     });

--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -112,6 +112,8 @@ vi.mock("@/store", () => {
       drawAnnotations: true,
       showTooltips: false,
       setMaps: vi.fn(),
+      popMap: vi.fn(),
+      clearMaps: vi.fn(),
       setCameraInfo: vi.fn(),
       setDrawAnnotations: vi.fn(),
       setShowTooltips: vi.fn(),
@@ -302,6 +304,12 @@ describe("ImageViewer", () => {
     (mockedStore.setMaps as any).mockImplementation((v: any) => {
       mockedStore.maps = v;
     });
+    (mockedStore.popMap as any).mockImplementation(() => {
+      mockedStore.maps = mockedStore.maps.slice(0, -1);
+    });
+    (mockedStore.clearMaps as any).mockImplementation(() => {
+      mockedStore.maps = [];
+    });
     (mockedStore.setCameraInfo as any).mockImplementation((v: any) => {
       mockedStore.cameraInfo = v;
     });
@@ -337,12 +345,12 @@ describe("ImageViewer", () => {
       // Clear any calls from mount
       map1.exit.mockClear();
       map2.exit.mockClear();
-      (mockedStore.setMaps as any).mockClear();
+      (mockedStore.clearMaps as any).mockClear();
       // Trigger onBeforeUnmount
       wrapper.unmount();
       expect(map1.exit).toHaveBeenCalled();
       expect(map2.exit).toHaveBeenCalled();
-      expect(mockedStore.setMaps).toHaveBeenCalledWith([]);
+      expect(mockedStore.clearMaps).toHaveBeenCalledOnce();
     });
 
     it("calls draw on mount when dataset and layers exist", () => {
@@ -1123,6 +1131,28 @@ describe("ImageViewer", () => {
       // draw runs on mount
       expect((wrapper.vm as any).tileWidth).toBe(256);
       expect((wrapper.vm as any).tileHeight).toBe(256);
+    });
+
+    it("shrinks excess maps through the store", () => {
+      const map1 = mockMap();
+      const map2 = mockMap();
+      const removedMaps: any[] = [];
+      (mockedStore.popMap as any).mockImplementation(() => {
+        removedMaps.push(mockedStore.maps[mockedStore.maps.length - 1]);
+        mockedStore.maps = mockedStore.maps.slice(0, -1);
+      });
+      mockedStore.maps = [
+        { map: map1, imageLayers: [], params: {} } as any,
+        { map: map2, imageLayers: [], params: {} } as any,
+      ];
+      mockedStore.layerStackImages = [createLayerStackImage()];
+
+      wrapper = mountComponent();
+
+      expect(map2.exit).toHaveBeenCalled();
+      expect(mockedStore.popMap).toHaveBeenCalledOnce();
+      expect(removedMaps[0].map.exit).toBe(map2.exit);
+      expect(mockedStore.maps).toHaveLength(1);
     });
   });
 

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -885,9 +885,7 @@ function _setupMap(
       workerPreviewFeature,
       interactionLayer,
     };
-    const newMaps = [...maps.value];
-    newMaps[mllidx] = mapentry;
-    maps.value = newMaps;
+    store.setMapAt({ index: mllidx, mapEntry: mapentry });
   } else {
     const mapentry = maps.value[mllidx];
     mapentry.params = markRaw(params);
@@ -1181,10 +1179,7 @@ function draw() {
 
   const currentMapLayerList = mapLayerList.value;
   while (maps.value.length > currentMapLayerList.length) {
-    const mapentry = maps.value[maps.value.length - 1];
-    if (mapentry) {
-      mapentry.map.exit();
-    }
+    maps.value.at(-1)?.map.exit();
     store.popMap();
   }
   let baseLayerIndex = 0;

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -1181,10 +1181,11 @@ function draw() {
 
   const currentMapLayerList = mapLayerList.value;
   while (maps.value.length > currentMapLayerList.length) {
-    const mapentry = maps.value.pop();
+    const mapentry = maps.value[maps.value.length - 1];
     if (mapentry) {
       mapentry.map.exit();
     }
+    store.popMap();
   }
   let baseLayerIndex = 0;
   const currentResetMaps = resetMapsOnDraw.value;
@@ -1431,7 +1432,7 @@ onBeforeUnmount(() => {
   }
   if (maps.value) {
     maps.value.forEach((mapentry) => mapentry.map.exit());
-    maps.value = [];
+    store.clearMaps();
   }
 });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -537,9 +537,15 @@ export class Main extends VuexModule {
     //
     // Note: markRaw(m) tags `m` itself by setting `__v_skip` — i.e., it
     // mutates the elements of the input array. In-practice unobservable
-    // since the only caller (_setupMap) discards its array reference
-    // immediately after, but worth knowing if a future caller reuses it.
+    // since callers should not rely on entries staying unmarked.
     this.maps = maps.map((m) => markRaw(m));
+  }
+
+  @Mutation
+  public setMapAt(payload: { index: number; mapEntry: IMapEntry }) {
+    const maps = [...this.maps];
+    maps[payload.index] = markRaw(payload.mapEntry);
+    this.maps = maps;
   }
 
   @Mutation

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -526,14 +526,24 @@ export class Main extends VuexModule {
     // Each entry already markRaws its inner GeoJS layers, but the IMapEntry
     // wrapper itself would still be Proxy-wrapped on assignment. Skip that —
     // every map-access in the canvas hot path is a Proxy.get otherwise.
-    // The outer array stays reactive so push/pop and length changes still
-    // trigger watchers (ImageViewer mutates maps.value.pop() in place).
+    // The outer array stays reactive so mutation handlers and replacements
+    // still trigger watchers.
     //
     // Note: markRaw(m) tags `m` itself by setting `__v_skip` — i.e., it
     // mutates the elements of the input array. In-practice unobservable
     // since the only caller (_setupMap) discards its array reference
     // immediately after, but worth knowing if a future caller reuses it.
     this.maps = maps.map((m) => markRaw(m));
+  }
+
+  @Mutation
+  public popMap() {
+    this.maps = this.maps.slice(0, -1);
+  }
+
+  @Mutation
+  public clearMaps() {
+    this.maps = [];
   }
 
   @Mutation


### PR DESCRIPTION
## Summary

- Add explicit `setMapAt`, `popMap`, and `clearMaps` mutations for the main store's Vuex-managed `maps` array.
- Update `ImageViewer` map creation/replacement, draw shrink, and unmount cleanup paths to exit GeoJS maps as needed, then mutate `maps` through the store API.
- Update `ImageViewer` tests to cover the new mutation calls for cleanup and shrinking excess maps.

Fixes #1134.

## Validation

- `pnpm vitest run src/components/ImageViewer.test.ts --silent`
- `pnpm tsc`
- `pnpm eslint --ext .js,.ts,.vue --ignore-path .gitignore src/components/ImageViewer.vue src/components/ImageViewer.test.ts src/store/index.ts`

Note: Vitest logs a sandbox websocket `EPERM` warning while trying to bind `0.0.0.0:24678`, but the test run exits successfully with 107 passing tests.