### PR TITLE
Drop vestigial girder mount step from compose

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -3,8 +3,6 @@ FROM girder/tox-and-node-lts:latest
 RUN virtualenv /venv --python=3.11
 ENV PATH=/venv/bin:$PATH
 
-RUN mkdir /mnt/fuse
-
 RUN mkdir /src
 WORKDIR /src
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     build:
       context: ./devops/girder
     privileged: true
-    command: -c "python3 /src/provision.py && girder mount /mnt/fuse && celery -A girder_worker.app worker -Q local -D && uvicorn girder.asgi:app --host 0.0.0.0 --port 8080"
+    command: -c "python3 /src/provision.py && celery -A girder_worker.app worker -Q local -D && uvicorn girder.asgi:app --host 0.0.0.0 --port 8080"
     ports:
       - "${GIRDER_PORT-8080}:8080"
     links:


### PR DESCRIPTION
## Summary

- The Girder 5 upgrade ([#964333d3](https://github.com/arjunrajlaboratory/NimbusImage/commit/964333d3)) dropped the explicit `pip install 'girder[mount]'` but left `girder mount /mnt/fuse` in the chained docker-compose command. Nothing in the project actually uses `/mnt/fuse` — the worker container doesn't share that volume, the assetstore is bind-mounted directly at `/assetstore`, and the AWS deployment uses Girder's native S3 assetstore (no FUSE anywhere).
- This started crashing the container today after the `girder/tox-and-node-lts:latest` base image dropped libfuse2 (Debian's `fuse` apt package became a transitional alias for `fuse3`). `fusepy 3.0.1` only binds libfuse 2.x, so `import fuse` at the top of `girder/cli/mount.py` raises at module load. `click_plugins` catches it as a "Warning: entry point could not be loaded" but the `mount` subcommand never registers, `girder mount /mnt/fuse` then exits non-zero, and the `&&` chain stops before uvicorn ever starts.
- Removing the unused step (and the matching `RUN mkdir /mnt/fuse` in the Dockerfile) restores a working container without needing to install libfuse2 just to immediately not use it.

Upstream Girder bug filed: girder/girder#3814.

This is also relevant to AWS — `AWSDeploy/templates/startup_girder.tftpl` builds from this same Dockerfile on every instance launch, so without this fix the next autoscaling event would have hit the same crash in production.

## Test plan

- [ ] `docker compose build girder && docker compose up` — container reaches `uvicorn` and serves on :8080
- [ ] Frontend at http://localhost:5173 loads, can log in, can view a dataset
- [ ] Worker container connects to broker and reports `ready` (already visible in the original crash log; should still work)
- [ ] Sanity check that no other code path references `/mnt/fuse` (grep is clean in this repo and in `AWSDeploy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)