### PR TITLE
Disable annotation mutation actions for anonymous users

### DIFF
--- a/src/components/AnnotationActionPanel.test.ts
+++ b/src/components/AnnotationActionPanel.test.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import AnnotationActionPanel from "./AnnotationActionPanel.vue";
 
+vi.mock("@/store", () => ({
+  default: {
+    isLoggedIn: true,
+  },
+}));
+
 vi.mock("@/store/annotation", () => ({
   default: {
     selectedAnnotationIds: new Set(["id1", "id2", "id3"]),

--- a/src/components/AnnotationActionPanel.vue
+++ b/src/components/AnnotationActionPanel.vue
@@ -1,19 +1,39 @@
 <template>
   <div class="action-panel">
     <div class="selected-count">{{ selectedCount }} objects selected</div>
-    <v-btn size="small" class="ma-1" @click="$emit('delete-selected')">
+    <v-btn
+      size="small"
+      class="ma-1"
+      :disabled="!isLoggedIn"
+      @click="$emit('delete-selected')"
+    >
       <v-icon start size="small">mdi-delete</v-icon>
       Delete Selected
     </v-btn>
-    <v-btn size="small" class="ma-1" @click="$emit('delete-unselected')">
+    <v-btn
+      size="small"
+      class="ma-1"
+      :disabled="!isLoggedIn"
+      @click="$emit('delete-unselected')"
+    >
       <v-icon start size="small">mdi-delete-sweep</v-icon>
       Delete Unselected
     </v-btn>
-    <v-btn size="small" class="ma-1" @click="$emit('tag-selected')">
+    <v-btn
+      size="small"
+      class="ma-1"
+      :disabled="!isLoggedIn"
+      @click="$emit('tag-selected')"
+    >
       <v-icon start size="small">mdi-tag</v-icon>
       Tag Selected
     </v-btn>
-    <v-btn size="small" class="ma-1" @click="$emit('color-selected')">
+    <v-btn
+      size="small"
+      class="ma-1"
+      :disabled="!isLoggedIn"
+      @click="$emit('color-selected')"
+    >
       <v-icon start size="small">mdi-palette</v-icon>
       Color Selected
     </v-btn>
@@ -31,13 +51,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { logError } from "@/utils/log";
+import store from "@/store";
 import annotationStore from "@/store/annotation";
 
 defineProps<{
   selectedCount: number;
 }>();
+
+const isLoggedIn = computed(() => store.isLoggedIn);
 
 defineEmits<{
   (e: "delete-selected"): void;

--- a/src/components/AnnotationActionPanel.vue
+++ b/src/components/AnnotationActionPanel.vue
@@ -60,8 +60,6 @@ defineProps<{
   selectedCount: number;
 }>();
 
-const isLoggedIn = computed(() => store.isLoggedIn);
-
 defineEmits<{
   (e: "delete-selected"): void;
   (e: "delete-unselected"): void;
@@ -69,6 +67,8 @@ defineEmits<{
   (e: "color-selected"): void;
   (e: "deselect-all"): void;
 }>();
+
+const isLoggedIn = computed(() => store.isLoggedIn);
 
 const copySuccess = ref(false);
 

--- a/src/components/AnnotationBrowser/AnnotationList.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationList.test.ts
@@ -8,6 +8,7 @@ const mockSetCameraInfo = vi.fn();
 
 vi.mock("@/store", () => ({
   default: {
+    isLoggedIn: true,
     setXY: (...args: any[]) => mockSetXY(...args),
     setZ: (...args: any[]) => mockSetZ(...args),
     setTime: (...args: any[]) => mockSetTime(...args),

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -11,7 +11,7 @@
               size="small"
               variant="outlined"
               :loading="isDeletingAnnotations"
-              :disabled="isDeletingAnnotations"
+              :disabled="!isLoggedIn || isDeletingAnnotations"
               @click.stop="deleteSelected"
             >
               Delete Selected
@@ -28,18 +28,24 @@
               <v-list>
                 <v-list-item
                   @click="deleteUnselected"
-                  :disabled="isDeletingAnnotations"
+                  :disabled="!isLoggedIn || isDeletingAnnotations"
                 >
                   <v-icon>mdi-delete-outline</v-icon>
                   <v-list-item-title>Delete Unselected</v-list-item-title>
                 </v-list-item>
 
-                <v-list-item @click="showTagDialog = true">
+                <v-list-item
+                  @click="showTagDialog = true"
+                  :disabled="!isLoggedIn"
+                >
                   <v-icon>mdi-tag</v-icon>
                   <v-list-item-title>Tag Selected</v-list-item-title>
                 </v-list-item>
 
-                <v-list-item @click="showColorDialog = true">
+                <v-list-item
+                  @click="showColorDialog = true"
+                  :disabled="!isLoggedIn"
+                >
                   <v-icon>mdi-palette</v-icon>
                   <v-list-item-title>Color Selected</v-list-item-title>
                 </v-list-item>
@@ -313,6 +319,8 @@ const showTagDialog = ref(false);
 const showColorDialog = ref(false);
 
 // Computeds
+const isLoggedIn = computed(() => store.isLoggedIn);
+
 const isDeletingAnnotations = computed(() => {
   return annotationStore.isDeleting;
 });
@@ -560,6 +568,7 @@ function deleteUnselected() {
 }
 
 defineExpose({
+  isLoggedIn,
   isDeletingAnnotations,
   columnOptions,
   selectedColumns,

--- a/src/components/ColorSelectionDialog.test.ts
+++ b/src/components/ColorSelectionDialog.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { nextTick } from "vue";
 import { mount } from "@vue/test-utils";
+
+vi.mock("@/store", () => ({
+  default: {
+    isLoggedIn: true,
+  },
+}));
+
 import ColorSelectionDialog from "./ColorSelectionDialog.vue";
 
 function mountComponent(props = {}) {

--- a/src/components/ColorSelectionDialog.vue
+++ b/src/components/ColorSelectionDialog.vue
@@ -16,7 +16,9 @@
       <v-card-actions>
         <v-spacer />
         <v-btn color="warning" @click="showDialog = false"> Cancel </v-btn>
-        <v-btn color="primary" @click="submit"> Apply color </v-btn>
+        <v-btn color="primary" :disabled="!isLoggedIn" @click="submit">
+          Apply color
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -24,6 +26,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
+import store from "@/store";
 import ColorPickerMenu from "@/components/ColorPickerMenu.vue";
 
 const props = defineProps<{
@@ -41,6 +44,8 @@ const emit = defineEmits<{
     },
   ): void;
 }>();
+
+const isLoggedIn = computed(() => store.isLoggedIn);
 
 const colorOption = ref("layer");
 const localCustomColor = ref("#FFFFFF");
@@ -61,5 +66,5 @@ function submit() {
   showDialog.value = false;
 }
 
-defineExpose({ colorOption, localCustomColor, showDialog, submit });
+defineExpose({ isLoggedIn, colorOption, localCustomColor, showDialog, submit });
 </script>

--- a/src/components/TagSelectionDialog.test.ts
+++ b/src/components/TagSelectionDialog.test.ts
@@ -4,6 +4,7 @@ import { mount } from "@vue/test-utils";
 
 vi.mock("@/store", () => ({
   default: {
+    isLoggedIn: true,
     toolTags: [],
   },
 }));

--- a/src/components/TagSelectionDialog.vue
+++ b/src/components/TagSelectionDialog.vue
@@ -22,7 +22,9 @@
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn color="warning" @click="clearTags"> Clear input </v-btn>
-        <v-btn color="primary" @click="submit"> Add/remove tags </v-btn>
+        <v-btn color="primary" :disabled="!isLoggedIn" @click="submit">
+          Add/remove tags
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -30,6 +32,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
+import store from "@/store";
 import TagPicker from "@/components/TagPicker.vue";
 
 const props = defineProps<{
@@ -47,6 +50,8 @@ const emit = defineEmits<{
     },
   ): void;
 }>();
+
+const isLoggedIn = computed(() => store.isLoggedIn);
 
 const localTags = ref<string[]>([]);
 const localAddOrRemove = ref<"add" | "remove">("add");
@@ -74,6 +79,7 @@ function submit() {
 }
 
 defineExpose({
+  isLoggedIn,
   localTags,
   localAddOrRemove,
   localReplaceExisting,


### PR DESCRIPTION
## Summary
- Disable Delete Selected, Delete Unselected, Tag Selected, and Color Selected in `AnnotationList.vue` and the floating `AnnotationActionPanel.vue` when the viewer is not logged in.
- Uses the existing `!isLoggedIn` (`store.isLoggedIn`) pattern already used in Toolset, Snapshots, AnnotationProperties, etc.
- Copy Selected IDs and Deselect All stay enabled — they're read-only.

## Test plan
- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean on changed files
- [x] `pnpm exec vitest run` on the two affected component test files (45 tests pass)
- [ ] Manual: open a public/shared project while logged out — verify the four buttons render disabled in both surfaces and re-enable after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)