### PR TITLE
Fix dataset primary dropzone to support drag-and-drop uploads

### DIFF
--- a/src/components/Files/FileDropzone.test.ts
+++ b/src/components/Files/FileDropzone.test.ts
@@ -35,6 +35,19 @@ describe("FileDropzone", () => {
     expect(wrapper.emitted("update:modelValue")![0][0]).toEqual([file]);
   });
 
+  it("emits files from a drop event", () => {
+    const wrapper = mountComponent();
+    const file = new File(["content"], "dropped.txt");
+
+    wrapper.find(".dropzone-wrapper").trigger("drop", {
+      dataTransfer: { files: [file] },
+    });
+
+    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+    expect(wrapper.emitted("update:modelValue")![0][0]).toEqual([file]);
+    expect(wrapper.vm.dropzoneClass).toBeNull();
+  });
+
   it("initializes dropzoneClass as null", () => {
     const wrapper = mountComponent();
     expect(wrapper.vm.dropzoneClass).toBeNull();

--- a/src/components/Files/FileDropzone.vue
+++ b/src/components/Files/FileDropzone.vue
@@ -70,7 +70,8 @@ function onChange(event: Event) {
 
 function onDrop(event: DragEvent) {
   dropzoneClass.value = null;
-  files.value = [...(event.dataTransfer?.files || [])];
+  const dropped = [...(event.dataTransfer?.files || [])];
+  files.value = props.multiple ? dropped : dropped.slice(0, 1);
 }
 
 defineExpose({ dropzoneClass, onDrop });

--- a/src/components/Files/FileDropzone.vue
+++ b/src/components/Files/FileDropzone.vue
@@ -2,9 +2,10 @@
   <div
     :class="dropzoneClass"
     class="dropzone-wrapper"
-    @dragenter="dropzoneClass = 'animate'"
+    @dragenter.prevent="dropzoneClass = 'animate'"
+    @dragover.prevent
     @dragleave="dropzoneClass = null"
-    @drop="dropzoneClass = null"
+    @drop.prevent="onDrop"
   >
     <div class="dropzone-overlay"></div>
     <v-row
@@ -67,7 +68,12 @@ function onChange(event: Event) {
   files.value = [...fileList];
 }
 
-defineExpose({ dropzoneClass });
+function onDrop(event: DragEvent) {
+  dropzoneClass.value = null;
+  files.value = [...(event.dataTransfer?.files || [])];
+}
+
+defineExpose({ dropzoneClass, onDrop });
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/dataset/NewDataset.test.ts
+++ b/src/views/dataset/NewDataset.test.ts
@@ -4,10 +4,19 @@ import { shallowMount } from "@vue/test-utils";
 
 // --- Top-level mock fn handles ---
 const mockGetUserApiKeys = vi.fn().mockResolvedValue([]);
+const mockGetUserPrivateFolder = vi.fn().mockResolvedValue({
+  _id: "private-folder",
+  _modelType: "folder",
+});
 const mockCreateDataset = vi.fn().mockResolvedValue(null);
 const mockSetSelectedDataset = vi.fn().mockResolvedValue(undefined);
 const mockCreateDatasetView = vi.fn().mockResolvedValue(null);
 const mockSetDatasetViewId = vi.fn();
+const mockCreateDefaultView = vi.fn().mockResolvedValue({ id: "view-1" });
+const mockDatasetInfoToRoute = vi.fn().mockReturnValue({
+  name: "dataset",
+  params: { datasetId: "ds-1" },
+});
 const mockSetSelectedConfiguration = vi.fn();
 const mockCreateUploadCollection = vi.fn().mockResolvedValue(null);
 const mockAddUploadedDataset = vi.fn();
@@ -69,6 +78,8 @@ vi.mock("@/store", () => ({
     },
     api: {
       getUserApiKeys: (...args: any[]) => mockGetUserApiKeys(...args),
+      getUserPrivateFolder: (...args: any[]) =>
+        mockGetUserPrivateFolder(...args),
     },
     createDataset: (...args: any[]) => mockCreateDataset(...args),
     setSelectedDataset: (...args: any[]) => mockSetSelectedDataset(...args),
@@ -226,6 +237,14 @@ const GirderUploadStub = {
   },
 };
 
+const DatasetInfoStub = {
+  template: "<div />",
+  methods: {
+    createDefaultView: (...args: any[]) => mockCreateDefaultView(...args),
+    toRoute: (...args: any[]) => mockDatasetInfoToRoute(...args),
+  },
+};
+
 function createFile(name: string, size = 100): File {
   const file = new File(["x"], name, { type: "application/octet-stream" });
   Object.defineProperty(file, "size", { value: size });
@@ -245,7 +264,7 @@ function mountComponent(props: Record<string, any> = {}, options: any = {}) {
         GirderLocationChooser: true,
         FileDropzone: true,
         MultiSourceConfiguration: true,
-        DatasetInfo: true,
+        DatasetInfo: DatasetInfoStub,
         GirderUpload: GirderUploadStub,
         // Vuetify 3 layout stubs need to render slot content for DOM tests
         VContainer: { template: "<div><slot /></div>" },
@@ -293,7 +312,16 @@ describe("NewDataset", () => {
     mockRouter.push = vi.fn();
     resetUploadWorkflow();
     mockGetUserApiKeys.mockResolvedValue([]);
+    mockGetUserPrivateFolder.mockResolvedValue({
+      _id: "private-folder",
+      _modelType: "folder",
+    });
     mockCreateDataset.mockResolvedValue(null);
+    mockCreateDefaultView.mockResolvedValue({ id: "view-1" });
+    mockDatasetInfoToRoute.mockReturnValue({
+      name: "dataset",
+      params: { datasetId: "ds-1" },
+    });
     mockGetFolder.mockResolvedValue({
       _id: "folder1",
       _modelType: "folder",
@@ -811,6 +839,16 @@ describe("NewDataset", () => {
       expect(vm.path).toEqual({ _id: "prop-folder", _modelType: "folder" });
       expect(vm.name).toBe("Prop Name");
       expect(vm.description).toBe("Prop Desc");
+    });
+
+    it("falls back to the user private folder when no initial location exists", async () => {
+      mockUploadWorkflow.active = false;
+      const wrapper = mountComponent({ initialUploadLocation: null });
+      await nextTick();
+      await nextTick();
+      const vm = wrapper.vm as any;
+      expect(mockGetUserPrivateFolder).toHaveBeenCalled();
+      expect(vm.path).toEqual({ _id: "private-folder", _modelType: "folder" });
     });
 
     it("calls getMaxUploadSize on mount", async () => {
@@ -1345,10 +1383,14 @@ describe("NewDataset", () => {
       const wrapper = mountComponent();
       const vm = wrapper.vm as any;
       vm.dataset = { id: "ds-1" };
-      // createView will fail without refs but we verify it's called path
       await vm.generationDone("json-id");
-      // setSelectedDataset should be called in createView path
       expect(mockSetSelectedDataset).toHaveBeenCalledWith("ds-1");
+      expect(mockCreateDefaultView).toHaveBeenCalled();
+      expect(mockSetDatasetViewId).toHaveBeenCalledWith({ id: "view-1" });
+      expect(mockRouter.push).toHaveBeenCalledWith({
+        name: "dataset",
+        params: { datasetId: "ds-1" },
+      });
     });
 
     it("returns for non-quick non-batch mode", () => {

--- a/src/views/dataset/NewDataset.test.ts
+++ b/src/views/dataset/NewDataset.test.ts
@@ -145,13 +145,41 @@ vi.mock("@girder/components", () => ({
 vi.mock("@/girder/components", () => ({
   Upload: {
     name: "GirderUpload",
-    template: "<div><slot name='files' :files='[]' /></div>",
-    props: ["dest", "uploadCls", "hideStartButton", "hideHeadline"],
+    template: `
+      <div>
+        <slot
+          name="dropzone"
+          :files="files"
+          :dropzoneMessage="dropzoneMessage"
+          :multiple="multiple"
+          :accept="accept"
+          :inputFilesChanged="inputFilesChanged"
+        />
+        <slot name="files" :files="files" />
+      </div>
+    `,
+    props: {
+      dest: { type: Object, required: true },
+      uploadCls: { type: Function, default: undefined },
+      hideStartButton: { type: Boolean, default: false },
+      hideHeadline: { type: Boolean, default: false },
+      multiple: { type: Boolean, default: true },
+      accept: { type: String, default: undefined },
+    },
     methods: {
-      inputFilesChanged: vi.fn(),
+      inputFilesChanged(this: any, files: File[]) {
+        this.files = files;
+        if (files.length > 0) {
+          this.$emit("filesChanged", files);
+        }
+      },
       startUpload: vi.fn(),
     },
-    data: () => ({ totalProgressPercent: 0 }),
+    data: () => ({
+      files: [],
+      dropzoneMessage: "Drag files here or click to select them",
+      totalProgressPercent: 0,
+    }),
   },
 }));
 
@@ -161,11 +189,39 @@ import { parseTranscodeOutput } from "@/utils/strings";
 
 const GirderUploadStub = {
   name: "GirderUpload",
-  template: "<div><slot name='files' :files='[]' /></div>",
-  props: ["dest", "uploadCls", "hideStartButton", "hideHeadline"],
-  data: () => ({ totalProgressPercent: 0 }),
+  template: `
+    <div>
+      <slot
+        name="dropzone"
+        :files="files"
+        :dropzoneMessage="dropzoneMessage"
+        :multiple="multiple"
+        :accept="accept"
+        :inputFilesChanged="inputFilesChanged"
+      />
+      <slot name="files" :files="files" />
+    </div>
+  `,
+  props: {
+    dest: { type: Object, required: true },
+    uploadCls: { type: Function, default: undefined },
+    hideStartButton: { type: Boolean, default: false },
+    hideHeadline: { type: Boolean, default: false },
+    multiple: { type: Boolean, default: true },
+    accept: { type: String, default: undefined },
+  },
+  data: () => ({
+    files: [],
+    dropzoneMessage: "Drag files here or click to select them",
+    totalProgressPercent: 0,
+  }),
   methods: {
-    inputFilesChanged: vi.fn(),
+    inputFilesChanged(this: any, files: File[]) {
+      this.files = files;
+      if (files.length > 0) {
+        this.$emit("filesChanged", files);
+      }
+    },
     startUpload: vi.fn(),
   },
 };
@@ -837,6 +893,34 @@ describe("NewDataset", () => {
       const vm = wrapper.vm as any;
       const result = await vm.getMaxUploadSize();
       expect(result).toBeNull();
+    });
+  });
+
+  describe("primary upload dropzone", () => {
+    it("renders the app FileDropzone in GirderUpload's dropzone slot", async () => {
+      const wrapper = mountComponent();
+      await nextTick();
+
+      const dropzone = wrapper.findComponent({ name: "FileDropzone" });
+
+      expect(dropzone.exists()).toBe(true);
+      expect(dropzone.props("multiple")).toBe(true);
+      expect(dropzone.props("accept")).toBeUndefined();
+    });
+
+    it("updates selected files when the primary dropzone emits files", async () => {
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      await nextTick();
+
+      const file = createFile("dropped-image.tif", 50);
+      const dropzone = wrapper.findComponent({ name: "FileDropzone" });
+
+      await dropzone.vm.$emit("update:modelValue", [file]);
+
+      expect(vm.uploadedFiles).toEqual([file]);
+      expect(vm.files).toEqual([file]);
+      expect(vm.name).toBe("dropped-image");
     });
   });
 

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -31,6 +31,29 @@
         @error="interruptedUpload"
         @vue:mounted="uploadMounted"
       >
+        <template
+          #dropzone="{
+            files: uploadFiles,
+            dropzoneMessage,
+            multiple,
+            accept,
+            inputFilesChanged,
+          }"
+        >
+          <file-dropzone
+            v-if="!uploadFiles.length"
+            :multiple="multiple"
+            :accept="accept"
+            class="new-dataset-primary-dropzone"
+            @update:model-value="inputFilesChanged"
+          >
+            <template #default>
+              <v-icon size="50px">mdi-file-upload</v-icon>
+              <div class="title mt-3">{{ dropzoneMessage }}</div>
+            </template>
+          </file-dropzone>
+        </template>
+
         <template #files="{ files }" v-if="quickupload && !pipelineError">
           <v-card>
             <v-card-text>
@@ -1266,6 +1289,10 @@ defineExpose({
 <style lang="scss">
 .new-dataset-upload .files-list {
   max-height: 260px;
+}
+
+.new-dataset-primary-dropzone {
+  height: 100%;
 }
 
 .job-log {

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -1069,9 +1069,9 @@ async function configureDataset() {
 
 function generationDone(jsonId: string | null) {
   if (isBatchMode.value) {
-    handleCollectionGenerationDone(jsonId);
+    return handleCollectionGenerationDone(jsonId);
   } else if (isQuickImport.value) {
-    createView(jsonId);
+    return createView(jsonId);
   } else {
     return;
   }
@@ -1200,6 +1200,17 @@ onMounted(async () => {
     path.value = props.initialUploadLocation ?? null;
     if (props.initialName) name.value = props.initialName;
     if (props.initialDescription) description.value = props.initialDescription;
+  }
+
+  if (!path.value) {
+    try {
+      const privateFolder = await store.api.getUserPrivateFolder();
+      if (!path.value) {
+        path.value = privateFolder;
+      }
+    } catch (error) {
+      logError(error);
+    }
   }
 
   maxApiKeyFileSize.value = await getMaxUploadSize();


### PR DESCRIPTION
## Summary
- Wire the dataset upload dropzone to the app `FileDropzone` component in the `dropzone` slot
- Support drag-and-drop file selection by handling drop events and preventing default browser behavior
- Add coverage for drop handling and the dataset view integration path

## Testing
- Added unit tests for `FileDropzone` drop event handling
- Added view tests covering the primary dataset dropzone rendering and file updates