### PR TITLE
[codex] Fix collection chips in location chooser

### DIFF
--- a/src/components/GirderLocationChooser.test.ts
+++ b/src/components/GirderLocationChooser.test.ts
@@ -15,8 +15,30 @@ function mountComponent(props = {}) {
     },
     global: {
       stubs: {
-        CustomFileManager: true,
+        CustomFileManager: {
+          name: "CustomFileManager",
+          props: [
+            "location",
+            "itemsPerPage",
+            "itemsPerPageOptions",
+            "menuEnabled",
+            "moreChips",
+            "clickableChips",
+          ],
+          template: "<div />",
+        },
         GirderBreadcrumb: true,
+        VDialog: {
+          props: ["modelValue"],
+          template:
+            "<div><slot name='activator' :props='{}' /><slot /></div>",
+        },
+        VCard: { template: "<div><slot /></div>" },
+        VCardTitle: { template: "<div><slot /></div>" },
+        VCardText: { template: "<div><slot /></div>" },
+        VCardActions: { template: "<div><slot /></div>" },
+        VSpacer: { template: "<div />" },
+        VBtn: { template: "<button><slot /></button>" },
       },
     },
   });
@@ -74,5 +96,13 @@ describe("GirderLocationChooser", () => {
     const newVal = { name: "New Folder", _modelType: "folder" };
     await wrapper.setProps({ modelValue: newVal as any });
     expect(wrapper.vm.selected).toEqual(newVal);
+  });
+
+  it("keeps collection relation chips enabled but not clickable", () => {
+    const wrapper = mountComponent();
+    const fileManager = wrapper.findComponent({ name: "CustomFileManager" });
+
+    expect(fileManager.props("moreChips")).toBeUndefined();
+    expect(fileManager.props("clickableChips")).toBe(false);
   });
 });

--- a/src/components/GirderLocationChooser.test.ts
+++ b/src/components/GirderLocationChooser.test.ts
@@ -30,8 +30,7 @@ function mountComponent(props = {}) {
         GirderBreadcrumb: true,
         VDialog: {
           props: ["modelValue"],
-          template:
-            "<div><slot name='activator' :props='{}' /><slot /></div>",
+          template: "<div><slot name='activator' :props='{}' /><slot /></div>",
         },
         VCard: { template: "<div><slot /></div>" },
         VCardTitle: { template: "<div><slot /></div>" },
@@ -102,7 +101,9 @@ describe("GirderLocationChooser", () => {
     const wrapper = mountComponent();
     const fileManager = wrapper.findComponent({ name: "CustomFileManager" });
 
-    expect(fileManager.props("moreChips")).toBeUndefined();
+    // moreChips should fall back to CustomFileManager's default (true).
+    // clickableChips stays explicitly false so chips do not navigate.
+    expect(fileManager.props("moreChips") ?? true).toBe(true);
     expect(fileManager.props("clickableChips")).toBe(false);
   });
 });

--- a/src/components/GirderLocationChooser.vue
+++ b/src/components/GirderLocationChooser.vue
@@ -33,7 +33,6 @@
           :items-per-page="-1"
           :items-per-page-options="[-1]"
           :menu-enabled="false"
-          :more-chips="false"
           :clickable-chips="false"
         />
       </v-card-text>


### PR DESCRIPTION
## Summary

- Restore collection relation chips inside `GirderLocationChooser` by letting `CustomFileManager` keep its default `moreChips` behavior.
- Keep chips non-clickable in the chooser dialog so it remains a folder picker rather than a navigation surface.
- Add a regression test that verifies relation chips are enabled while clickable chips stay disabled.

## Root Cause

`GirderLocationChooser` was passing `:more-chips="false"` to `CustomFileManager`. That short-circuited the dataset-view mapping lookup, so `FileItemRow` only saw the header `Dataset` chip and displayed `Not in a collection` for every dataset.

## Validation

- `pnpm vitest run src/components/GirderLocationChooser.test.ts src/components/CustomFileManager.test.ts`

Note: the test run still emits existing Vuetify/jsdom CSS warnings and a sandbox Vite websocket `EPERM` warning, but exits successfully.