### PR TITLE
Install libfuse2 so girder mount works after base image transition

### DIFF
--- a/devops/girder/Dockerfile
+++ b/devops/girder/Dockerfile
@@ -1,5 +1,15 @@
 FROM girder/tox-and-node-lts:latest
 
+# fusepy (pulled in by girder[mount]) dlopens libfuse.so.2 at module import
+# time. Recent rebuilds of the base image dropped libfuse2 because Debian's
+# `fuse` apt package became a transitional alias for fuse3, breaking
+# `girder mount` and emitting an entry-point load warning on every CLI call.
+# Install libfuse2 explicitly until fusepy/Girder support libfuse3.
+# See https://github.com/girder/girder/issues/3814
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libfuse2 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN virtualenv /venv --python=3.11
 ENV PATH=/venv/bin:$PATH
 


### PR DESCRIPTION
## Summary

- `girder/tox-and-node-lts:latest` recently stopped shipping `libfuse2` because Debian's `fuse` apt package became a transitional alias for `fuse3`. `fusepy 3.0.1` (pulled in by `girder[mount]`) only binds libfuse 2.x via ctypes, so `import fuse` at the top of `girder/cli/mount.py` now raises `OSError: Unable to find libfuse` at module load time.
- Effects: `click_plugins` catches the error as a "Warning: entry point could not be loaded" on every `girder` CLI invocation (including `girder --help`), the `mount` subcommand never registers, and `girder mount /mnt/fuse` then exits non-zero — breaking the `&&` chain in our docker-compose so uvicorn never starts.
- On AWS the same crash would hit the next EC2 rebuild: `OutsetaLogin`'s `entrypoint.sh` runs `girder mount -o diskcache,...` as a real production feature (disk-backed read cache for large_image tile serving from S3), and OutsetaLogin's Dockerfile is `FROM nimbusimage-girder`, so it inherits this image.
- Installing `libfuse2` explicitly restores the working pre-rebuild state on both dev and prod without otherwise changing behavior.

## Upstream

Filed girder/girder#3814 for the longer-term concerns: the eager `import fuse` should be lazy (a 1-line fix that removes the alarming warning), and the `[mount]` extra should eventually migrate from the unmaintained fusepy to a libfuse3-capable wrapper (refuse or pyfuse3). Until that lands, pinning libfuse2 is the right move.

## Notes

- libfuse2 is still available in Debian/Ubuntu repos for legacy compatibility.
- Supersedes #1147, which mistakenly removed the mount step entirely; that approach would have broken `OutsetaLogin`'s production diskcache mount on the next deploy.

## Test plan

- [ ] `docker compose build girder && docker compose up` — container reaches `uvicorn` and serves on :8080 without the "entry point could not be loaded" warning
- [ ] `docker compose exec girder girder --help` — no warning
- [ ] `docker compose exec girder ls /mnt/fuse` — succeeds and shows the mounted Girder hierarchy
- [ ] Frontend at http://localhost:5173 loads and a dataset opens
- [ ] After merge, verify production deploys cleanly (next AWS autoscale event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)