### PR TITLE
Centralize Vuetify dialog width fix via .wide-dialog class

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -243,6 +243,27 @@ Persister wraps `localStorage` with JSON serialization. It's already used for th
 </v-dialog>
 ```
 
+### Wide dialogs: `class="wide-dialog"` when using percentage or `vw` widths
+
+Vuetify ships `.v-dialog { width: 50% }` on the outer overlay wrapper. The `width` / `max-width` props on `<v-dialog>` only size the inner `.v-overlay__content` — so `width="60%"` actually renders at 60% of that 50% box (= 30% of viewport), and `width="70vw"` is silently clamped to 50vw.
+
+Whenever a dialog needs a percentage or `vw` width, opt in with `class="wide-dialog"`. The shared rule lives in `src/style.scss` (look for `.wide-dialog.v-dialog { width: auto }`) and lets the prop size against the viewport directly.
+
+```vue
+<!-- Bad: width prop silently shrinks to 30% of viewport -->
+<v-dialog v-model="open" width="60%">…</v-dialog>
+
+<!-- Good: class lets the 60% prop apply to the viewport -->
+<v-dialog v-model="open" width="60%" class="wide-dialog">…</v-dialog>
+```
+
+When **not** to add the class:
+- `max-width` in pixels (e.g. `max-width="500px"`) — works correctly without the class on any reasonable screen.
+- `max-width="33vw"` and similar — `vw` max-widths smaller than 50vw fit inside the default wrapper, so the class is unnecessary.
+- Dialogs with no width prop — they rely on the implicit 50% wrapper as a sane default; adding the class would let them shrink to content width, which is usually not what's wanted for confirmation-style dialogs.
+
+If you see a dialog with a `width="N%"` or `width="Nvw"` prop and no `wide-dialog` class, it's almost certainly rendering narrower than intended — add the class.
+
 ## API Calls
 
 Use the API classes from store — never put `girderRest.get(...)` in components:

--- a/src/components/AnnotationBrowser/AnnotationProperties.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties.vue
@@ -24,6 +24,7 @@
       min-width="1150px"
       max-width="1300px"
       width="85%"
+      class="wide-dialog"
       @update:model-value="onDialogClose"
     >
       <v-card>

--- a/src/components/ColorSelectionDialog.vue
+++ b/src/components/ColorSelectionDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="showDialog" width="50%">
+  <v-dialog v-model="showDialog" width="50%" class="wide-dialog">
     <v-card>
       <v-card-title> Color selected annotations </v-card-title>
       <v-card-text>

--- a/src/components/GirderLocationChooser.vue
+++ b/src/components/GirderLocationChooser.vue
@@ -127,14 +127,3 @@ function select() {
 
 defineExpose({ dialogInternal, selectedName, select, selected });
 </script>
-
-<style lang="scss">
-// Override Vuetify 3's default .v-dialog { width: 50% } on outer overlay element.
-// Without this, width="70vw" on v-dialog only applies to the inner .v-overlay__content,
-// making the actual dialog 70vw of 50% = 35vw. (See VUE3_STEPS.md P14)
-// Note: same rule exists in ProjectInfo.vue — both are needed since unscoped
-// styles are only emitted when the component is mounted.
-.wide-dialog.v-dialog {
-  width: auto;
-}
-</style>

--- a/src/components/JobsLogs.vue
+++ b/src/components/JobsLogs.vue
@@ -19,7 +19,7 @@
           v-model="showJobsDialog"
           width="90vw"
           max-width="1400px"
-          class="jobs-logs-dialog"
+          class="wide-dialog"
         >
           <v-card>
             <v-toolbar density="compact" color="transparent">
@@ -93,7 +93,7 @@
           v-model="showLogDialog"
           width="80vw"
           max-width="1000px"
-          class="jobs-logs-dialog"
+          class="wide-dialog"
         >
           <v-card>
             <v-toolbar density="compact" color="transparent">
@@ -401,13 +401,5 @@ defineExpose({
   border-radius: 4px;
   width: 100%;
   color: rgba(255, 255, 255, 0.85);
-}
-</style>
-<style>
-/* Unscoped: v-dialog teleports to body-level overlay container.
-   Vuetify 4 defaults .v-dialog { width: 50% } on the outer overlay,
-   so the `width` prop only applies within that 50% box. (See VUE3_STEPS.md P14) */
-.jobs-logs-dialog.v-dialog {
-  width: auto;
 }
 </style>

--- a/src/components/TagSelectionDialog.vue
+++ b/src/components/TagSelectionDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="showDialog" width="50%">
+  <v-dialog v-model="showDialog" width="50%" class="wide-dialog">
     <v-card>
       <v-card-title>
         Add tags to or remove tags from selected objects

--- a/src/layout/BreadCrumbs.vue
+++ b/src/layout/BreadCrumbs.vue
@@ -117,7 +117,7 @@
     <!-- Dialog to add a dataset to the current collection -->
     <v-dialog
       content-class="smart-overflow"
-      class="add-dataset-dialog"
+      class="wide-dialog"
       v-model="addDatasetFlag"
       width="60%"
     >
@@ -561,9 +561,5 @@ defineExpose({
 
 .v-alert__content {
   min-width: 0;
-}
-
-.add-dataset-dialog.v-dialog {
-  width: auto;
 }
 </style>

--- a/src/style.scss
+++ b/src/style.scss
@@ -247,6 +247,14 @@ body {
   border-radius: var(--nimbus-radius-lg) !important;
 }
 
+/* Vuetify ships .v-dialog { width: 50% } on the outer overlay wrapper, so a
+   width="N%" or width="Nvw" prop on <v-dialog> only sizes the inner
+   .v-overlay__content within that 50% box (e.g. width="60%" → 30% of viewport).
+   Opt a dialog into using the prop directly by adding class="wide-dialog". */
+.wide-dialog.v-dialog {
+  width: auto;
+}
+
 /* Menus with v-list (e.g. GirderSearch dropdown): ensure opaque background */
 .v-menu > .v-overlay__content > .v-list {
   background: rgb(var(--v-theme-surface-bright)) !important;

--- a/src/tools/toolsets/Toolset.vue
+++ b/src/tools/toolsets/Toolset.vue
@@ -117,7 +117,7 @@
     v-model="toolCreationDialogOpen"
     :width="toolCreationWide ? '85%' : '55%'"
     :max-width="toolCreationWide ? '1400px' : '800px'"
-    class="tool-creation-dialog"
+    class="wide-dialog"
     @update:model-value="onToolCreationDialogInput"
   >
     <tool-creation
@@ -275,13 +275,5 @@ defineExpose({
 .tight-list :deep(.v-list-item) {
   padding-left: 8px;
   padding-right: 4px;
-}
-</style>
-<style>
-/* Unscoped: v-dialog teleports to body-level overlay container.
-   Vuetify 3 defaults .v-dialog { width: 50% } on the outer overlay,
-   making percentage-based content widths relative to half the viewport. */
-.tool-creation-dialog.v-dialog {
-  width: auto;
 }
 </style>

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -134,6 +134,7 @@
         </div>
         <v-dialog
           content-class="smart-overflow"
+          class="wide-dialog"
           v-model="addDatasetDialog"
           width="60%"
         >

--- a/src/views/project/ProjectInfo.vue
+++ b/src/views/project/ProjectInfo.vue
@@ -1153,12 +1153,3 @@ defineExpose({
   align-items: center;
 }
 </style>
-
-<style lang="scss">
-// Override Vuetify 3's default .v-dialog { width: 50% } on outer overlay element.
-// Without this, width="70%" on v-dialog only applies to the inner .v-overlay__content,
-// making the actual dialog 90% of 50% = 45% of viewport. (See VUE3_STEPS.md P14)
-.wide-dialog.v-dialog {
-  width: auto;
-}
-</style>


### PR DESCRIPTION
## Summary
- Replace five duplicated per-component dialog-width overrides (`tool-creation-dialog`, `add-dataset-dialog`, two `wide-dialog` blocks, `jobs-logs-dialog`) with a single opt-in `.wide-dialog.v-dialog { width: auto }` rule in `src/style.scss`.
- Fix three dialogs that were silently rendering too narrow because they had no override: `ColorSelectionDialog`, `TagSelectionDialog`, and `AnnotationBrowser/AnnotationProperties` (the "Measure objects" dialog).
- Document the pattern in the `nimbus-frontend` skill so the next dialog with `width="N%"` or `width="Nvw"` doesn't repeat the mistake.

### Background
Vuetify ships `.v-dialog { width: 50% }` on the outer overlay wrapper. The `width` prop on `<v-dialog>` only sizes the inner `.v-overlay__content`, so `width="60%"` actually rendered at 60% of that 50% box (30% of viewport), and `width="70vw"` was silently clamped to 50vw. (See `VUE3_STEPS.md` P14 for the original root-cause analysis.)

I first tried a fully global `.v-dialog { width: auto }`, but that let every dialog without a `width` prop auto-expand to its content — too wide for confirmation dialogs that had been relying on the implicit 50% wrapper. The class-based opt-in keeps the original default for the ~20 dialogs that didn't need a fix while still centralizing the override.

### When to use `class="wide-dialog"`
- ✅ `width="N%"` or `width="Nvw"` (>50vw) — the prop only works correctly with the class.
- ❌ `max-width` in pixels — works without the class.
- ❌ `max-width="33vw"` and similar small `vw` max-widths — fit inside the default wrapper.
- ❌ No width prop — adding the class lets content shrink the dialog, usually not desired.

## Test plan
- [ ] Configuration page → "Add dataset to current collection" — dialog renders at intended 60vw width.
- [ ] Project page → "Add dataset / Add collection" dialogs render at 70vw.
- [ ] Breadcrumb add-dataset shortcut renders at 60vw.
- [ ] Tool creation dialog (Toolset → "+"): default + Advanced-mode (toggle wider state).
- [ ] GirderLocationChooser dialog (used in upload / collection picker) renders at 70vw.
- [ ] Jobs / Logs dialogs render at 90vw / 80vw.
- [ ] Annotation browser → Measure objects ("Analyze") dialog renders at 85vw.
- [ ] Tag selection dialog and "Color selected annotations" dialog (annotation context menu) render at 50vw.
- [ ] Confirmation dialogs without a width prop (e.g. remove-dataset, delete-collection, scale dialog, file manager rename/delete) are visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)