### PR TITLE
Add optional CSV column-name sanitization

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
@@ -502,17 +502,17 @@ class Export(Resource):
         sanitizeColumnNames=False,
     ):
         """Build CSV columns and matching property paths."""
-        # After sanitization, names cannot contain commas, so fixed
-        # columns get is_quoted recomputed on the sanitized name to
-        # match the property-column rule below.
-        columns = []
-        for col in CSV_FIXED_COLUMNS:
-            name = (
+        # Fixed-column is_quoted controls value quoting, not just header
+        # quoting (Tags joins multiple tags with ", ", Name is freeform
+        # user text), so preserve it regardless of sanitization.
+        columns = [
+            CsvColumn(
                 sanitizeCsvColumnName(col.name)
-                if sanitizeColumnNames else col.name
+                if sanitizeColumnNames else col.name,
+                is_quoted=col.is_quoted,
             )
-            is_quoted = ',' in name if sanitizeColumnNames else col.is_quoted
-            columns.append(CsvColumn(name, is_quoted=is_quoted))
+            for col in CSV_FIXED_COLUMNS
+        ]
         includedPaths = []
         for path in parsedPropertyPaths:
             propertyName = self._getPropertyColumnName(

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
@@ -49,6 +49,9 @@ CSV_FIXED_COLUMNS = [
     CsvColumn("Name", is_quoted=True),
 ]
 
+# Must stay in sync with UNSAFE_CSV_COLUMN_CHARS in
+# src/components/AnnotationBrowser/AnnotationCSVDialog.vue so that the
+# client-side preview matches the server-generated CSV exactly.
 CSV_UNSAFE_COLUMN_CHARS = re.compile(r"[^A-Za-z0-9_]+")
 
 
@@ -61,6 +64,22 @@ def sanitizeCsvColumnName(name):
     """
     sanitized = CSV_UNSAFE_COLUMN_CHARS.sub("_", name).strip("_")
     return sanitized or "_"
+
+
+def _deduplicateColumnNames(names):
+    """Suffix repeated names with _2, _3, ... in order of appearance.
+
+    Sanitization can collapse distinct names to the same token (e.g.,
+    "Mean Area (um^2)" and "Mean/Area/um/2" both -> "Mean_Area_um_2"),
+    which would break R imports that rely on unique header names.
+    """
+    seen = {}
+    result = []
+    for name in names:
+        count = seen.get(name, 0)
+        result.append(name if count == 0 else f"{name}_{count + 1}")
+        seen[name] = count + 1
+    return result
 
 
 class Export(Resource):
@@ -483,14 +502,17 @@ class Export(Resource):
         sanitizeColumnNames=False,
     ):
         """Build CSV columns and matching property paths."""
-        columns = [
-            CsvColumn(
+        # After sanitization, names cannot contain commas, so fixed
+        # columns get is_quoted recomputed on the sanitized name to
+        # match the property-column rule below.
+        columns = []
+        for col in CSV_FIXED_COLUMNS:
+            name = (
                 sanitizeCsvColumnName(col.name)
-                if sanitizeColumnNames else col.name,
-                is_quoted=col.is_quoted,
+                if sanitizeColumnNames else col.name
             )
-            for col in CSV_FIXED_COLUMNS
-        ]
+            is_quoted = ',' in name if sanitizeColumnNames else col.is_quoted
+            columns.append(CsvColumn(name, is_quoted=is_quoted))
         includedPaths = []
         for path in parsedPropertyPaths:
             propertyName = self._getPropertyColumnName(
@@ -504,6 +526,14 @@ class Export(Resource):
                     is_quoted=',' in propertyName
                 ))
                 includedPaths.append(path)
+        if sanitizeColumnNames:
+            uniqueNames = _deduplicateColumnNames(
+                [c.name for c in columns]
+            )
+            columns = [
+                CsvColumn(name, is_quoted=c.is_quoted)
+                for c, name in zip(columns, uniqueNames)
+            ]
         return columns, includedPaths
 
     def _iterAnnotations(self, datasetId, annotationIds):
@@ -564,9 +594,13 @@ class Export(Resource):
         Args:
             path: Property path [propertyId, subKey1, subKey2, ...]
             propertyNameMap: Dict mapping propertyId -> propertyName
+            sanitizeColumnNames: When True, replace non-alphanumeric
+                characters with underscores (e.g., "Foo / Bar" ->
+                "Foo_Bar").
 
         Returns:
-            Column name like "PropertyName / SubKey1 / SubKey2"
+            Column name like "PropertyName / SubKey1 / SubKey2", or the
+            sanitized form when sanitizeColumnNames is True.
         """
         if not path:
             return None

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
@@ -6,6 +6,7 @@ values for a dataset.
 """
 
 import orjson
+import re
 from dataclasses import dataclass
 
 from bson.objectid import ObjectId
@@ -47,6 +48,19 @@ CSV_FIXED_COLUMNS = [
     CsvColumn("Shape", is_quoted=True),
     CsvColumn("Name", is_quoted=True),
 ]
+
+CSV_UNSAFE_COLUMN_CHARS = re.compile(r"[^A-Za-z0-9_]+")
+
+
+def sanitizeCsvColumnName(name):
+    """Return an R-friendly CSV column name.
+
+    Column names are limited to ASCII letters, numbers, and underscores.
+    Runs of spaces, slashes, commas, and other punctuation are collapsed
+    to one underscore.
+    """
+    sanitized = CSV_UNSAFE_COLUMN_CHARS.sub("_", name).strip("_")
+    return sanitized or "_"
 
 
 class Export(Resource):
@@ -293,6 +307,15 @@ class Export(Resource):
                         "description": "Delimiter: , or \\t",
                         "default": ","
                     },
+                    "sanitizeColumnNames": {
+                        "type": "boolean",
+                        "description": (
+                            "Replace spaces, slashes, commas, and other "
+                            "non-alphanumeric column-name characters with "
+                            "underscores"
+                        ),
+                        "default": False
+                    },
                     "filename": {
                         "type": "string",
                         "description": "Filename for download",
@@ -320,6 +343,7 @@ class Export(Resource):
         annotationIds = body.get("annotationIds")
         undefinedValue = body.get("undefinedValue", "")
         delimiter = body.get("delimiter", ",")
+        sanitizeColumnNames = bool(body.get("sanitizeColumnNames", False))
         filename = body.get("filename", "export.csv")
 
         # Permission check
@@ -359,9 +383,6 @@ class Export(Resource):
         setResponseHeader("Content-Type", content_type)
         setContentDisposition(safe_filename, disposition='attachment')
 
-        # Build property name mapping
-        propertyNameMap = self._buildPropertyNameMap(parsedPropertyPaths)
-
         # Capture self for use inside the generate() closure.
         # In Python, nested functions (including generators) capture
         # variables from the enclosing scope, but `self` can be
@@ -372,110 +393,134 @@ class Export(Resource):
 
         # Generator for streaming CSV output
         def generate():
-            # Build column definitions: fixed columns + property columns
-            # Filter to only paths that resolve to a name, so the
-            # column count matches the row value count.
-            columns = CSV_FIXED_COLUMNS.copy()
-            includedPaths = []
-            for path in parsedPropertyPaths:
-                propertyName = exportSelf._getPropertyColumnName(
-                    path, propertyNameMap)
-                if propertyName:
-                    columns.append(CsvColumn(
-                        propertyName,
-                        is_quoted=',' in propertyName
-                    ))
-                    includedPaths.append(path)
-
-            # Build header row
-            headerRow = []
-            for col in columns:
-                if col.is_quoted:
-                    headerRow.append(f'"{col.name}"')
-                else:
-                    headerRow.append(col.name)
-            yield delimiter.join(headerRow) + '\n'
-
-            # Load all property values for the dataset
-            propertyValues = exportSelf._getPropertyValues(
-                datasetObjectId
+            yield from exportSelf._generateCsvLines(
+                datasetObjectId,
+                parsedPropertyPaths,
+                parsedAnnotationIds,
+                undefinedValue,
+                delimiter,
+                sanitizeColumnNames,
             )
 
-            # Query annotations. When filtering by IDs, chunk
-            # the $in to stay under MongoDB's 16MB BSON limit.
-            for annotation in _iterAnnotations(
-                exportSelf, datasetObjectId,
-                parsedAnnotationIds,
-            ):
-                annId = str(annotation["_id"])
-                location = annotation.get("location", {})
-                tags = annotation.get("tags") or []
-
-                row = [
-                    annId,
-                    str(annotation.get("channel", 0)),
-                    str(location.get("XY", 0) + 1),
-                    str(location.get("Z", 0) + 1),
-                    str(location.get("Time", 0) + 1),
-                    ", ".join(str(t) for t in tags),
-                    str(annotation.get("shape", "")),
-                    str(annotation.get("name", "") or ""),
-                ]
-
-                # Add property values
-                annPropValues = propertyValues.get(
-                    annId, {}
-                )
-                for path in includedPaths:
-                    value = exportSelf._getValueFromPath(
-                        annPropValues, path
-                    )
-                    if value is None:
-                        row.append(undefinedValue)
-                    elif isinstance(value, dict):
-                        row.append(str(value))
-                    else:
-                        row.append(
-                            exportSelf._formatValue(value)
-                        )
-
-                # Format row with quoting
-                formattedRow = []
-                for col, value in zip(columns, row):
-                    if col.is_quoted:
-                        escapedValue = str(value).replace(
-                            '"', '""'
-                        )
-                        formattedRow.append(
-                            f'"{escapedValue}"'
-                        )
-                    else:
-                        formattedRow.append(str(value))
-
-                yield delimiter.join(formattedRow) + '\n'
-
-        def _iterAnnotations(
-            exportSelf, datasetId, annotationIds,
-        ):
-            """Iterate annotations, chunking $in queries to
-            stay under MongoDB's 16MB BSON document limit."""
-            if not annotationIds:
-                for ann in exportSelf._annotationModel.find(
-                    {"datasetId": datasetId}
-                ):
-                    yield ann
-                return
-
-            IN_CHUNK_SIZE = 500000
-            for i in range(0, len(annotationIds), IN_CHUNK_SIZE):
-                chunk = annotationIds[i:i + IN_CHUNK_SIZE]
-                for ann in exportSelf._annotationModel.find({
-                    "datasetId": datasetId,
-                    "_id": {"$in": chunk},
-                }):
-                    yield ann
-
         return generate
+
+    def _generateCsvLines(
+        self,
+        datasetObjectId,
+        parsedPropertyPaths,
+        parsedAnnotationIds=None,
+        undefinedValue="",
+        delimiter=",",
+        sanitizeColumnNames=False,
+    ):
+        """Generate CSV lines for a dataset."""
+        propertyNameMap = self._buildPropertyNameMap(parsedPropertyPaths)
+        columns, includedPaths = self._buildCsvColumns(
+            parsedPropertyPaths,
+            propertyNameMap,
+            sanitizeColumnNames,
+        )
+
+        # Build header row
+        headerRow = []
+        for col in columns:
+            if col.is_quoted:
+                headerRow.append(f'"{col.name}"')
+            else:
+                headerRow.append(col.name)
+        yield delimiter.join(headerRow) + '\n'
+
+        # Load all property values for the dataset
+        propertyValues = self._getPropertyValues(datasetObjectId)
+
+        # Query annotations. When filtering by IDs, chunk
+        # the $in to stay under MongoDB's 16MB BSON limit.
+        for annotation in self._iterAnnotations(
+            datasetObjectId,
+            parsedAnnotationIds,
+        ):
+            annId = str(annotation["_id"])
+            location = annotation.get("location", {})
+            tags = annotation.get("tags") or []
+
+            row = [
+                annId,
+                str(annotation.get("channel", 0)),
+                str(location.get("XY", 0) + 1),
+                str(location.get("Z", 0) + 1),
+                str(location.get("Time", 0) + 1),
+                ", ".join(str(t) for t in tags),
+                str(annotation.get("shape", "")),
+                str(annotation.get("name", "") or ""),
+            ]
+
+            # Add property values
+            annPropValues = propertyValues.get(annId, {})
+            for path in includedPaths:
+                value = self._getValueFromPath(annPropValues, path)
+                if value is None:
+                    row.append(undefinedValue)
+                elif isinstance(value, dict):
+                    row.append(str(value))
+                else:
+                    row.append(self._formatValue(value))
+
+            # Format row with quoting
+            formattedRow = []
+            for col, value in zip(columns, row):
+                if col.is_quoted:
+                    escapedValue = str(value).replace('"', '""')
+                    formattedRow.append(f'"{escapedValue}"')
+                else:
+                    formattedRow.append(str(value))
+
+            yield delimiter.join(formattedRow) + '\n'
+
+    def _buildCsvColumns(
+        self,
+        parsedPropertyPaths,
+        propertyNameMap,
+        sanitizeColumnNames=False,
+    ):
+        """Build CSV columns and matching property paths."""
+        columns = [
+            CsvColumn(
+                sanitizeCsvColumnName(col.name)
+                if sanitizeColumnNames else col.name,
+                is_quoted=col.is_quoted,
+            )
+            for col in CSV_FIXED_COLUMNS
+        ]
+        includedPaths = []
+        for path in parsedPropertyPaths:
+            propertyName = self._getPropertyColumnName(
+                path,
+                propertyNameMap,
+                sanitizeColumnNames=sanitizeColumnNames,
+            )
+            if propertyName:
+                columns.append(CsvColumn(
+                    propertyName,
+                    is_quoted=',' in propertyName
+                ))
+                includedPaths.append(path)
+        return columns, includedPaths
+
+    def _iterAnnotations(self, datasetId, annotationIds):
+        """Iterate annotations, chunking $in queries to stay under limit."""
+        if not annotationIds:
+            for ann in self._annotationModel.find({"datasetId": datasetId}):
+                yield ann
+            return
+
+        IN_CHUNK_SIZE = 500000
+        for i in range(0, len(annotationIds), IN_CHUNK_SIZE):
+            chunk = annotationIds[i:i + IN_CHUNK_SIZE]
+            for ann in self._annotationModel.find({
+                "datasetId": datasetId,
+                "_id": {"$in": chunk},
+            }):
+                yield ann
 
     def _buildPropertyNameMap(self, propertyPaths):
         """
@@ -507,7 +552,12 @@ class Export(Resource):
 
         return {str(prop["_id"]): prop["name"] for prop in properties}
 
-    def _getPropertyColumnName(self, path, propertyNameMap):
+    def _getPropertyColumnName(
+        self,
+        path,
+        propertyNameMap,
+        sanitizeColumnNames=False,
+    ):
         """
         Get the column name for a property path.
 
@@ -528,8 +578,13 @@ class Export(Resource):
 
         subKeys = path[1:]
         if subKeys:
-            return " / ".join([propertyName] + subKeys)
-        return propertyName
+            columnName = " / ".join([propertyName] + subKeys)
+        else:
+            columnName = propertyName
+
+        if sanitizeColumnNames:
+            return sanitizeCsvColumnName(columnName)
+        return columnName
 
     def _getValueFromPath(self, values, path):
         """

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
@@ -71,14 +71,20 @@ def _deduplicateColumnNames(names):
 
     Sanitization can collapse distinct names to the same token (e.g.,
     "Mean Area (um^2)" and "Mean/Area/um/2" both -> "Mean_Area_um_2"),
-    which would break R imports that rely on unique header names.
+    which would break R imports that rely on unique header names. The
+    suffixed candidate is also checked against the used set to avoid
+    cases like ["Area", "Area_2", "Area"] producing two "Area_2".
     """
-    seen = {}
+    used = set()
     result = []
     for name in names:
-        count = seen.get(name, 0)
-        result.append(name if count == 0 else f"{name}_{count + 1}")
-        seen[name] = count + 1
+        candidate = name
+        counter = 1
+        while candidate in used:
+            counter += 1
+            candidate = f"{name}_{counter}"
+        used.add(candidate)
+        result.append(candidate)
     return result
 
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
@@ -14,6 +14,7 @@ from upenncontrast_annotation.server.models.datasetView import (
 )
 from upenncontrast_annotation.server.api.export import (
     Export,
+    _deduplicateColumnNames,
     sanitizeCsvColumnName,
 )
 
@@ -673,6 +674,44 @@ class TestCSVExport:
         ) == "cell_fibroblast_Blob_Metrics_Mean_Area_um_2"
         assert sanitizeCsvColumnName("already_ok_123") == "already_ok_123"
         assert sanitizeCsvColumnName("///") == "_"
+
+    def testDeduplicateColumnNames(self, admin):
+        """Repeated column names are suffixed _2, _3, ... in order."""
+        assert _deduplicateColumnNames(["A", "B", "A"]) == ["A", "B", "A_2"]
+        assert _deduplicateColumnNames(["A", "A", "A"]) == ["A", "A_2", "A_3"]
+        assert _deduplicateColumnNames(["A", "B"]) == ["A", "B"]
+        assert _deduplicateColumnNames([]) == []
+
+    def testBuildCsvColumnsDeduplicatesAfterSanitization(self, admin):
+        """Collisions from sanitization get unique suffixes."""
+        export = Export()
+        propertyNameMap = {
+            "p1": "Mean Area (um^2)",
+            "p2": "Mean/Area/um/2",
+        }
+        columns, includedPaths = export._buildCsvColumns(
+            [["p1"], ["p2"]],
+            propertyNameMap,
+            sanitizeColumnNames=True,
+        )
+        names = [c.name for c in columns]
+        # Two property columns sanitize to the same token; the second
+        # must be suffixed to keep header names unique.
+        assert "Mean_Area_um_2" in names
+        assert "Mean_Area_um_2_2" in names
+        assert len(names) == len(set(names))
+
+    def testBuildCsvColumnsRecomputesFixedColumnQuotingWhenSanitized(
+        self, admin
+    ):
+        """After sanitization, fixed columns drop comma-based quoting."""
+        export = Export()
+        columns, _ = export._buildCsvColumns(
+            [], {}, sanitizeColumnNames=True
+        )
+        fixed = {c.name: c.is_quoted for c in columns}
+        # Sanitized fixed names contain no commas, so none should be quoted.
+        assert all(not is_quoted for is_quoted in fixed.values())
 
     def testGetPropertyColumnNameSanitized(self, admin):
         """Sanitized property columns replace delimiters and punctuation."""

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
@@ -12,7 +12,10 @@ from upenncontrast_annotation.server.models.collection import Collection
 from upenncontrast_annotation.server.models.datasetView import (
     DatasetView as DatasetViewModel
 )
-from upenncontrast_annotation.server.api.export import Export
+from upenncontrast_annotation.server.api.export import (
+    Export,
+    sanitizeCsvColumnName,
+)
 
 from . import girder_utilities as utilities
 from . import upenn_testing_utilities as upenn_utilities
@@ -663,6 +666,25 @@ class TestCSVExport:
         # Test empty path
         assert export._getPropertyColumnName([], propertyNameMap) is None
 
+    def testSanitizeCsvColumnName(self, admin):
+        """Column names can be normalized for R-friendly CSV headers."""
+        assert sanitizeCsvColumnName(
+            "cell, fibroblast/Blob Metrics (%) / Mean Area (um^2)"
+        ) == "cell_fibroblast_Blob_Metrics_Mean_Area_um_2"
+        assert sanitizeCsvColumnName("already_ok_123") == "already_ok_123"
+        assert sanitizeCsvColumnName("///") == "_"
+
+    def testGetPropertyColumnNameSanitized(self, admin):
+        """Sanitized property columns replace delimiters and punctuation."""
+        export = Export()
+        propertyNameMap = {"prop123": "cell, fibroblast/Blob Metrics (%)"}
+
+        assert export._getPropertyColumnName(
+            ["prop123", "Mean Area (um^2)"],
+            propertyNameMap,
+            sanitizeColumnNames=True,
+        ) == "cell_fibroblast_Blob_Metrics_Mean_Area_um_2"
+
     def testPropertyColumnQuotedWhenNameContainsComma(self, admin):
         """Property columns with commas in name are quoted in CSV."""
         dataset, annotations, _ = createDatasetWithData(admin)
@@ -701,6 +723,62 @@ class TestCSVExport:
         # Verify a column without comma is not quoted
         col_no_comma = CsvColumn("Area", is_quoted=',' in "Area")
         assert col_no_comma.is_quoted is False
+
+    def testExportCsvGeneratedHeaderSanitizesColumnNames(self, admin):
+        """CSV generation applies sanitized column names when requested."""
+        dataset, annotations, _ = createDatasetWithData(admin)
+
+        prop = AnnotationProperty().save({
+            "name": "cell, fibroblast/Blob Metrics (%)",
+            "image": "properties/test:latest",
+            "tags": {"exclusive": False, "tags": ["polygon"]},
+            "shape": "polygon",
+            "workerInterface": {}
+        })
+        propId = str(prop["_id"])
+
+        PropertyValuesModel = AnnotationPropertyValues()
+        PropertyValuesModel.appendValues(
+            {propId: {"Mean Area (um^2)": 100}},
+            annotations[0]["_id"],
+            dataset["_id"]
+        )
+
+        export = Export()
+        lines = list(export._generateCsvLines(
+            dataset["_id"],
+            [[propId, "Mean Area (um^2)"]],
+            sanitizeColumnNames=True,
+        ))
+
+        header = lines[0].strip()
+        assert "cell_fibroblast_Blob_Metrics_Mean_Area_um_2" in header
+        assert "cell, fibroblast" not in header
+        assert "/" not in header
+        assert "(" not in header
+
+    def testExportCsvGeneratedHeaderKeepsColumnNamesByDefault(self, admin):
+        """CSV generation preserves existing header format by default."""
+        dataset, _, _ = createDatasetWithData(admin)
+
+        prop = AnnotationProperty().save({
+            "name": "cell, fibroblast/Blob Metrics (%)",
+            "image": "properties/test:latest",
+            "tags": {"exclusive": False, "tags": ["polygon"]},
+            "shape": "polygon",
+            "workerInterface": {}
+        })
+        propId = str(prop["_id"])
+
+        export = Export()
+        lines = list(export._generateCsvLines(
+            dataset["_id"],
+            [[propId, "Mean Area (um^2)"]],
+        ))
+
+        header = lines[0].strip()
+        assert '"cell, fibroblast/Blob Metrics (%) / Mean Area (um^2)"' \
+            in header
 
     def testPropertyColumnNotQuotedWhenNoComma(self, admin):
         """Property columns without commas are not quoted."""

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
@@ -682,6 +682,23 @@ class TestCSVExport:
         assert _deduplicateColumnNames(["A", "B"]) == ["A", "B"]
         assert _deduplicateColumnNames([]) == []
 
+    def testDeduplicateColumnNamesSkipsExistingSuffixCollisions(
+        self, admin
+    ):
+        """Suffixed candidate that already exists is skipped."""
+        # Naive count-based suffixing would emit two "Area_2"s here.
+        assert _deduplicateColumnNames(
+            ["Area", "Area_2", "Area"]
+        ) == ["Area", "Area_2", "Area_3"]
+        assert _deduplicateColumnNames(
+            ["A", "A_2", "A_3", "A"]
+        ) == ["A", "A_2", "A_3", "A_4"]
+        # Pre-existing _2 that isn't tied to a collision is left alone;
+        # subsequent "X" collision walks past the taken _2.
+        assert _deduplicateColumnNames(
+            ["X_2", "X", "X"]
+        ) == ["X_2", "X", "X_3"]
+
     def testBuildCsvColumnsDeduplicatesAfterSanitization(self, admin):
         """Collisions from sanitization get unique suffixes."""
         export = Export()
@@ -808,8 +825,13 @@ class TestCSVExport:
         """Tags with multiple values keep CSV quoting under sanitization.
 
         Tags render as ', '.join(tags). Without quoting, a multi-tag
-        value like 'red, blue' would split the row across columns.
+        value like 'red, blue' would split the row across columns when a
+        real CSV parser reads it. Parse the output with csv.reader to
+        verify the round-trip rather than just substring-matching.
         """
+        import csv as csv_module
+        import io
+
         dataset = utilities.createFolder(
             admin, "multi_tag_dataset", upenn_utilities.datasetMetadata
         )
@@ -818,13 +840,16 @@ class TestCSVExport:
         Annotation().create(ann_data)
 
         export = Export()
-        lines = list(export._generateCsvLines(
+        csv_output = "".join(export._generateCsvLines(
             dataset["_id"], [], sanitizeColumnNames=True,
         ))
 
-        assert len(lines) == 2
-        # Tags column is index 5; rendered as 'red, blue' and must be quoted.
-        assert '"red, blue"' in lines[1]
+        rows = list(csv_module.reader(io.StringIO(csv_output)))
+        assert len(rows) == 2
+        header, data_row = rows
+        assert len(data_row) == len(header)
+        tags_idx = header.index("Tags")
+        assert data_row[tags_idx] == "red, blue"
 
     def testExportCsvGeneratedHeaderKeepsColumnNamesByDefault(self, admin):
         """CSV generation preserves existing header format by default."""

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
@@ -701,17 +701,25 @@ class TestCSVExport:
         assert "Mean_Area_um_2_2" in names
         assert len(names) == len(set(names))
 
-    def testBuildCsvColumnsRecomputesFixedColumnQuotingWhenSanitized(
+    def testBuildCsvColumnsPreservesFixedColumnQuotingWhenSanitized(
         self, admin
     ):
-        """After sanitization, fixed columns drop comma-based quoting."""
+        """Fixed-column quoting is preserved through sanitization.
+
+        Fixed-column is_quoted controls value quoting too (Tags joins
+        multiple tags with ', ', Name is freeform user text), so it must
+        not change just because the column NAME no longer has commas.
+        """
         export = Export()
         columns, _ = export._buildCsvColumns(
             [], {}, sanitizeColumnNames=True
         )
         fixed = {c.name: c.is_quoted for c in columns}
-        # Sanitized fixed names contain no commas, so none should be quoted.
-        assert all(not is_quoted for is_quoted in fixed.values())
+        assert fixed["Id"] is True
+        assert fixed["Tags"] is True
+        assert fixed["Shape"] is True
+        assert fixed["Name"] is True
+        assert fixed["Channel"] is False
 
     def testGetPropertyColumnNameSanitized(self, admin):
         """Sanitized property columns replace delimiters and punctuation."""
@@ -795,6 +803,28 @@ class TestCSVExport:
         assert "cell, fibroblast" not in header
         assert "/" not in header
         assert "(" not in header
+
+    def testExportCsvSanitizedQuotesMultiTagValues(self, admin):
+        """Tags with multiple values keep CSV quoting under sanitization.
+
+        Tags render as ', '.join(tags). Without quoting, a multi-tag
+        value like 'red, blue' would split the row across columns.
+        """
+        dataset = utilities.createFolder(
+            admin, "multi_tag_dataset", upenn_utilities.datasetMetadata
+        )
+        ann_data = upenn_utilities.getSampleAnnotation(dataset["_id"])
+        ann_data["tags"] = ["red", "blue"]
+        Annotation().create(ann_data)
+
+        export = Export()
+        lines = list(export._generateCsvLines(
+            dataset["_id"], [], sanitizeColumnNames=True,
+        ))
+
+        assert len(lines) == 2
+        # Tags column is index 5; rendered as 'red, blue' and must be quoted.
+        assert '"red, blue"' in lines[1]
 
     def testExportCsvGeneratedHeaderKeepsColumnNamesByDefault(self, admin):
         """CSV generation preserves existing header format by default."""

--- a/nimbusimage/nimbusimage/export.py
+++ b/nimbusimage/nimbusimage/export.py
@@ -39,6 +39,7 @@ class ExportAccessor:
         property_paths: list[list[str]],
         delimiter: str = ",",
         undefined_value: str = "",
+        sanitize_column_names: bool = False,
         path: str | None = None,
     ) -> bytes:
         """Export dataset as CSV.
@@ -48,6 +49,8 @@ class ExportAccessor:
                 (e.g., [["propId", "Area"]]).
             delimiter: CSV delimiter.
             undefined_value: Value for undefined fields.
+            sanitize_column_names: Replace spaces, slashes, commas, and other
+                non-alphanumeric column-name characters with underscores.
             path: If provided, write to this file path.
 
         Returns:
@@ -58,6 +61,7 @@ class ExportAccessor:
             "propertyPaths": property_paths,
             "delimiter": delimiter,
             "undefinedValue": undefined_value,
+            "sanitizeColumnNames": sanitize_column_names,
         }
         import json as json_mod
 

--- a/nimbusimage/tests/test_export.py
+++ b/nimbusimage/tests/test_export.py
@@ -23,6 +23,18 @@ class TestExportAccessor:
         assert isinstance(result, bytes)
         assert b"Id,Channel" in result
 
+    def test_to_csv_can_request_sanitized_column_names(self, mock_gc):
+        mock_response = MagicMock()
+        mock_response.content = b"Id,Channel\nann1,0"
+        mock_gc.sendRestRequest.return_value = mock_response
+        accessor = ExportAccessor(mock_gc, "ds_001")
+        accessor.to_csv(
+            property_paths=[["prop1", "Area"]],
+            sanitize_column_names=True,
+        )
+        body = mock_gc.sendRestRequest.call_args.kwargs["data"]
+        assert '"sanitizeColumnNames": true' in body
+
     def test_to_csv_with_path(self, mock_gc, tmp_path):
         mock_response = MagicMock()
         mock_response.content = b"Id,Channel\nann1,0"

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -427,6 +427,31 @@ describe("AnnotationCSVDialog", () => {
     expect(new Set(columns).size).toBe(columns.length);
   });
 
+  it("generateCSVStringForAnnotations dedup walks past existing suffixed names", async () => {
+    // Naive count-based suffixing would emit two "Area_2" headers if a
+    // sanitized name happens to already match the would-be suffix; the
+    // dedup must check candidates against the used set.
+    (propertyStore as any).getFullNameFromPath = vi.fn((path: string[]) => {
+      const map: Record<string, string> = {
+        "propA.sub1": "Area",
+        "propB.sub2": "Area_2",
+        "propC.sub3": "Area",
+      };
+      return map[path.join(".")] || null;
+    });
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.propertyExportMode = "all";
+    vm.sanitizeColumnNames = true;
+    const csv = await vm.generateCSVStringForAnnotations();
+    const header = csv.split("\n")[0];
+    const columns = header.split(",");
+    expect(columns).toContain("Area");
+    expect(columns).toContain("Area_2");
+    expect(columns).toContain("Area_3");
+    expect(new Set(columns).size).toBe(columns.length);
+  });
+
   it("watcher on propertyExportMode causes text regeneration when dialog open", async () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as any;

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -235,6 +235,22 @@ describe("AnnotationCSVDialog", () => {
     expect(vm.getUndefinedValueString()).toBe("NaN");
   });
 
+  it("sanitizeColumnNames defaults to false", () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    expect(vm.sanitizeColumnNames).toBe(false);
+  });
+
+  it("sanitizeCsvColumnName replaces special characters", () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    expect(
+      vm.sanitizeCsvColumnName(
+        "cell, fibroblast/Blob Metrics (%) / Mean Area (um^2)",
+      ),
+    ).toBe("cell_fibroblast_Blob_Metrics_Mean_Area_um_2");
+  });
+
   it("getIncludedPropertyPaths filters based on mode", () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as any;
@@ -318,6 +334,7 @@ describe("AnnotationCSVDialog", () => {
     expect(arg.datasetId).toBe("ds1");
     expect(arg.filename).toBe("export.csv");
     expect(arg.undefinedValue).toBe("");
+    expect(arg.sanitizeColumnNames).toBe(false);
     // When exporting all annotations (not a subset), annotationIds is omitted
     // to avoid exceeding MongoDB's BSON size limit
     expect(arg.annotationIds).toBeUndefined();
@@ -346,6 +363,24 @@ describe("AnnotationCSVDialog", () => {
     vm.undefinedHandling = "na";
     const csv = await vm.generateCSVStringForAnnotations();
     expect(csv).toContain("NA");
+  });
+
+  it("generateCSVStringForAnnotations sanitizes headers when enabled", async () => {
+    (propertyStore as any).getFullNameFromPath = vi.fn((path: string[]) => {
+      const map: Record<string, string> = {
+        "propA.sub1": "cell, fibroblast/Blob Metrics (%)",
+        "propB.sub2": "Property B > Sub2",
+        "propC.sub3": "Property C > Sub3",
+      };
+      return map[path.join(".")] || null;
+    });
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.propertyExportMode = "all";
+    vm.sanitizeColumnNames = true;
+    const csv = await vm.generateCSVStringForAnnotations();
+    expect(csv).toContain("cell_fibroblast_Blob_Metrics");
+    expect(csv).not.toContain("cell, fibroblast/Blob Metrics (%)");
   });
 
   it("watcher on propertyExportMode causes text regeneration when dialog open", async () => {
@@ -478,6 +513,17 @@ describe("AnnotationCSVDialog", () => {
     await vm.download();
     const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
     expect(arg.delimiter).toBe(",");
+  });
+
+  it("download passes sanitizeColumnNames when enabled", async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.sanitizeColumnNames = true;
+    vm.filename = "export.csv";
+    vm.propertyExportMode = "all";
+    await vm.download();
+    const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+    expect(arg.sanitizeColumnNames).toBe(true);
   });
 
   it("hasCommasInPropertyNames detects commas in property names", () => {
@@ -626,6 +672,7 @@ describe("AnnotationCSVDialog", () => {
         ],
         undefinedValue: "NA",
         delimiter: ",",
+        sanitizeColumnNames: false,
       }),
     );
   });
@@ -649,6 +696,19 @@ describe("AnnotationCSVDialog", () => {
     await vm.downloadAllDatasets();
     expect(store.exportAPI.exportBulkCsv).toHaveBeenCalledWith(
       expect.objectContaining({ delimiter: "\t" }),
+    );
+  });
+
+  it("downloadAllDatasets passes sanitizeColumnNames when enabled", async () => {
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.exportScope = "all";
+    vm.collectionDatasets = [{ datasetId: "ds1", datasetName: "DS1" }];
+    vm.propertyExportMode = "all";
+    vm.sanitizeColumnNames = true;
+    await vm.downloadAllDatasets();
+    expect(store.exportAPI.exportBulkCsv).toHaveBeenCalledWith(
+      expect.objectContaining({ sanitizeColumnNames: true }),
     );
   });
 

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -384,12 +384,16 @@ describe("AnnotationCSVDialog", () => {
     expect(csv).not.toContain("cell, fibroblast/Blob Metrics (%)");
   });
 
-  it("generateCSVStringForAnnotations preserves fixed-column quoting under sanitization", async () => {
-    // Regression: fixed-column is_quoted controls VALUE quoting too.
-    // Tags is rendered as ", ".join(tags); without quoting on the Tags
-    // column, a multi-tag value would split the row across columns when
-    // parsed. Verify the `quotes` array passed to Papa.unparse keeps
-    // Id/Tags/Shape/Name force-quoted even when sanitization is on.
+  it("generateCSVStringForAnnotations keeps fixed-column quote flags aligned by column identity", async () => {
+    // Regression: fixed-column isQuoted controls VALUE quoting too. Tags is
+    // rendered as ", ".join(tags); without quoting on the Tags column, a
+    // multi-tag value would split the row across columns when parsed.
+    //
+    // Look up each flag by the column's NAME rather than a hardcoded index.
+    // The quotes array is derived from the same {name, isQuoted} column
+    // objects as fields, so each name must carry its own flag regardless of
+    // ordering. This fails if a hand-maintained parallel `quotes` array is
+    // reintroduced and drifts out of alignment with `fields`.
     const wrapper = mountComponent();
     const vm = wrapper.vm as any;
     vm.propertyExportMode = "all";
@@ -399,11 +403,17 @@ describe("AnnotationCSVDialog", () => {
     const fields = lastCall[0].fields as string[];
     const quotes = lastCall[1].quotes as boolean[];
     expect(quotes.length).toBe(fields.length);
-    // Fixed-column quote flags: Id, Tags, Shape, Name (indices 0, 5, 6, 7).
-    expect(quotes[0]).toBe(true);
-    expect(quotes[5]).toBe(true);
-    expect(quotes[6]).toBe(true);
-    expect(quotes[7]).toBe(true);
+    const quoteFor = (name: string) => quotes[fields.indexOf(name)];
+    // Force-quoted fixed columns.
+    expect(quoteFor("Id")).toBe(true);
+    expect(quoteFor("Tags")).toBe(true);
+    expect(quoteFor("Shape")).toBe(true);
+    expect(quoteFor("Name")).toBe(true);
+    // Unquoted fixed columns.
+    expect(quoteFor("Channel")).toBe(false);
+    expect(quoteFor("XY")).toBe(false);
+    expect(quoteFor("Z")).toBe(false);
+    expect(quoteFor("Time")).toBe(false);
   });
 
   it("generateCSVStringForAnnotations deduplicates colliding sanitized headers", async () => {

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -73,6 +73,7 @@ vi.mock("@/utils/paths", () => ({
   }),
 }));
 
+import Papa from "papaparse";
 import AnnotationCSVDialog from "./AnnotationCSVDialog.vue";
 import store from "@/store";
 import propertyStore from "@/store/properties";
@@ -381,6 +382,28 @@ describe("AnnotationCSVDialog", () => {
     const csv = await vm.generateCSVStringForAnnotations();
     expect(csv).toContain("cell_fibroblast_Blob_Metrics");
     expect(csv).not.toContain("cell, fibroblast/Blob Metrics (%)");
+  });
+
+  it("generateCSVStringForAnnotations preserves fixed-column quoting under sanitization", async () => {
+    // Regression: fixed-column is_quoted controls VALUE quoting too.
+    // Tags is rendered as ", ".join(tags); without quoting on the Tags
+    // column, a multi-tag value would split the row across columns when
+    // parsed. Verify the `quotes` array passed to Papa.unparse keeps
+    // Id/Tags/Shape/Name force-quoted even when sanitization is on.
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.propertyExportMode = "all";
+    vm.sanitizeColumnNames = true;
+    await vm.generateCSVStringForAnnotations();
+    const lastCall = (Papa.unparse as any).mock.calls.at(-1);
+    const fields = lastCall[0].fields as string[];
+    const quotes = lastCall[1].quotes as boolean[];
+    expect(quotes.length).toBe(fields.length);
+    // Fixed-column quote flags: Id, Tags, Shape, Name (indices 0, 5, 6, 7).
+    expect(quotes[0]).toBe(true);
+    expect(quotes[5]).toBe(true);
+    expect(quotes[6]).toBe(true);
+    expect(quotes[7]).toBe(true);
   });
 
   it("generateCSVStringForAnnotations deduplicates colliding sanitized headers", async () => {

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -383,6 +383,27 @@ describe("AnnotationCSVDialog", () => {
     expect(csv).not.toContain("cell, fibroblast/Blob Metrics (%)");
   });
 
+  it("generateCSVStringForAnnotations deduplicates colliding sanitized headers", async () => {
+    (propertyStore as any).getFullNameFromPath = vi.fn((path: string[]) => {
+      const map: Record<string, string> = {
+        "propA.sub1": "Mean Area (um^2)",
+        "propB.sub2": "Mean/Area/um/2",
+        "propC.sub3": "Property C",
+      };
+      return map[path.join(".")] || null;
+    });
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.propertyExportMode = "all";
+    vm.sanitizeColumnNames = true;
+    const csv = await vm.generateCSVStringForAnnotations();
+    const header = csv.split("\n")[0];
+    expect(header).toContain("Mean_Area_um_2");
+    expect(header).toContain("Mean_Area_um_2_2");
+    const columns = header.split(",");
+    expect(new Set(columns).size).toBe(columns.length);
+  });
+
   it("watcher on propertyExportMode causes text regeneration when dialog open", async () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as any;

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -297,6 +297,29 @@ const DISPLAY_CHAR_LIMIT = 10000;
 // so this client-side preview matches the server-generated CSV exactly.
 const UNSAFE_CSV_COLUMN_CHARS = /[^A-Za-z0-9_]+/g;
 
+interface CsvColumn {
+  name: string;
+  // isQuoted controls value quoting, not just header quoting: Tags joins
+  // multiple tags with ", " and Name is freeform user text, so these stay
+  // quoted regardless of sanitization. Keeping the flag on the column
+  // (rather than a separate parallel array) means it cannot drift out of
+  // alignment with the name when fixed columns are added/moved/removed.
+  isQuoted: boolean;
+}
+
+// Fixed columns for CSV export. Mirrors CSV_FIXED_COLUMNS in
+// devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py.
+const CSV_FIXED_COLUMNS: readonly CsvColumn[] = [
+  { name: "Id", isQuoted: true },
+  { name: "Channel", isQuoted: false },
+  { name: "XY", isQuoted: false },
+  { name: "Z", isQuoted: false },
+  { name: "Time", isQuoted: false },
+  { name: "Tags", isQuoted: true },
+  { name: "Shape", isQuoted: true },
+  { name: "Name", isQuoted: true },
+];
+
 const props = defineProps<{
   annotations: IAnnotation[];
   propertyPaths: string[][];
@@ -461,21 +484,12 @@ async function generateCSVStringForAnnotations() {
   processingProgress.value = 0;
 
   try {
-    // Fields
-    // Fixed-column quote flags control value quoting too (Tags joins
-    // multiple tags with ", ", Name is freeform user text), so preserve
-    // them regardless of sanitization.
-    const fields = [
-      "Id",
-      "Channel",
-      "XY",
-      "Z",
-      "Time",
-      "Tags",
-      "Shape",
-      "Name",
-    ].map(getCsvColumnName);
-    const quotes = [true, false, false, false, false, true, true, true];
+    // Build columns as {name, isQuoted} so the quote flag travels with its
+    // column. Fixed columns first, then one column per included property.
+    const columns: CsvColumn[] = CSV_FIXED_COLUMNS.map((col) => ({
+      name: getCsvColumnName(col.name),
+      isQuoted: col.isQuoted,
+    }));
     const usedPaths: string[][] = [];
 
     // Pre-compute included paths to avoid repeated checks
@@ -487,15 +501,20 @@ async function generateCSVStringForAnnotations() {
     includedPaths.forEach((path) => {
       const name = propertyStore.getFullNameFromPath(path)!;
       const columnName = getCsvColumnName(name);
-      fields.push(columnName);
-      quotes.push(columnName.includes(","));
+      columns.push({ name: columnName, isQuoted: columnName.includes(",") });
       usedPaths.push(path);
     });
 
     if (sanitizeColumnNames.value) {
-      const uniqueFields = deduplicateColumnNames(fields);
-      fields.splice(0, fields.length, ...uniqueFields);
+      // Dedup operates on names only; re-attach to the existing columns so
+      // each name keeps its isQuoted flag.
+      const uniqueNames = deduplicateColumnNames(columns.map((c) => c.name));
+      uniqueNames.forEach((name, i) => (columns[i].name = name));
     }
+
+    // Papa.unparse takes parallel fields/quotes arrays, so split only here.
+    const fields = columns.map((c) => c.name);
+    const quotes = columns.map((c) => c.isQuoted);
 
     // Process annotations in chunks
     const CHUNK_SIZE = 100;

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -455,7 +455,10 @@ async function generateCSVStringForAnnotations() {
 
   try {
     // Fields
-    const fixedFields = [
+    // Fixed-column quote flags control value quoting too (Tags joins
+    // multiple tags with ", ", Name is freeform user text), so preserve
+    // them regardless of sanitization.
+    const fields = [
       "Id",
       "Channel",
       "XY",
@@ -464,13 +467,8 @@ async function generateCSVStringForAnnotations() {
       "Tags",
       "Shape",
       "Name",
-    ];
-    const fields = fixedFields.map(getCsvColumnName);
-    // After sanitization, names can't contain commas, so recompute
-    // fixed-column quoting on the sanitized name to match property-column logic.
-    const quotes = sanitizeColumnNames.value
-      ? fields.map((name) => name.includes(","))
-      : [true, false, false, false, false, true, true, true];
+    ].map(getCsvColumnName);
+    const quotes = [true, false, false, false, false, true, true, true];
     const usedPaths: string[][] = [];
 
     // Pre-compute included paths to avoid repeated checks

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -439,13 +439,20 @@ function getCsvColumnName(name: string): string {
 
 // Sanitization can collapse distinct names to the same token, which would
 // break R imports that rely on unique header names. Suffix repeats with
-// _2, _3, ... in order of appearance to match the backend dedup logic.
+// _2, _3, ... in order of appearance, checking each candidate against the
+// used set so ["Area", "Area_2", "Area"] becomes ["Area", "Area_2",
+// "Area_3"] rather than two "Area_2"s. Matches the backend dedup logic.
 function deduplicateColumnNames(names: string[]): string[] {
-  const seen = new Map<string, number>();
+  const used = new Set<string>();
   return names.map((name) => {
-    const count = seen.get(name) ?? 0;
-    seen.set(name, count + 1);
-    return count === 0 ? name : `${name}_${count + 1}`;
+    let candidate = name;
+    let counter = 1;
+    while (used.has(candidate)) {
+      counter += 1;
+      candidate = `${name}_${counter}`;
+    }
+    used.add(candidate);
+    return candidate;
   });
 }
 

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -292,6 +292,9 @@ const UNDEFINED_VALUE_MAP = {
 
 const PREVIEW_ANNOTATION_LIMIT = 1000;
 const DISPLAY_CHAR_LIMIT = 10000;
+// Must stay in sync with CSV_UNSAFE_COLUMN_CHARS in
+// devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+// so this client-side preview matches the server-generated CSV exactly.
 const UNSAFE_CSV_COLUMN_CHARS = /[^A-Za-z0-9_]+/g;
 
 const props = defineProps<{
@@ -434,13 +437,25 @@ function getCsvColumnName(name: string): string {
   return sanitizeColumnNames.value ? sanitizeCsvColumnName(name) : name;
 }
 
+// Sanitization can collapse distinct names to the same token, which would
+// break R imports that rely on unique header names. Suffix repeats with
+// _2, _3, ... in order of appearance to match the backend dedup logic.
+function deduplicateColumnNames(names: string[]): string[] {
+  const seen = new Map<string, number>();
+  return names.map((name) => {
+    const count = seen.get(name) ?? 0;
+    seen.set(name, count + 1);
+    return count === 0 ? name : `${name}_${count + 1}`;
+  });
+}
+
 async function generateCSVStringForAnnotations() {
   isProcessing.value = true;
   processingProgress.value = 0;
 
   try {
     // Fields
-    const fields = [
+    const fixedFields = [
       "Id",
       "Channel",
       "XY",
@@ -449,8 +464,13 @@ async function generateCSVStringForAnnotations() {
       "Tags",
       "Shape",
       "Name",
-    ].map(getCsvColumnName);
-    const quotes = [true, false, false, false, false, true, true, true];
+    ];
+    const fields = fixedFields.map(getCsvColumnName);
+    // After sanitization, names can't contain commas, so recompute
+    // fixed-column quoting on the sanitized name to match property-column logic.
+    const quotes = sanitizeColumnNames.value
+      ? fields.map((name) => name.includes(","))
+      : [true, false, false, false, false, true, true, true];
     const usedPaths: string[][] = [];
 
     // Pre-compute included paths to avoid repeated checks
@@ -466,6 +486,11 @@ async function generateCSVStringForAnnotations() {
       quotes.push(columnName.includes(","));
       usedPaths.push(path);
     });
+
+    if (sanitizeColumnNames.value) {
+      const uniqueFields = deduplicateColumnNames(fields);
+      fields.splice(0, fields.length, ...uniqueFields);
+    }
 
     // Process annotations in chunks
     const CHUNK_SIZE = 100;

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -98,7 +98,7 @@
         </v-radio-group>
 
         <v-alert
-          v-if="hasCommasInPropertyNames"
+          v-if="hasCommasInPropertyNames && !sanitizeColumnNames"
           :type="fileFormat === 'csv' ? 'warning' : 'info'"
           variant="tonal"
           class="mb-4"
@@ -122,6 +122,13 @@
             value="selected"
           ></v-radio>
         </v-radio-group>
+
+        <v-checkbox
+          v-model="sanitizeColumnNames"
+          label="Replace special characters in column names"
+          class="mb-4"
+          hide-details
+        />
 
         <v-list-subheader>Undefined Value Handling</v-list-subheader>
         <v-radio-group v-model="undefinedHandling" class="mb-4">
@@ -285,6 +292,7 @@ const UNDEFINED_VALUE_MAP = {
 
 const PREVIEW_ANNOTATION_LIMIT = 1000;
 const DISPLAY_CHAR_LIMIT = 10000;
+const UNSAFE_CSV_COLUMN_CHARS = /[^A-Za-z0-9_]+/g;
 
 const props = defineProps<{
   annotations: IAnnotation[];
@@ -302,6 +310,7 @@ const displayText = ref("");
 const propertyExportMode = ref<"all" | "selected" | "listed">("all");
 const propertyFilter = ref("");
 const selectedPropertyPaths = ref<string[]>([]);
+const sanitizeColumnNames = ref(false);
 
 const fileFormat = ref<"csv" | "tsv">("csv");
 const fileDelimiter = computed(() => (fileFormat.value === "tsv" ? "\t" : ","));
@@ -415,6 +424,16 @@ function copyCSVText() {
   }
 }
 
+function sanitizeCsvColumnName(name: string): string {
+  return (
+    name.replace(UNSAFE_CSV_COLUMN_CHARS, "_").replace(/^_+|_+$/g, "") || "_"
+  );
+}
+
+function getCsvColumnName(name: string): string {
+  return sanitizeColumnNames.value ? sanitizeCsvColumnName(name) : name;
+}
+
 async function generateCSVStringForAnnotations() {
   isProcessing.value = true;
   processingProgress.value = 0;
@@ -430,7 +449,7 @@ async function generateCSVStringForAnnotations() {
       "Tags",
       "Shape",
       "Name",
-    ];
+    ].map(getCsvColumnName);
     const quotes = [true, false, false, false, false, true, true, true];
     const usedPaths: string[][] = [];
 
@@ -442,8 +461,9 @@ async function generateCSVStringForAnnotations() {
 
     includedPaths.forEach((path) => {
       const name = propertyStore.getFullNameFromPath(path)!;
-      fields.push(name);
-      quotes.push(name.includes(","));
+      const columnName = getCsvColumnName(name);
+      fields.push(columnName);
+      quotes.push(columnName.includes(","));
       usedPaths.push(path);
     });
 
@@ -560,6 +580,7 @@ async function downloadSingleDataset() {
         : {}),
       undefinedValue: getUndefinedValueString(),
       delimiter: fileDelimiter.value,
+      sanitizeColumnNames: sanitizeColumnNames.value,
       filename:
         filename.value || `upenn_annotation_export${fileExtension.value}`,
     });
@@ -581,6 +602,7 @@ async function downloadAllDatasets() {
       propertyPaths: getIncludedPropertyPaths(),
       undefinedValue: getUndefinedValueString(),
       delimiter: fileDelimiter.value,
+      sanitizeColumnNames: sanitizeColumnNames.value,
       onProgress: (completed) => {
         bulkExportProgress.value = completed;
       },
@@ -616,6 +638,7 @@ watch(
     propertyExportMode,
     selectedPropertyPaths,
     undefinedHandling,
+    sanitizeColumnNames,
     fileFormat,
     dialog,
     annotationScope,
@@ -635,6 +658,7 @@ defineExpose({
   propertyExportMode,
   fileFormat,
   undefinedHandling,
+  sanitizeColumnNames,
   processingProgress,
   isProcessing,
   isTooLargeForPreview,
@@ -643,6 +667,7 @@ defineExpose({
   propertyNamesWithCommas,
   hasCommasInPropertyNames,
   resetFilename,
+  sanitizeCsvColumnName,
   generateCSVStringForAnnotations,
   updateText,
   getIncludedPropertyPaths,

--- a/src/store/ExportAPI.test.ts
+++ b/src/store/ExportAPI.test.ts
@@ -22,6 +22,36 @@ describe("ExportAPI", () => {
     api = new ExportAPI(createMockClient());
   });
 
+  describe("exportCsv", () => {
+    beforeEach(() => {
+      const mockBlob = new Blob(["csv-content"], { type: "text/csv" });
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      });
+      global.URL.createObjectURL = vi.fn().mockReturnValue("blob:mock-url");
+      global.URL.revokeObjectURL = vi.fn();
+    });
+
+    it("sends sanitizeColumnNames in the request body", async () => {
+      await api.exportCsv({
+        datasetId: "ds1",
+        propertyPaths: [["propA", "sub1"]],
+        sanitizeColumnNames: true,
+      });
+
+      const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+      expect(body.sanitizeColumnNames).toBe(true);
+    });
+
+    it("defaults sanitizeColumnNames to false", async () => {
+      await api.exportCsv({ datasetId: "ds1" });
+
+      const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+      expect(body.sanitizeColumnNames).toBe(false);
+    });
+  });
+
   describe("exportBulkCsv", () => {
     beforeEach(() => {
       // Mock fetch for exportCsv calls
@@ -45,6 +75,7 @@ describe("ExportAPI", () => {
         propertyPaths: [["propA", "sub1"]],
         undefinedValue: "NA",
         delimiter: ",",
+        sanitizeColumnNames: true,
       });
 
       // Advance past delays
@@ -59,6 +90,7 @@ describe("ExportAPI", () => {
           propertyPaths: [["propA", "sub1"]],
           undefinedValue: "NA",
           delimiter: ",",
+          sanitizeColumnNames: true,
         }),
       );
       expect(exportCsvSpy).toHaveBeenCalledWith(

--- a/src/store/ExportAPI.ts
+++ b/src/store/ExportAPI.ts
@@ -17,6 +17,7 @@ export interface ICsvExportOptions {
   annotationIds?: string[];
   undefinedValue?: "" | "NA" | "NaN";
   delimiter?: "," | "\t";
+  sanitizeColumnNames?: boolean;
   filename?: string;
 }
 
@@ -40,6 +41,7 @@ export interface IBulkCsvExportOptions {
   propertyPaths?: string[][];
   undefinedValue?: "" | "NA" | "NaN";
   delimiter?: "," | "\t";
+  sanitizeColumnNames?: boolean;
   onProgress?: (completed: number, total: number) => void;
 }
 
@@ -109,6 +111,7 @@ export default class ExportAPI {
       annotationIds: options.annotationIds || [],
       undefinedValue: options.undefinedValue ?? "",
       delimiter: options.delimiter || ",",
+      sanitizeColumnNames: options.sanitizeColumnNames ?? false,
       filename: options.filename || "export.csv",
     };
 
@@ -195,6 +198,7 @@ export default class ExportAPI {
         propertyPaths: options.propertyPaths,
         undefinedValue: options.undefinedValue,
         delimiter: options.delimiter,
+        sanitizeColumnNames: options.sanitizeColumnNames,
         filename,
       });
 


### PR DESCRIPTION
## Summary
- Added an optional `sanitizeColumnNames` flag to CSV export on the backend, frontend dialog, TypeScript store client, and Python accessor.
- Sanitized headers now replace spaces, slashes, commas, punctuation, and other non-alphanumeric characters with underscores for R-friendly column names.
- Added a default-off checkbox in the CSV export dialog and kept preview/download behavior aligned with the server.
- Added backend tests for the new sanitization behavior and request plumbing, plus frontend tests for the dialog and export API.

## Testing
- `tox -e py311 -- upenncontrast_annotation/test/test_export.py` passed.
- `pnpm test -- run src/store/ExportAPI.test.ts src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts` passed.
- `pnpm tsc` passed.
- `nimbusimage/tests/test_export.py` passed using the existing tox Python environment with package dependencies installed.