### PR TITLE
[codex] Add collection navigator for import flow

### DIFF
--- a/src/components/CollectionNavigator.test.ts
+++ b/src/components/CollectionNavigator.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { shallowMount, flushPromises } from "@vue/test-utils";
+
+const mockGetFolders = vi.fn();
+const mockGetAllConfigurations = vi.fn();
+const mockFindDatasetViews = vi.fn();
+const mockGetUserPrivateFolder = vi.fn();
+
+let mockDataset: any = {
+  id: "dataset-1",
+  name: "Dataset 1",
+  channels: [{ channel: 0, frameIndex: 0 }],
+};
+
+vi.mock("@/store", () => ({
+  default: {
+    get dataset() {
+      return mockDataset;
+    },
+    girderUser: {
+      _id: "user-1",
+      _modelType: "user",
+      login: "user",
+      name: "user",
+    },
+    api: {
+      getFolders: (...args: any[]) => mockGetFolders(...args),
+      getAllConfigurations: (...args: any[]) =>
+        mockGetAllConfigurations(...args),
+      findDatasetViews: (...args: any[]) => mockFindDatasetViews(...args),
+      getUserPrivateFolder: (...args: any[]) =>
+        mockGetUserPrivateFolder(...args),
+    },
+  },
+}));
+
+vi.mock("@/store/model", () => ({
+  areCompatibles: vi.fn(
+    (configurationCompatibility: any, datasetCompatibility: any) =>
+      configurationCompatibility?.channels === datasetCompatibility?.channels,
+  ),
+}));
+
+vi.mock("@/store/GirderAPI", () => ({
+  getDatasetCompatibility: vi.fn((dataset: any) => ({
+    channels: dataset.channels?.length ?? 0,
+  })),
+}));
+
+vi.mock("@/utils/log", () => ({
+  logError: vi.fn(),
+}));
+
+import CollectionNavigator from "./CollectionNavigator.vue";
+
+const rootFolder = {
+  _id: "folder-1",
+  _modelType: "folder" as const,
+  name: "Folder 1",
+  description: "",
+  creatorId: "user-1",
+  meta: {},
+};
+
+function mountComponent(props = {}) {
+  return shallowMount(CollectionNavigator, {
+    props: {
+      location: rootFolder,
+      useDefaultLocation: false,
+      ...props,
+    },
+    global: {
+      stubs: {
+        GirderBreadcrumb: true,
+      },
+    },
+  });
+}
+
+describe("CollectionNavigator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDataset = {
+      id: "dataset-1",
+      name: "Dataset 1",
+      channels: [{ channel: 0, frameIndex: 0 }],
+    };
+    mockGetFolders.mockResolvedValue([
+      {
+        _id: "folder-b",
+        _modelType: "folder",
+        name: "Bravo",
+        description: "",
+        meta: {},
+      },
+      {
+        _id: "dataset-folder",
+        _modelType: "folder",
+        name: "Dataset Folder",
+        description: "",
+        meta: { subtype: "contrastDataset" },
+      },
+      {
+        _id: "folder-a",
+        _modelType: "folder",
+        name: "Alpha",
+        description: "",
+        meta: {},
+      },
+    ]);
+    mockGetAllConfigurations.mockResolvedValue([
+      {
+        id: "linked",
+        name: "Already Linked",
+        description: "",
+        compatibility: { channels: 1 },
+      },
+      {
+        id: "compatible",
+        name: "Compatible",
+        description: "",
+        compatibility: { channels: 1 },
+      },
+      {
+        id: "incompatible",
+        name: "Incompatible",
+        description: "",
+        compatibility: { channels: 2 },
+      },
+    ]);
+    mockFindDatasetViews.mockResolvedValue([{ configurationId: "linked" }]);
+    mockGetUserPrivateFolder.mockResolvedValue(rootFolder);
+  });
+
+  it("shows normal folders and compatible unlinked collections", async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const vm = wrapper.vm as any;
+
+    expect(mockGetFolders).toHaveBeenCalledWith("folder-1", "folder");
+    expect(mockGetAllConfigurations).toHaveBeenCalledWith("folder-1");
+    expect(mockFindDatasetViews).toHaveBeenCalledWith({
+      datasetId: "dataset-1",
+    });
+    expect(vm.folders.map((folder: any) => folder._id)).toEqual([
+      "folder-a",
+      "folder-b",
+    ]);
+    expect(
+      vm.configurations.map((configuration: any) => configuration.id),
+    ).toEqual(["compatible"]);
+  });
+
+  it("navigates by emitting the selected folder location", async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const folder = (wrapper.vm as any).folders[0];
+    (wrapper.vm as any).navigateToLocation(folder);
+
+    expect(wrapper.emitted("update:location")?.[0]).toEqual([folder]);
+  });
+
+  it("emits selected collections on submit", async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const vm = wrapper.vm as any;
+    vm.toggleSelection(vm.configurations[0]);
+    vm.submit();
+
+    expect(vm.selectedConfigurations).toHaveLength(1);
+    expect(wrapper.emitted("submit")?.[0][0]).toEqual([
+      expect.objectContaining({ id: "compatible" }),
+    ]);
+  });
+
+  it("fetches folders but not collections at a user location", async () => {
+    const userLocation = {
+      _id: "user-1",
+      _modelType: "user" as const,
+      login: "user",
+      email: "user@example.com",
+      firstName: "First",
+      lastName: "Last",
+      name: "user",
+    };
+
+    const wrapper = mountComponent({ location: userLocation });
+    await flushPromises();
+
+    expect(mockGetFolders).toHaveBeenCalledWith("user-1", "user");
+    expect(mockGetAllConfigurations).not.toHaveBeenCalled();
+    expect((wrapper.vm as any).configurations).toEqual([]);
+  });
+});

--- a/src/components/CollectionNavigator.test.ts
+++ b/src/components/CollectionNavigator.test.ts
@@ -132,7 +132,7 @@ describe("CollectionNavigator", () => {
     mockGetUserPrivateFolder.mockResolvedValue(rootFolder);
   });
 
-  it("shows normal folders and compatible unlinked collections", async () => {
+  it("shows normal folders, compatible collections, and incompatible collections", async () => {
     const wrapper = mountComponent();
     await flushPromises();
 
@@ -150,6 +150,26 @@ describe("CollectionNavigator", () => {
     expect(
       vm.configurations.map((configuration: any) => configuration.id),
     ).toEqual(["compatible"]);
+    expect(
+      vm.incompatibleConfigurations.map(
+        (configuration: any) => configuration.id,
+      ),
+    ).toEqual(["incompatible"]);
+  });
+
+  it("filters incompatible collections separately from selectable collections", async () => {
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const vm = wrapper.vm as any;
+    vm.search = "incompatible";
+
+    expect(vm.filteredConfigurations).toEqual([]);
+    expect(
+      vm.filteredIncompatibleConfigurations.map(
+        (configuration: any) => configuration.id,
+      ),
+    ).toEqual(["incompatible"]);
   });
 
   it("navigates by emitting the selected folder location", async () => {
@@ -193,5 +213,6 @@ describe("CollectionNavigator", () => {
     expect(mockGetFolders).toHaveBeenCalledWith("user-1", "user");
     expect(mockGetAllConfigurations).not.toHaveBeenCalled();
     expect((wrapper.vm as any).configurations).toEqual([]);
+    expect((wrapper.vm as any).incompatibleConfigurations).toEqual([]);
   });
 });

--- a/src/components/CollectionNavigator.vue
+++ b/src/components/CollectionNavigator.vue
@@ -34,7 +34,11 @@
 
       <div v-else class="navigator-list-wrap">
         <v-list
-          v-if="filteredFolders.length || filteredConfigurations.length"
+          v-if="
+            filteredFolders.length ||
+            filteredConfigurations.length ||
+            filteredIncompatibleConfigurations.length
+          "
           class="navigator-list"
           density="compact"
         >
@@ -56,7 +60,7 @@
           </v-list-item>
 
           <v-list-subheader v-if="filteredConfigurations.length">
-            Collections
+            Compatible Collections
           </v-list-subheader>
           <v-list-item
             v-for="configuration in filteredConfigurations"
@@ -79,6 +83,27 @@
               {{ configuration.description }}
             </v-list-item-subtitle>
           </v-list-item>
+
+          <v-list-subheader v-if="filteredIncompatibleConfigurations.length">
+            Incompatible Collections
+          </v-list-subheader>
+          <v-list-item
+            v-for="configuration in filteredIncompatibleConfigurations"
+            :key="`incompatible-configuration-${configuration.id}`"
+            disabled
+            class="incompatible-configuration"
+          >
+            <template #prepend>
+              <v-icon color="grey">mdi-file-tree-outline</v-icon>
+            </template>
+            <v-list-item-title>{{ configuration.name }}</v-list-item-title>
+            <v-list-item-subtitle v-if="configuration.description">
+              {{ configuration.description }}
+            </v-list-item-subtitle>
+            <v-list-item-subtitle>
+              Not compatible with this dataset
+            </v-list-item-subtitle>
+          </v-list-item>
         </v-list>
 
         <div v-else class="empty-state text-center pa-6">
@@ -86,8 +111,8 @@
           <div class="text-body-1 text-grey mt-2">
             {{
               search
-                ? "No folders or compatible collections match your search"
-                : "No folders or compatible collections in this folder"
+                ? "No folders or collections match your search"
+                : "No folders or collections in this folder"
             }}
           </div>
         </div>
@@ -153,6 +178,7 @@ const errorMessage = ref("");
 const search = ref("");
 const folders = ref<IGirderFolder[]>([]);
 const configurations = ref<IDatasetConfiguration[]>([]);
+const incompatibleConfigurations = ref<IDatasetConfiguration[]>([]);
 const selectedConfigurationMap = ref<Map<string, IDatasetConfiguration>>(
   new Map(),
 );
@@ -194,6 +220,18 @@ const filteredConfigurations = computed(() => {
   );
 });
 
+const filteredIncompatibleConfigurations = computed(() => {
+  const query = search.value.trim().toLowerCase();
+  if (!query) {
+    return incompatibleConfigurations.value;
+  }
+  return incompatibleConfigurations.value.filter(
+    (configuration) =>
+      configuration.name.toLowerCase().includes(query) ||
+      configuration.description?.toLowerCase().includes(query),
+  );
+});
+
 function folderId(location: IGirderLocation): string | null {
   if ("_modelType" in location && location._modelType === "folder") {
     return location._id;
@@ -217,6 +255,7 @@ async function refreshRows() {
   if (!location) {
     folders.value = [];
     configurations.value = [];
+    incompatibleConfigurations.value = [];
     loading.value = false;
     return;
   }
@@ -266,14 +305,20 @@ async function refreshRows() {
 
     if (!dataset.value) {
       configurations.value = [];
+      incompatibleConfigurations.value = [];
       return;
     }
 
     const datasetCompatibility = getDatasetCompatibility(dataset.value);
-    configurations.value = folderConfigurations.filter(
+    const unlinkedConfigurations = folderConfigurations.filter(
+      (configuration) => !linkedConfigurationIds.has(configuration.id),
+    );
+    configurations.value = unlinkedConfigurations.filter((configuration) =>
+      areCompatibles(configuration.compatibility, datasetCompatibility),
+    );
+    incompatibleConfigurations.value = unlinkedConfigurations.filter(
       (configuration) =>
-        !linkedConfigurationIds.has(configuration.id) &&
-        areCompatibles(configuration.compatibility, datasetCompatibility),
+        !areCompatibles(configuration.compatibility, datasetCompatibility),
     );
   } catch (error) {
     if (generation !== fetchGeneration) {
@@ -282,6 +327,7 @@ async function refreshRows() {
     logError("Failed to fetch collection navigator rows:", error);
     folders.value = [];
     configurations.value = [];
+    incompatibleConfigurations.value = [];
     errorMessage.value = "Could not load collections for this folder.";
   } finally {
     if (generation === fetchGeneration) {
@@ -324,6 +370,7 @@ defineExpose({
   search,
   folders,
   configurations,
+  incompatibleConfigurations,
   selectedConfigurationMap,
   dataset,
   currentLocation,
@@ -331,6 +378,7 @@ defineExpose({
   selectedConfigurationIds,
   filteredFolders,
   filteredConfigurations,
+  filteredIncompatibleConfigurations,
   refreshRows,
   navigateToLocation,
   toggleSelection,
@@ -377,6 +425,10 @@ defineExpose({
 
 .navigator-list {
   padding: 0;
+}
+
+.incompatible-configuration {
+  opacity: 0.62;
 }
 
 .collection-navigator-actions {

--- a/src/components/CollectionNavigator.vue
+++ b/src/components/CollectionNavigator.vue
@@ -103,7 +103,7 @@
         }}
       </span>
       <v-btn
-        :disabled="selectedConfigurations.length <= 0"
+        :disabled="selectedConfigurations.length === 0"
         color="primary"
         class="mr-4"
         @click="submit"
@@ -119,9 +119,14 @@ import { computed, onMounted, ref, watch } from "vue";
 import { Breadcrumb as GirderBreadcrumb } from "@/girder/components";
 import { IGirderFolder, IGirderLocation, IGirderSelectAble } from "@/girder";
 import store from "@/store";
-import { areCompatibles, IDatasetConfiguration } from "@/store/model";
+import {
+  areCompatibles,
+  IDatasetConfiguration,
+  IDatasetView,
+} from "@/store/model";
 import { getDatasetCompatibility } from "@/store/GirderAPI";
 import { isDatasetFolder } from "@/utils/girderSelectable";
+import { getDefaultGirderLocation } from "@/utils/girderLocation";
 import { logError } from "@/utils/log";
 
 const props = withDefaults(
@@ -204,13 +209,7 @@ async function initializeDefaultLocation() {
   if (!props.useDefaultLocation || currentLocation.value) {
     return;
   }
-  try {
-    const privateFolder = await store.api.getUserPrivateFolder();
-    emit("update:location", privateFolder || store.girderUser);
-  } catch (error) {
-    logError("Failed to initialize collection navigator location:", error);
-    emit("update:location", store.girderUser);
-  }
+  emit("update:location", await getDefaultGirderLocation());
 }
 
 async function refreshRows() {
@@ -259,7 +258,7 @@ async function refreshRows() {
     );
 
     const linkedConfigurationIds = new Set<string>(
-      linkedViews.map((view: any) => String(view.configurationId)),
+      linkedViews.map((view: IDatasetView) => String(view.configurationId)),
     );
     const nextSelected = new Map(selectedConfigurationMap.value);
     linkedConfigurationIds.forEach((id) => nextSelected.delete(id));

--- a/src/components/CollectionNavigator.vue
+++ b/src/components/CollectionNavigator.vue
@@ -1,0 +1,386 @@
+<template>
+  <v-card class="collection-navigator-card">
+    <v-card-title class="collection-navigator-title">
+      {{ title }}
+    </v-card-title>
+
+    <v-card-text class="collection-navigator-content">
+      <div class="navigator-toolbar">
+        <div class="breadcrumb-wrap">
+          <girder-breadcrumb
+            v-if="currentLocation"
+            :location="currentLocation"
+            root-location-disabled
+            @crumb-click="navigateToLocation"
+          />
+          <span v-else class="text-medium-emphasis">Loading...</span>
+        </div>
+      </div>
+
+      <v-text-field
+        v-model="search"
+        append-icon="mdi-magnify"
+        label="Search"
+        single-line
+        hide-details
+        class="mb-2"
+      />
+
+      <v-progress-linear v-if="loading" indeterminate />
+
+      <v-alert v-else-if="errorMessage" type="error" density="compact">
+        {{ errorMessage }}
+      </v-alert>
+
+      <div v-else class="navigator-list-wrap">
+        <v-list
+          v-if="filteredFolders.length || filteredConfigurations.length"
+          class="navigator-list"
+          density="compact"
+        >
+          <v-list-subheader v-if="filteredFolders.length">
+            Folders
+          </v-list-subheader>
+          <v-list-item
+            v-for="folder in filteredFolders"
+            :key="`folder-${folder._id}`"
+            @click="navigateToLocation(folder)"
+          >
+            <template #prepend>
+              <v-icon color="primary">mdi-folder</v-icon>
+            </template>
+            <v-list-item-title>{{ folder.name }}</v-list-item-title>
+            <v-list-item-subtitle v-if="folder.description">
+              {{ folder.description }}
+            </v-list-item-subtitle>
+          </v-list-item>
+
+          <v-list-subheader v-if="filteredConfigurations.length">
+            Collections
+          </v-list-subheader>
+          <v-list-item
+            v-for="configuration in filteredConfigurations"
+            :key="`configuration-${configuration.id}`"
+            :active="selectedConfigurationIds.has(configuration.id)"
+            @click="toggleSelection(configuration)"
+          >
+            <template #prepend>
+              <v-checkbox
+                :model-value="selectedConfigurationIds.has(configuration.id)"
+                hide-details
+                density="compact"
+                color="primary"
+                @click.stop
+                @update:model-value="toggleSelection(configuration)"
+              />
+            </template>
+            <v-list-item-title>{{ configuration.name }}</v-list-item-title>
+            <v-list-item-subtitle v-if="configuration.description">
+              {{ configuration.description }}
+            </v-list-item-subtitle>
+          </v-list-item>
+        </v-list>
+
+        <div v-else class="empty-state text-center pa-6">
+          <v-icon size="48" color="grey">mdi-file-tree</v-icon>
+          <div class="text-body-1 text-grey mt-2">
+            {{
+              search
+                ? "No folders or compatible collections match your search"
+                : "No folders or compatible collections in this folder"
+            }}
+          </div>
+        </div>
+      </div>
+    </v-card-text>
+
+    <v-card-actions class="collection-navigator-actions">
+      <v-btn color="warning" class="mr-4" @click="cancel">Cancel</v-btn>
+      <v-spacer />
+      <span v-if="selectedConfigurations.length" class="text-caption mr-3">
+        Selected {{ selectedConfigurations.length }} collection{{
+          selectedConfigurations.length === 1 ? "" : "s"
+        }}
+      </span>
+      <v-btn
+        :disabled="selectedConfigurations.length <= 0"
+        color="primary"
+        class="mr-4"
+        @click="submit"
+      >
+        Submit
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from "vue";
+import { Breadcrumb as GirderBreadcrumb } from "@/girder/components";
+import { IGirderFolder, IGirderLocation, IGirderSelectAble } from "@/girder";
+import store from "@/store";
+import { areCompatibles, IDatasetConfiguration } from "@/store/model";
+import { getDatasetCompatibility } from "@/store/GirderAPI";
+import { isDatasetFolder } from "@/utils/girderSelectable";
+import { logError } from "@/utils/log";
+
+const props = withDefaults(
+  defineProps<{
+    title?: string;
+    location?: IGirderLocation | null;
+    useDefaultLocation?: boolean;
+  }>(),
+  {
+    title: "Select collections",
+    location: null,
+    useDefaultLocation: true,
+  },
+);
+
+const emit = defineEmits<{
+  (e: "update:location", value: IGirderLocation | null): void;
+  (e: "submit", configurations: IDatasetConfiguration[]): void;
+  (e: "cancel"): void;
+}>();
+
+const loading = ref(false);
+const errorMessage = ref("");
+const search = ref("");
+const folders = ref<IGirderFolder[]>([]);
+const configurations = ref<IDatasetConfiguration[]>([]);
+const selectedConfigurationMap = ref<Map<string, IDatasetConfiguration>>(
+  new Map(),
+);
+let fetchGeneration = 0;
+
+const dataset = computed(() => store.dataset);
+
+const currentLocation = computed(() => props.location ?? null);
+
+const selectedConfigurations = computed(() =>
+  Array.from(selectedConfigurationMap.value.values()),
+);
+
+const selectedConfigurationIds = computed(
+  () => new Set(selectedConfigurationMap.value.keys()),
+);
+
+const filteredFolders = computed(() => {
+  const query = search.value.trim().toLowerCase();
+  if (!query) {
+    return folders.value;
+  }
+  return folders.value.filter(
+    (folder) =>
+      folder.name.toLowerCase().includes(query) ||
+      folder.description?.toLowerCase().includes(query),
+  );
+});
+
+const filteredConfigurations = computed(() => {
+  const query = search.value.trim().toLowerCase();
+  if (!query) {
+    return configurations.value;
+  }
+  return configurations.value.filter(
+    (configuration) =>
+      configuration.name.toLowerCase().includes(query) ||
+      configuration.description?.toLowerCase().includes(query),
+  );
+});
+
+function folderId(location: IGirderLocation): string | null {
+  if ("_modelType" in location && location._modelType === "folder") {
+    return location._id;
+  }
+  return null;
+}
+
+function sortedFolders(items: IGirderFolder[]) {
+  return [...items].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function initializeDefaultLocation() {
+  if (!props.useDefaultLocation || currentLocation.value) {
+    return;
+  }
+  try {
+    const privateFolder = await store.api.getUserPrivateFolder();
+    emit("update:location", privateFolder || store.girderUser);
+  } catch (error) {
+    logError("Failed to initialize collection navigator location:", error);
+    emit("update:location", store.girderUser);
+  }
+}
+
+async function refreshRows() {
+  const location = currentLocation.value;
+  if (!location) {
+    folders.value = [];
+    configurations.value = [];
+    loading.value = false;
+    return;
+  }
+
+  const generation = ++fetchGeneration;
+  loading.value = true;
+  errorMessage.value = "";
+
+  try {
+    const currentFolderId = folderId(location);
+
+    const foldersPromise =
+      "_modelType" in location &&
+      (location._modelType === "folder" || location._modelType === "user")
+        ? store.api.getFolders(location._id, location._modelType)
+        : Promise.resolve([]);
+
+    const configurationsPromise =
+      currentFolderId && dataset.value
+        ? store.api.getAllConfigurations(currentFolderId)
+        : Promise.resolve([]);
+
+    const linkedViewsPromise = dataset.value
+      ? store.api.findDatasetViews({ datasetId: dataset.value.id })
+      : Promise.resolve([]);
+
+    const [childFolders, folderConfigurations, linkedViews] = await Promise.all(
+      [foldersPromise, configurationsPromise, linkedViewsPromise],
+    );
+
+    if (generation !== fetchGeneration) {
+      return;
+    }
+
+    folders.value = sortedFolders(
+      childFolders.filter(
+        (folder) => !isDatasetFolder(folder as IGirderSelectAble),
+      ),
+    );
+
+    const linkedConfigurationIds = new Set<string>(
+      linkedViews.map((view: any) => String(view.configurationId)),
+    );
+    const nextSelected = new Map(selectedConfigurationMap.value);
+    linkedConfigurationIds.forEach((id) => nextSelected.delete(id));
+    selectedConfigurationMap.value = nextSelected;
+
+    if (!dataset.value) {
+      configurations.value = [];
+      return;
+    }
+
+    const datasetCompatibility = getDatasetCompatibility(dataset.value);
+    configurations.value = folderConfigurations.filter(
+      (configuration) =>
+        !linkedConfigurationIds.has(configuration.id) &&
+        areCompatibles(configuration.compatibility, datasetCompatibility),
+    );
+  } catch (error) {
+    if (generation !== fetchGeneration) {
+      return;
+    }
+    logError("Failed to fetch collection navigator rows:", error);
+    folders.value = [];
+    configurations.value = [];
+    errorMessage.value = "Could not load collections for this folder.";
+  } finally {
+    if (generation === fetchGeneration) {
+      loading.value = false;
+    }
+  }
+}
+
+function navigateToLocation(location: IGirderLocation) {
+  emit("update:location", location);
+}
+
+function toggleSelection(configuration: IDatasetConfiguration) {
+  const nextSelected = new Map(selectedConfigurationMap.value);
+  if (nextSelected.has(configuration.id)) {
+    nextSelected.delete(configuration.id);
+  } else {
+    nextSelected.set(configuration.id, configuration);
+  }
+  selectedConfigurationMap.value = nextSelected;
+}
+
+function submit() {
+  emit("submit", selectedConfigurations.value);
+}
+
+function cancel() {
+  emit("cancel");
+}
+
+watch([currentLocation, dataset], refreshRows, { immediate: true });
+
+onMounted(() => {
+  initializeDefaultLocation();
+});
+
+defineExpose({
+  loading,
+  errorMessage,
+  search,
+  folders,
+  configurations,
+  selectedConfigurationMap,
+  dataset,
+  currentLocation,
+  selectedConfigurations,
+  selectedConfigurationIds,
+  filteredFolders,
+  filteredConfigurations,
+  refreshRows,
+  navigateToLocation,
+  toggleSelection,
+  submit,
+  cancel,
+});
+</script>
+
+<style scoped lang="scss">
+.collection-navigator-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.collection-navigator-title {
+  flex-shrink: 0;
+}
+
+.collection-navigator-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.navigator-toolbar {
+  align-items: center;
+  display: flex;
+  margin-bottom: 12px;
+  min-height: 32px;
+}
+
+.breadcrumb-wrap {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.navigator-list-wrap {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.navigator-list {
+  padding: 0;
+}
+
+.collection-navigator-actions {
+  flex-shrink: 0;
+}
+</style>

--- a/src/utils/girderLocation.ts
+++ b/src/utils/girderLocation.ts
@@ -1,0 +1,13 @@
+import { IGirderLocation } from "@/girder";
+import store from "@/store";
+import { logError } from "@/utils/log";
+
+export async function getDefaultGirderLocation(): Promise<IGirderLocation | null> {
+  try {
+    const privateFolder = await store.api.getUserPrivateFolder();
+    return privateFolder || store.girderUser;
+  } catch (error) {
+    logError("Failed to fetch default Girder location:", error);
+    return store.girderUser;
+  }
+}

--- a/src/utils/girderSelectable.ts
+++ b/src/utils/girderSelectable.ts
@@ -3,8 +3,8 @@ import { IGirderFolder, IGirderItem, IGirderSelectAble } from "@/girder";
 export function isConfigurationItem(selectable: IGirderSelectAble): boolean {
   return (
     selectable._modelType === "upenn_collection" &&
-    selectable.meta.subtype === "contrastConfiguration" &&
-    selectable.meta.compatibility
+    selectable.meta?.subtype === "contrastConfiguration" &&
+    selectable.meta?.compatibility
   );
 }
 
@@ -17,7 +17,7 @@ export function toConfigurationItem(
 export function isDatasetFolder(selectable: IGirderSelectAble): boolean {
   return (
     selectable._modelType === "folder" &&
-    selectable.meta.subtype === "contrastDataset"
+    selectable.meta?.subtype === "contrastDataset"
   );
 }
 

--- a/src/views/configuration/ImportConfiguration.test.ts
+++ b/src/views/configuration/ImportConfiguration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 
 vi.mock("@/store", () => ({
   default: {
@@ -70,19 +70,23 @@ describe("ImportConfiguration", () => {
     expect(mockRouter.back).toHaveBeenCalled();
   });
 
-  it("folderId derives from selectedFolder", async () => {
+  it("does not replace a user-selected folder during reinitialization", async () => {
     const wrapper = mountComponent();
-    (wrapper.vm as any).selectedFolder = {
-      _id: "folder-abc",
-      name: "Abc",
+    await flushPromises();
+
+    const userFolder = {
+      _id: "user-folder",
+      name: "User Folder",
       _modelType: "folder",
     };
-    expect((wrapper.vm as any).folderId).toBe("folder-abc");
-  });
 
-  it("folderId falls back to route query", () => {
-    const wrapper = mountComponent({ folderId: "query-folder" });
-    expect((wrapper.vm as any).folderId).toBe("query-folder");
+    (wrapper.vm as any).onNavigatorLocationUpdate(userFolder);
+    await (wrapper.vm as any).initializeSelectedFolder({
+      replaceDefault: true,
+    });
+
+    expect((wrapper.vm as any).selectedFolder).toEqual(userFolder);
+    expect((wrapper.vm as any).selectedFolderSource).toBe("user");
   });
 
   it("submit calls createDatasetView for each configuration", async () => {

--- a/src/views/configuration/ImportConfiguration.test.ts
+++ b/src/views/configuration/ImportConfiguration.test.ts
@@ -4,6 +4,21 @@ import { mount } from "@vue/test-utils";
 vi.mock("@/store", () => ({
   default: {
     dataset: { id: "ds-1", name: "Test Dataset" },
+    selectedDatasetId: "ds-1",
+    setSelectedDataset: vi.fn().mockResolvedValue(undefined),
+    girderUser: {
+      _id: "user-1",
+      _modelType: "user",
+      login: "user",
+      name: "user",
+    },
+    api: {
+      getUserPrivateFolder: vi.fn().mockResolvedValue({
+        _id: "private-folder",
+        name: "Private",
+        _modelType: "folder",
+      }),
+    },
     createDatasetView: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -33,8 +48,7 @@ function mountComponent(routeQuery = {}) {
         ...routerProvider(mockRouter),
       },
       stubs: {
-        ConfigurationSelect: true,
-        GirderLocationChooser: true,
+        CollectionNavigator: true,
       },
     },
   });

--- a/src/views/configuration/ImportConfiguration.vue
+++ b/src/views/configuration/ImportConfiguration.vue
@@ -1,26 +1,11 @@
 <template>
   <v-container>
-    <v-card class="mb-4">
-      <v-card-title>Search Location</v-card-title>
-      <v-card-text>
-        <div class="d-flex align-center">
-          <span class="mr-4">
-            <strong>Current folder:</strong>
-            {{ currentFolderName || "Loading..." }}
-          </span>
-          <girder-location-chooser
-            v-model="selectedFolder"
-            :breadcrumb="true"
-            title="Select a folder to search for collections"
-          />
-        </div>
-      </v-card-text>
-    </v-card>
-    <configuration-select
+    <collection-navigator
+      v-model:location="selectedFolder"
       @submit="submit"
       @cancel="cancel"
       :title="`Add dataset ${datasetName} to one or several existing collections`"
-      :folderId="folderId"
+      :use-default-location="false"
     />
   </v-container>
 </template>
@@ -30,10 +15,10 @@ import { ref, computed, watch, onMounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import store from "@/store";
 import girderResources from "@/store/girderResources";
-import ConfigurationSelect from "@/components/ConfigurationSelect.vue";
-import GirderLocationChooser from "@/components/GirderLocationChooser.vue";
+import CollectionNavigator from "@/components/CollectionNavigator.vue";
 import { IDatasetConfiguration } from "@/store/model";
 import { IGirderLocation } from "@/girder";
+import { useRouteMapper } from "@/utils/useRouteMapper";
 
 const route = useRoute();
 const router = useRouter();
@@ -41,6 +26,18 @@ const router = useRouter();
 const selectedFolder = ref<IGirderLocation | null>(null);
 const currentFolderName = ref("");
 
+useRouteMapper(
+  {},
+  {
+    datasetId: {
+      parse: String,
+      get: () => store.selectedDatasetId,
+      set: (value: string) => store.setSelectedDataset(value),
+    },
+  },
+);
+
+const dataset = computed(() => store.dataset);
 const datasetName = computed(() => store.dataset?.name || "");
 
 const folderId = computed((): string | undefined => {
@@ -62,15 +59,17 @@ const folderId = computed((): string | undefined => {
 watch(selectedFolder, async () => {
   const sel = selectedFolder.value as any;
   if (sel && sel._modelType === "folder") {
-    const folder = await girderResources.getFolder(sel._id);
-    currentFolderName.value = folder?.name || "Unknown folder";
+    currentFolderName.value = sel.name || "";
+    if (!currentFolderName.value) {
+      const folder = await girderResources.getFolder(sel._id);
+      currentFolderName.value = folder?.name || "Unknown folder";
+    }
   } else {
     currentFolderName.value = "";
   }
 });
 
-onMounted(async () => {
-  // Initialize selectedFolder from route query
+async function initializeSelectedFolder() {
   const folderIdQuery = route.query.folderId;
   const targetFolderId = Array.isArray(folderIdQuery)
     ? folderIdQuery[0]
@@ -82,9 +81,8 @@ onMounted(async () => {
       currentFolderName.value = folder.name;
     }
   } else {
-    // If no folderId in query, try to get dataset's parent folder
-    if (store.dataset) {
-      const datasetFolder = await girderResources.getFolder(store.dataset.id);
+    if (dataset.value) {
+      const datasetFolder = await girderResources.getFolder(dataset.value.id);
       if (datasetFolder?.parentId) {
         const parentFolder = await girderResources.getFolder(
           datasetFolder.parentId,
@@ -95,7 +93,17 @@ onMounted(async () => {
         }
       }
     }
+    if (!selectedFolder.value) {
+      const privateFolder = await store.api.getUserPrivateFolder();
+      selectedFolder.value = privateFolder || store.girderUser;
+    }
   }
+}
+
+watch(dataset, initializeSelectedFolder);
+
+onMounted(() => {
+  initializeSelectedFolder();
 });
 
 async function submit(configurations: IDatasetConfiguration[]) {
@@ -124,7 +132,9 @@ defineExpose({
   selectedFolder,
   currentFolderName,
   datasetName,
+  dataset,
   folderId,
+  initializeSelectedFolder,
   submit,
   cancel,
 });

--- a/src/views/configuration/ImportConfiguration.vue
+++ b/src/views/configuration/ImportConfiguration.vue
@@ -1,7 +1,8 @@
 <template>
   <v-container>
     <collection-navigator
-      v-model:location="selectedFolder"
+      :location="selectedFolder"
+      @update:location="onNavigatorLocationUpdate"
       @submit="submit"
       @cancel="cancel"
       :title="`Add dataset ${datasetName} to one or several existing collections`"
@@ -19,12 +20,15 @@ import CollectionNavigator from "@/components/CollectionNavigator.vue";
 import { IDatasetConfiguration } from "@/store/model";
 import { IGirderLocation } from "@/girder";
 import { useRouteMapper } from "@/utils/useRouteMapper";
+import { getDefaultGirderLocation } from "@/utils/girderLocation";
 
 const route = useRoute();
 const router = useRouter();
 
 const selectedFolder = ref<IGirderLocation | null>(null);
-const currentFolderName = ref("");
+const selectedFolderSource = ref<
+  "route" | "dataset" | "default" | "user" | null
+>(null);
 
 useRouteMapper(
   {},
@@ -40,36 +44,13 @@ useRouteMapper(
 const dataset = computed(() => store.dataset);
 const datasetName = computed(() => store.dataset?.name || "");
 
-const folderId = computed((): string | undefined => {
-  const folder = selectedFolder.value as any;
-  if (folder && folder._modelType === "folder") {
-    return folder._id;
+async function initializeSelectedFolder(options = { replaceDefault: false }) {
+  if (
+    selectedFolder.value &&
+    !(options.replaceDefault && selectedFolderSource.value === "default")
+  ) {
+    return;
   }
-  // Fallback to route query if folder not yet loaded
-  const folderIdQuery = route.query.folderId;
-  if (Array.isArray(folderIdQuery)) {
-    return folderIdQuery[0] || undefined;
-  }
-  if (folderIdQuery === null) {
-    return undefined;
-  }
-  return folderIdQuery;
-});
-
-watch(selectedFolder, async () => {
-  const sel = selectedFolder.value as any;
-  if (sel && sel._modelType === "folder") {
-    currentFolderName.value = sel.name || "";
-    if (!currentFolderName.value) {
-      const folder = await girderResources.getFolder(sel._id);
-      currentFolderName.value = folder?.name || "Unknown folder";
-    }
-  } else {
-    currentFolderName.value = "";
-  }
-});
-
-async function initializeSelectedFolder() {
   const folderIdQuery = route.query.folderId;
   const targetFolderId = Array.isArray(folderIdQuery)
     ? folderIdQuery[0]
@@ -78,7 +59,8 @@ async function initializeSelectedFolder() {
     const folder = await girderResources.getFolder(targetFolderId);
     if (folder) {
       selectedFolder.value = folder;
-      currentFolderName.value = folder.name;
+      selectedFolderSource.value = "route";
+      return;
     }
   } else {
     if (dataset.value) {
@@ -89,22 +71,28 @@ async function initializeSelectedFolder() {
         );
         if (parentFolder) {
           selectedFolder.value = parentFolder;
-          currentFolderName.value = parentFolder.name;
+          selectedFolderSource.value = "dataset";
+          return;
         }
       }
     }
-    if (!selectedFolder.value) {
-      const privateFolder = await store.api.getUserPrivateFolder();
-      selectedFolder.value = privateFolder || store.girderUser;
-    }
   }
+  selectedFolder.value = await getDefaultGirderLocation();
+  selectedFolderSource.value = "default";
 }
 
-watch(dataset, initializeSelectedFolder);
+watch(dataset, () => {
+  initializeSelectedFolder({ replaceDefault: true });
+});
 
 onMounted(() => {
   initializeSelectedFolder();
 });
+
+function onNavigatorLocationUpdate(location: IGirderLocation | null) {
+  selectedFolder.value = location;
+  selectedFolderSource.value = "user";
+}
 
 async function submit(configurations: IDatasetConfiguration[]) {
   const dataset = store.dataset;
@@ -130,11 +118,11 @@ function cancel() {
 
 defineExpose({
   selectedFolder,
-  currentFolderName,
+  selectedFolderSource,
   datasetName,
   dataset,
-  folderId,
   initializeSelectedFolder,
+  onNavigatorLocationUpdate,
   submit,
   cancel,
 });


### PR DESCRIPTION
## Summary

- Replace the old folder chooser plus collection table on the add-dataset-to-existing-collection import route with a focused collection navigator.
- Show navigable folders and compatible, unlinked collections in one in-page flow while hiding dataset folders.
- Preserve route/query dataset syncing, avoid resetting user navigation after the user browses, and share the default Girder location fallback through a utility.
- Add focused tests for navigator filtering, navigation, selection, and import initialization behavior.

## Validation

- `pnpm run tsc`
- `pnpm test -- src/components/CollectionNavigator.test.ts src/views/configuration/ImportConfiguration.test.ts src/components/ConfigurationSelect.test.ts`
- `pnpm exec eslint --ext .js,.ts,.vue src/components/CollectionNavigator.vue src/components/CollectionNavigator.test.ts src/views/configuration/ImportConfiguration.vue src/views/configuration/ImportConfiguration.test.ts src/utils/girderSelectable.ts src/utils/girderLocation.ts`

Note: the focused Vitest run exits successfully but still prints existing sandbox/jsdom warnings about the Vite websocket and Vuetify CSS `@layer` parsing.