### PR TITLE
[codex] Add quota warning to app bar

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/store", () => ({
   default: {
     isLoggedIn: false,
     girderUser: null,
+    userQuota: null,
     dataset: null,
     setToolTemplateList: vi.fn(),
     setIsAnnotationPanelOpen: vi.fn(),
@@ -97,6 +98,7 @@ describe("App", () => {
     // Reset store mocks
     (store as any).isLoggedIn = false;
     (store as any).girderUser = null;
+    (store as any).userQuota = null;
     (store as any).dataset = null;
     (store as any).setToolTemplateList = vi.fn();
     (store as any).setIsAnnotationPanelOpen = vi.fn();
@@ -201,6 +203,41 @@ describe("App", () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as any;
     expect(vm.hasUncomputedProperties).toBe(false);
+  });
+
+  it("shows quota warning when usage is within 100 MB of the limit", () => {
+    (store as any).userQuota = {
+      used: 950 * 1024 * 1024,
+      limit: 1024 * 1024 * 1024,
+    };
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    expect(vm.isNearUserQuota).toBe(true);
+    expect(vm.showQuotaWarning).toBe(true);
+    expect(vm.quotaWarningMessage).toContain("Your usage is 950.00 MB out of");
+  });
+
+  it("does not show quota warning when usage is more than 100 MB below the limit", () => {
+    (store as any).userQuota = {
+      used: 800 * 1024 * 1024,
+      limit: 1024 * 1024 * 1024,
+    };
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    expect(vm.isNearUserQuota).toBe(false);
+    expect(vm.showQuotaWarning).toBe(false);
+  });
+
+  it("dismisses quota warning for the current near-quota state", async () => {
+    (store as any).userQuota = {
+      used: 950 * 1024 * 1024,
+      limit: 1024 * 1024 * 1024,
+    };
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.dismissQuotaWarning();
+    await nextTick();
+    expect(vm.showQuotaWarning).toBe(false);
   });
 
   // -- Computed: filteredToursByCategory --

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,6 +90,17 @@
       </h1>
       <bread-crumbs />
       <v-spacer />
+      <v-alert
+        v-if="showQuotaWarning"
+        type="error"
+        density="compact"
+        variant="tonal"
+        closable
+        class="quota-warning ml-4"
+        @click:close="dismissQuotaWarning"
+      >
+        {{ quotaWarningMessage }}
+      </v-alert>
       <v-tooltip text="Upload a new dataset">
         <template v-slot:activator="{ props: activatorProps }">
           <v-btn
@@ -317,6 +328,7 @@ import ChatComponent from "@/components/ChatComponent.vue";
 import { IGirderFolder } from "@/girder";
 import { ITourMetadata } from "./store/model";
 import { useTour } from "@/utils/useTour";
+import { formatSize } from "@/utils/conversion";
 
 // Suppress unused import warnings for template-only components
 void UserMenu;
@@ -346,6 +358,9 @@ const chatbotOpen = ref(false);
 const lastModifiedRightPanel = ref<string | null>(null);
 const isUploadLoading = ref(false);
 const helpPanelIsOpen = ref(false);
+const quotaWarningDismissed = ref(false);
+
+const QUOTA_WARNING_THRESHOLD_BYTES = 100 * 1024 * 1024;
 
 const panelRefs: Record<string, Ref<boolean>> = {
   snapshotPanel,
@@ -413,6 +428,29 @@ const hasUncomputedProperties = computed(() => {
   return false;
 });
 
+const isNearUserQuota = computed(() => {
+  if (!store.userQuota) {
+    return false;
+  }
+  return (
+    store.userQuota.limit - store.userQuota.used <=
+    QUOTA_WARNING_THRESHOLD_BYTES
+  );
+});
+
+const showQuotaWarning = computed(
+  () => isNearUserQuota.value && !quotaWarningDismissed.value,
+);
+
+const quotaWarningMessage = computed(() => {
+  if (!store.userQuota) {
+    return "";
+  }
+  return `Your usage is ${formatSize(store.userQuota.used)} out of ${formatSize(
+    store.userQuota.limit,
+  )}; some functionality may be limited as you approach your quota.`;
+});
+
 const filteredToursByCategory = computed(
   (): Record<string, Record<string, ITourMetadata>> => {
     const tours = availableTours.value;
@@ -448,6 +486,10 @@ function handleTourStart(tourId: string) {
     router.push({ name: tour.entryPoint });
   }
   startTour(tourId);
+}
+
+function dismissQuotaWarning() {
+  quotaWarningDismissed.value = true;
 }
 
 async function goToNewDataset() {
@@ -491,6 +533,11 @@ function datasetChanged() {
 
 watch(annotationPanel, () => annotationPanelChanged());
 watch(routeName, () => datasetChanged());
+watch(isNearUserQuota, (nearQuota) => {
+  if (!nearQuota) {
+    quotaWarningDismissed.value = false;
+  }
+});
 
 onMounted(() => {
   fetchConfig();
@@ -512,6 +559,9 @@ defineExpose({
   appHotkeys,
   routeName,
   hasUncomputedProperties,
+  isNearUserQuota,
+  showQuotaWarning,
+  quotaWarningMessage,
   filteredToursByCategory,
   fetchConfig,
   loadAllTours,
@@ -519,6 +569,7 @@ defineExpose({
   toggleRightPanel,
   toggleHelpDialogUsingHotkey,
   handleTourStart,
+  dismissQuotaWarning,
   goToNewDataset,
 });
 </script>
@@ -528,6 +579,19 @@ defineExpose({
   text-overflow: unset;
   overflow: unset;
   flex: 0 0 auto;
+}
+
+.quota-warning {
+  flex: 1 1 360px;
+  max-width: min(560px, 42vw);
+  min-width: 0;
+  font-size: 0.8125rem;
+}
+
+.quota-warning :deep(.v-alert__content) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>
 <style lang="scss">

--- a/src/components/FileManagerOptions.test.ts
+++ b/src/components/FileManagerOptions.test.ts
@@ -7,6 +7,7 @@ const mockRenameItem = vi.fn();
 const mockDeleteItems = vi.fn();
 const mockDownloadResource = vi.fn();
 const mockMoveFolderToAssetstore = vi.fn();
+const mockRefreshUserQuota = vi.fn();
 
 vi.mock("@/store", () => ({
   default: {
@@ -23,6 +24,7 @@ vi.mock("@/store", () => ({
       moveFolderToAssetstore: (...args: any[]) =>
         mockMoveFolderToAssetstore(...args),
     },
+    refreshUserQuota: (...args: any[]) => mockRefreshUserQuota(...args),
   },
 }));
 
@@ -74,6 +76,7 @@ describe("FileManagerOptions", () => {
     mockDeleteItems.mockResolvedValue(undefined);
     mockDownloadResource.mockResolvedValue(new Blob(["data"]));
     mockMoveFolderToAssetstore.mockResolvedValue(undefined);
+    mockRefreshUserQuota.mockClear();
   });
 
   it("initializes with disableOptions false", () => {
@@ -200,6 +203,7 @@ describe("FileManagerOptions", () => {
     vm.deleteDialog = true;
     await vm.deleteItems();
     expect(mockDeleteItems).toHaveBeenCalledWith(items);
+    expect(mockRefreshUserQuota).toHaveBeenCalled();
     expect(vm.deleteDialog).toBe(false);
     expect(wrapper.emitted("itemsChanged")).toBeTruthy();
   });

--- a/src/components/FileManagerOptions.vue
+++ b/src/components/FileManagerOptions.vue
@@ -196,6 +196,7 @@ function afterMutating() {
   for (const item of props.items) {
     girderResources.ressourceChanged(item._id);
   }
+  store.refreshUserQuota();
   emit("itemsChanged");
 }
 

--- a/src/girder/index.ts
+++ b/src/girder/index.ts
@@ -7,12 +7,20 @@ export interface IGirderAssetstore {
   name: string;
 }
 
+export interface IGirderQuotaPolicy {
+  fileSizeQuota?: number | null;
+  useQuotaDefault?: boolean;
+  _currentFileSizeQuota?: number | null;
+  [key: string]: unknown;
+}
+
 interface IGirderBase {
   _id: string;
   name: string;
   created?: string;
   updated?: string;
   icon?: string;
+  size?: number;
 }
 
 export interface IGirderUser extends IGirderBase {
@@ -27,6 +35,10 @@ export interface IGirderUser extends IGirderBase {
     channelColors?: { [key: string]: string };
     [key: string]: any;
   };
+}
+
+export interface IGirderUserQuota extends IGirderUser {
+  quota: IGirderQuotaPolicy;
 }
 
 export interface IGirderItem extends IGirderBase {

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -10,6 +10,7 @@ import {
   IGirderApiKey,
   IUPennCollection,
   IGirderLocation,
+  IGirderUserQuota,
 } from "@/girder";
 import {
   configurationBaseKeys,
@@ -1024,6 +1025,16 @@ export default class GirderAPI {
     } catch (error) {
       logError("Failed to fetch user API keys");
       return [];
+    }
+  }
+
+  async getUserQuota(userId: string): Promise<IGirderUserQuota | null> {
+    try {
+      const response = await this.client.get(`user/${userId}/quota`);
+      return response.data;
+    } catch (error) {
+      logWarning("Failed to fetch user quota", error);
+      return null;
     }
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -89,6 +89,11 @@ const apiRootSuffix = "/api/v1";
 const defaultGirderUrl =
   import.meta.env.VITE_GIRDER_URL || "http://localhost:8080";
 
+export interface IUserQuotaStatus {
+  used: number;
+  limit: number;
+}
+
 export function girderUrlFromApiRoot(apiRoot: string): string {
   if (apiRoot.endsWith(apiRootSuffix)) {
     return apiRoot.slice(0, apiRoot.length - apiRootSuffix.length);
@@ -138,6 +143,7 @@ export class Main extends VuexModule {
   readonly girderResources = girderResources;
 
   girderUser: IGirderUser | null = this.girderRest.user as IGirderUser | null;
+  userQuota: IUserQuotaStatus | null = null;
   folderLocation: IGirderLocation = this.girderUser || { type: "users" };
   assetstores: IGirderAssetstore[] = [];
   hasUserLoggedOut: boolean = false;
@@ -517,6 +523,11 @@ export class Main extends VuexModule {
   }
 
   @Mutation
+  setUserQuota(userQuota: IUserQuotaStatus | null) {
+    this.userQuota = userQuota;
+  }
+
+  @Mutation
   setFolderLocation(location: IGirderLocation) {
     this.folderLocation = location;
   }
@@ -803,12 +814,14 @@ export class Main extends VuexModule {
           .catch(() => {
             this.setAssetstores([]);
           }),
+        this.refreshUserQuota(),
         this.loadUserColors().catch((error) => {
           logError("Failed to load user colors during login:", error);
         }),
       );
     } else {
       this.setAssetstores([]);
+      this.setUserQuota(null);
     }
     promises.push(
       this.setSelectedConfiguration(this.selectedConfigurationId),
@@ -832,11 +845,31 @@ export class Main extends VuexModule {
   @Mutation
   protected loggedOut() {
     this.girderUser = null;
+    this.userQuota = null;
     this.selectedDatasetId = null;
     this.dataset = null;
     this.selectedConfigurationId = null;
     this.configuration = null;
     this.hasUserLoggedOut = true;
+  }
+
+  @Action
+  async refreshUserQuota() {
+    const user = this.girderUser;
+    if (!user) {
+      this.setUserQuota(null);
+      return;
+    }
+
+    const quotaResource = await this.api.getUserQuota(user._id);
+    const limit = quotaResource?.quota?._currentFileSizeQuota;
+    const used = quotaResource?.size ?? user.size;
+
+    if (typeof limit === "number" && typeof used === "number") {
+      this.setUserQuota({ used, limit });
+    } else {
+      this.setUserQuota(null);
+    }
   }
 
   @Mutation

--- a/src/views/dataset/NewDataset.test.ts
+++ b/src/views/dataset/NewDataset.test.ts
@@ -14,6 +14,7 @@ const mockAddUploadedDataset = vi.fn();
 const mockAdvanceUploadDatasetIndex = vi.fn();
 const mockSetUploadOriginalPath = vi.fn();
 const mockCompleteUploadWorkflow = vi.fn();
+const mockRefreshUserQuota = vi.fn();
 const mockGetFolder = vi.fn().mockResolvedValue({
   _id: "folder2",
   _modelType: "folder",
@@ -85,6 +86,7 @@ vi.mock("@/store", () => ({
       mockSetUploadOriginalPath(...args),
     completeUploadWorkflow: (...args: any[]) =>
       mockCompleteUploadWorkflow(...args),
+    refreshUserQuota: (...args: any[]) => mockRefreshUserQuota(...args),
   },
 }));
 
@@ -238,6 +240,7 @@ describe("NewDataset", () => {
     resetUploadWorkflow();
     mockGetUserApiKeys.mockResolvedValue([]);
     mockCreateDataset.mockResolvedValue(null);
+    mockRefreshUserQuota.mockClear();
     mockGetFolder.mockResolvedValue({
       _id: "folder1",
       _modelType: "folder",

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -999,6 +999,7 @@ function interruptedUpload() {
 function nextStep() {
   hideUploader.value = true;
   uploading.value = false;
+  store.refreshUserQuota();
 
   if (!dataset.value) {
     logError("nextStep called but dataset is null");


### PR DESCRIPTION
## Summary

Adds a dismissible red quota warning to the app bar when a logged-in user's storage usage is within 100 MiB of their configured file-size quota.

## Details

- Fetches quota status from the `girder-user-quota` endpoint at `GET /user/:id/quota` and stores `{ used, limit }` in the main store.
- Refreshes quota status on login, after uploads complete, and after file-manager mutations such as deletes.
- Shows the app-bar message: `Your usage is XXX out of YYY; some functionality may be limited as you approach your quota.`
- Keeps the alert compact, dismissible, and constrained so it does not resize the surrounding app-bar controls.

## Validation

- `pnpm exec eslint src/App.vue src/App.test.ts src/girder/index.ts src/store/GirderAPI.ts src/store/index.ts src/views/dataset/NewDataset.vue src/views/dataset/NewDataset.test.ts src/components/FileManagerOptions.vue src/components/FileManagerOptions.test.ts`
- `pnpm tsc`
- `pnpm test -- --run src/App.test.ts src/components/FileManagerOptions.test.ts`
- `pnpm test -- --run src/App.test.ts src/views/dataset/NewDataset.test.ts src/components/FileManagerOptions.test.ts` (assertions passed; existing Vuetify/jsdom CSS noise and an existing NewDataset quick-upload unhandled rejection are still emitted)
- `pnpm build`