### PR TITLE
[codex] Fix unroll image tile redraws

### DIFF
--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -1091,7 +1091,7 @@ describe("ImageViewer", () => {
   // ---- 13. _setTileUrls ----
 
   describe("_setTileUrls", () => {
-    it("assigns unrolled tile URLs and skips redraw when hist is ready", () => {
+    it("assigns unrolled tile URLs and skips histogram fetch when hist is ready", () => {
       wrapper = mountComponent();
       vi.clearAllMocks();
 
@@ -1130,7 +1130,7 @@ describe("ImageViewer", () => {
       expect(mockedStore.getLayerHistogram).not.toHaveBeenCalled();
     });
 
-    it("requests a histogram redraw when tile URLs are not ready", async () => {
+    it("requests a histogram fetch when tile URLs are not ready", async () => {
       wrapper = mountComponent();
       vi.clearAllMocks();
 

--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -115,6 +115,7 @@ vi.mock("@/store", () => {
       setCameraInfo: vi.fn(),
       setDrawAnnotations: vi.fn(),
       setShowTooltips: vi.fn(),
+      getLayerHistogram: vi.fn().mockResolvedValue(null),
     }),
   };
 });
@@ -297,6 +298,7 @@ describe("ImageViewer", () => {
     mockedStore.showPixelScalebar = false;
     mockedStore.scalebarColor = "#ffffff";
     mockedAnnotationStore.submitPendingAnnotation = null;
+    (mockedStore as any).getLayerHistogram = vi.fn().mockResolvedValue(null);
     vi.clearAllMocks();
     // Make setMaps/setCameraInfo actually update the reactive store
     (mockedStore.setMaps as any).mockImplementation((v: any) => {
@@ -1086,7 +1088,80 @@ describe("ImageViewer", () => {
     });
   });
 
-  // ---- 13. draw() ----
+  // ---- 13. _setTileUrls ----
+
+  describe("_setTileUrls", () => {
+    it("assigns unrolled tile URLs and skips redraw when hist is ready", () => {
+      wrapper = mountComponent();
+      vi.clearAllMocks();
+
+      const fullLayer = mockLayer();
+      const adjLayer = mockLayer();
+      mockedStore.maps = [
+        {
+          map: mockMap(),
+          imageLayers: [fullLayer, adjLayer],
+          params: {},
+        } as any,
+      ];
+
+      const baseImage = createLayerStackImage().images[0];
+      const lsi = createLayerStackImage({
+        images: [baseImage, { ...baseImage, frameIndex: 1 }],
+        urls: [
+          "http://localhost/api/v1/tile/0/{z}/{x}/{y}",
+          "http://localhost/api/v1/tile/1/{z}/{x}/{y}",
+        ],
+        fullUrls: [
+          "http://localhost/api/v1/tile/0/{z}/{x}/{y}?full=true",
+          "http://localhost/api/v1/tile/1/{z}/{x}/{y}?full=true",
+        ],
+        singleFrame: null,
+        baseQuadOptions: {},
+      });
+
+      (wrapper.vm as any)._setTileUrls([lsi], 0, lsi.images[0], 0);
+
+      expect(fullLayer._imageUrls).toEqual(lsi.fullUrls);
+      expect(adjLayer._imageUrls).toEqual(lsi.urls);
+      expect(fullLayer.visible).toHaveBeenCalledWith(true);
+      expect(adjLayer.visible).toHaveBeenCalledWith(true);
+      expect(fullLayer.visible).not.toHaveBeenCalledWith(false);
+      expect(mockedStore.getLayerHistogram).not.toHaveBeenCalled();
+    });
+
+    it("requests a histogram redraw when tile URLs are not ready", async () => {
+      wrapper = mountComponent();
+      vi.clearAllMocks();
+
+      const fullLayer = mockLayer();
+      const adjLayer = mockLayer();
+      mockedStore.maps = [
+        {
+          map: mockMap(),
+          imageLayers: [fullLayer, adjLayer],
+          params: {},
+        } as any,
+      ];
+
+      const lsi = createLayerStackImage({
+        urls: [],
+        fullUrls: [],
+        hist: null,
+        singleFrame: null,
+        baseQuadOptions: undefined,
+      });
+
+      (wrapper.vm as any)._setTileUrls([lsi], 0, lsi.images[0], 0);
+      await Promise.resolve();
+
+      expect(mockedStore.getLayerHistogram).toHaveBeenCalledWith(lsi.layer);
+      expect(fullLayer.visible).toHaveBeenCalledWith(false);
+      expect(adjLayer.visible).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // ---- 14. draw() ----
 
   describe("draw", () => {
     it("returns early when width equals height equals 1", () => {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -1047,6 +1047,30 @@ function _setupTileLayers(
   }
 }
 
+const pendingHistogramRedraws = new Set<Promise<unknown>>();
+
+function scheduleHistogramRedraw(layer: ILayerStackImage["layer"]) {
+  const request = store.getLayerHistogram(layer);
+  if (pendingHistogramRedraws.has(request)) {
+    return;
+  }
+  pendingHistogramRedraws.add(request);
+  request.then(
+    () => {
+      pendingHistogramRedraws.delete(request);
+      nextTick(() => {
+        if (refsMounted.value) {
+          draw();
+        }
+      });
+    },
+    (err) => {
+      pendingHistogramRedraws.delete(request);
+      logWarning("Histogram redraw failed", err);
+    },
+  );
+}
+
 /**
  * Set tile urls for all tile layers.
  */
@@ -1059,7 +1083,7 @@ function _setTileUrls(
   const mapentry = maps.value[mllidx];
   mll.forEach(
     (
-      { layer, urls, fullUrls, hist, singleFrame, baseQuadOptions },
+      { layer, images, urls, fullUrls, hist, singleFrame, baseQuadOptions },
       layerIndex: number,
     ) => {
       const fullLayer = mapentry.imageLayers[layerIndex * 2];
@@ -1069,6 +1093,9 @@ function _setTileUrls(
       fullLayer.node().css("filter", `url(#recolor-${layerIndex})`);
       adjLayer.node().css("filter", "none");
       if (!fullUrls[0] || !urls[0] || !baseQuadOptions) {
+        if (!hist && images.length) {
+          scheduleHistogramRedraw(layer);
+        }
         if (singleFrame !== null && fullLayer.setFrameQuad) {
           fullLayer.setFrameQuad(singleFrame);
           fullLayer.visible(true);

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -1047,26 +1047,25 @@ function _setupTileLayers(
   }
 }
 
-const pendingHistogramRedraws = new Set<Promise<unknown>>();
+const pendingHistogramFetches = new Set<string>();
 
-function scheduleHistogramRedraw(layer: ILayerStackImage["layer"]) {
-  const request = store.getLayerHistogram(layer);
-  if (pendingHistogramRedraws.has(request)) {
+// Kick off a histogram fetch for a layer whose tiles can't render yet. We
+// don't schedule a draw here: when the fetch resolves, GirderAPI bumps
+// `histogramsLoaded`, which invalidates `layerStackImages` and fires the
+// `watch(mapLayerList)` redraw. Dedupe by `layer.id` so repeated calls (and
+// promise replacements inside `nextHistogram`) don't pile on .then handlers.
+function requestLayerHistogram(layer: ILayerStackImage["layer"]) {
+  if (pendingHistogramFetches.has(layer.id)) {
     return;
   }
-  pendingHistogramRedraws.add(request);
-  request.then(
+  pendingHistogramFetches.add(layer.id);
+  store.getLayerHistogram(layer).then(
     () => {
-      pendingHistogramRedraws.delete(request);
-      nextTick(() => {
-        if (refsMounted.value) {
-          draw();
-        }
-      });
+      pendingHistogramFetches.delete(layer.id);
     },
     (err) => {
-      pendingHistogramRedraws.delete(request);
-      logWarning("Histogram redraw failed", err);
+      pendingHistogramFetches.delete(layer.id);
+      logWarning("Layer histogram fetch failed", err);
     },
   );
 }
@@ -1094,7 +1093,7 @@ function _setTileUrls(
       adjLayer.node().css("filter", "none");
       if (!fullUrls[0] || !urls[0] || !baseQuadOptions) {
         if (!hist && images.length) {
-          scheduleHistogramRedraw(layer);
+          requestLayerHistogram(layer);
         }
         if (singleFrame !== null && fullLayer.setFrameQuad) {
           fullLayer.setFrameQuad(singleFrame);

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -94,7 +94,14 @@ export default class GirderAPI {
     this.client = client;
   }
 
+  // Reactive counters used by viewer getters. `histogramsLoaded` is bumped
+  // both when a histogram resolves and when caches are invalidated, so
+  // computed tile URLs re-evaluate. `histogramCacheRevision` is bumped only
+  // on cache invalidation and is recorded on each layer's `_histogram` so
+  // `getLayerHistogram` can force a refetch when the revision no longer
+  // matches.
   histogramsLoaded = 0;
+  histogramCacheRevision = 0;
 
   baseHistogramOptions: IHistogramOptions = {
     frame: 0,
@@ -883,6 +890,8 @@ export default class GirderAPI {
     this.imageCache.clear();
     this.histogramCache.clear();
     this.resolvedHistogramCache.clear();
+    this.histogramCacheRevision = this.histogramCacheRevision + 1;
+    this.histogramsLoaded = this.histogramsLoaded + 1;
   }
 
   // Read-only snapshot of cache sizes for memory diagnostics.

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2361,6 +2361,7 @@ export class Main extends VuexModule {
           lastImages: null,
           nextImages: null,
           lock: false,
+          cacheRevision: this.api.histogramCacheRevision,
         };
       }
 
@@ -2373,6 +2374,7 @@ export class Main extends VuexModule {
         ) {
           const histogramObj = layer._histogram;
           const images = layer._histogram.nextImages;
+          const cacheRevision = this.api.histogramCacheRevision;
           histogramObj.nextImages = null;
           histogramObj.lock = true;
           histogramObj.promise = this.api.getLayerHistogram(images);
@@ -2384,6 +2386,7 @@ export class Main extends VuexModule {
           });
           histogramObj.promise.finally(() => {
             histogramObj.lastImages = images;
+            histogramObj.cacheRevision = cacheRevision;
             histogramObj.lock = false;
             nextHistogram();
           });
@@ -2402,6 +2405,7 @@ export class Main extends VuexModule {
 
       if (
         lastImages === null ||
+        layer._histogram.cacheRevision !== this.api.histogramCacheRevision ||
         nextImages.length !== lastImages.length ||
         nextImages.some((image, idx) => image !== lastImages[idx])
       ) {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -593,6 +593,7 @@ export interface IDisplayLayer {
     lastImages: IImage[] | null;
     nextImages: IImage[] | null;
     lock: boolean;
+    cacheRevision: number;
   };
 }
 


### PR DESCRIPTION
## Summary

- Re-request image layer histograms from `ImageViewer` when tile URLs are missing during unroll and redraw after they resolve.
- Add a reactive histogram cache revision so per-layer histogram debounce state is invalidated when Girder caches are flushed during dataset refresh.
- Add focused `ImageViewer` regression tests for unrolled multi-image tile URLs and missing-histogram redraw scheduling.

## Root Cause

Unroll annotations read live unroll flags directly, but image tiles depend on refreshed dataset tile URLs and resolved histograms. After `refreshDataset()` flushed Girder histogram caches, layer-local `_histogram` state could still consider its previous image set current, leaving `layerStackImages` without URLs. `_setTileUrls()` then hid image layers while annotations continued rendering.

## Validation

- `pnpm exec vitest run src/components/ImageViewer.test.ts`
- `pnpm exec vitest run src/components/ViewerToolbar.test.ts`
- `pnpm run tsc`
- `pnpm exec eslint src/components/ImageViewer.vue src/components/ImageViewer.test.ts src/store/GirderAPI.ts src/store/index.ts src/store/model.ts`
- `git diff --check`

Closes #1159