### PR TITLE
Standardize v-btn usage across the codebase

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -295,7 +295,8 @@ Every `<v-btn>` should declare an explicit **`variant`** and **`size`**. Omittin
 | Secondary | `variant="outlined" color="primary" size="small"` | Supporting actions |
 | Tertiary / text | `variant="text" size="small"` | Cancel, low-emphasis, inline |
 | Destructive (confirmed) | `variant="flat" color="error" size="small"` | The irreversible button in a confirm dialog |
-| Destructive (inline) | `variant="text" color="error" size="small"` | The trigger that opens a confirm dialog |
+| Destructive (inline) | `variant="text" color="error" size="small"` | The trigger that opens a confirm dialog (use `mdi-delete`, not `mdi-close`) |
+| Informational | `variant="text" color="info" size="small"` | View log / inspect detail / open help — actions that read rather than mutate |
 | Icon-only | `variant="text" icon size="small"` | Toolbar / row actions; wrap in `v-tooltip` if ambiguous |
 
 **Color tokens — never use literals.** Use `error`/`success`/`warning`/`secondary`, not `red`/`green`/`orange`/`grey`. Semantic tokens are theme-aware.

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nimbus-frontend
-description: "Use when writing or modifying Vue 3 components, Vuex store modules, TypeScript interfaces, or Vuetify 4 UI in the src/ directory. Covers: <script setup> composition API, vuex-module-decorators (@Module, @Action, @Mutation), Vuetify 4 theming (CSS Cascade Layers, light/dark mode), select slot patterns (no .raw wrapper), dialog patterns, API client usage (GirderAPI.ts, AnnotationsAPI.ts), logging utilities (logWarning/logError instead of console.*), button loading states, @girder/components compatibility, and style guidelines."
+description: "Use when writing or modifying Vue 3 components, Vuex store modules, TypeScript interfaces, or Vuetify 4 UI in the src/ directory. Covers: <script setup> composition API, vuex-module-decorators (@Module, @Action, @Mutation), Vuetify 4 theming (CSS Cascade Layers, light/dark mode), select slot patterns (no .raw wrapper), dialog patterns, API client usage (GirderAPI.ts, AnnotationsAPI.ts), logging utilities (logWarning/logError instead of console.*), button conventions (5-role taxonomy — primary/secondary/tertiary/destructive/icon-only — with required variant and size), button loading states, @girder/components compatibility, and style guidelines."
 ---
 
 # Nimbus Frontend Development
@@ -284,15 +284,51 @@ logWarning("Something unexpected happened");
 logError("An error occurred", error);
 ```
 
-## Button Loading States
+## Buttons — five-role taxonomy
+
+Every `<v-btn>` should declare an explicit **`variant`** and **`size`**. Omitting them falls back to Vuetify's `elevated` default at default size, which looks generic and out of place against the Linear-inspired theme.
+
+| Role | Props | Use |
+|---|---|---|
+| Primary | `variant="flat" color="primary" size="small"` | The one main action of a view or dialog |
+| Primary positive | `variant="flat" color="success" size="small"` | View / Go / Start CTAs |
+| Secondary | `variant="outlined" color="primary" size="small"` | Supporting actions |
+| Tertiary / text | `variant="text" size="small"` | Cancel, low-emphasis, inline |
+| Destructive (confirmed) | `variant="flat" color="error" size="small"` | The irreversible button in a confirm dialog |
+| Destructive (inline) | `variant="text" color="error" size="small"` | The trigger that opens a confirm dialog |
+| Icon-only | `variant="text" icon size="small"` | Toolbar / row actions; wrap in `v-tooltip` if ambiguous |
+
+**Color tokens — never use literals.** Use `error`/`success`/`warning`/`secondary`, not `red`/`green`/`orange`/`grey`. Semantic tokens are theme-aware.
+
+**Dialog action bar pattern:**
+```vue
+<v-card-actions class="button-bar">
+  <v-btn variant="text" size="small" @click="close">Cancel</v-btn>
+  <v-btn variant="flat" color="primary" size="small" @click="save">Save</v-btn>
+</v-card-actions>
+```
+Never two filled buttons. For destructive confirms, swap `color="primary"` → `color="error"` on the right button.
+
+**`:to` vs `@click`:** a `v-btn` with `:to` renders as `<a>`, one with `@click` renders as `<button>`. `src/style.scss` makes form elements inherit `font-family` so they match; for groups of buttons that must look identical, use the same action type across all of them so they share the underlying tag.
+
+Full guide: `codebaseDocumentation/BUTTON_CONVENTIONS.md`
+
+### Loading state
 
 ```vue
-<v-btn :loading="isLoading" :disabled="isLoading" @click="doAction">
+<v-btn
+  variant="flat"
+  color="primary"
+  size="small"
+  :loading="isLoading"
+  :disabled="isLoading"
+  @click="doAction"
+>
   <template v-slot:loader>
     <v-progress-circular indeterminate size="18" width="2" class="mr-2" />
     Loading...
   </template>
-  <v-icon>mdi-check</v-icon>
+  <v-icon start>mdi-check</v-icon>
   Submit
 </v-btn>
 ```
@@ -315,6 +351,7 @@ For the full API, recorded fields, the load-order constraint (don't import store
 ## Codebase Documentation References
 
 - Vuetify 4 migration details: read `codebaseDocumentation/VUETIFY4_MIGRATION.md`
+- Button taxonomy and patterns: read `codebaseDocumentation/BUTTON_CONVENTIONS.md`
 - When working on batch processing: read `references/batch-processing-patterns.md`
 - When working on projects feature: read `codebaseDocumentation/PROJECTS.md`
 - When working on sharing UI: read `codebaseDocumentation/SHARING.md`

--- a/codebaseDocumentation/BUTTON_CONVENTIONS.md
+++ b/codebaseDocumentation/BUTTON_CONVENTIONS.md
@@ -13,7 +13,7 @@ A 2026 audit of 300 button instances found:
 
 These conventions standardize button roles so the visual hierarchy on every page reads the same way.
 
-## The five button roles
+## The six button roles
 
 ### 1. Primary
 
@@ -59,6 +59,10 @@ Low-emphasis actions: Cancel buttons, inline actions, link-like buttons.
 
 Irreversible or risky actions: delete, remove, revoke.
 
+**Always use `color="error"`, not `color="warning"`.** Warning is for *cautionary* state (e.g., "this dataset is incompatible"), not for confirmed destructive intent. If the action irreversibly removes data, it's error-colored.
+
+**Pair destructive buttons with `mdi-delete` (trash), not `mdi-close` (×).** `mdi-close` is for dismissal — closing dialogs, deselecting chips, clearing input. The X icon reads as "cancel", which is the wrong signal for "delete this thing permanently."
+
 **Confirmed** (the irreversible button inside a confirmation dialog, or in a primary-action slot):
 
 ```vue
@@ -76,7 +80,22 @@ Irreversible or risky actions: delete, remove, revoke.
 </v-btn>
 ```
 
-### 5. Icon-only
+Inside a toolbar or row cluster where the destructive button sits next to outlined siblings, use `variant="outlined" color="error"` instead of `text` so the shape matches its neighbors (see [Toolbar buttons — same row, same shape](#toolbar-buttons--same-row-same-shape)).
+
+### 5. Informational accent
+
+Low-emphasis actions that open auxiliary information (view log, inspect detail, open help). Uses `color="info"` so it doesn't compete with primary CTAs but is still clearly clickable.
+
+```vue
+<v-btn variant="text" color="info" size="small" @click="viewLog">
+  <v-icon start>mdi-text-box-outline</v-icon>
+  View Log
+</v-btn>
+```
+
+Reach for `info` when an action is *about* inspecting state rather than *changing* it — log viewers, "open details" affordances, debug panels.
+
+### 6. Icon-only
 
 Toolbar icons and row actions where the icon is self-explanatory.
 
@@ -218,7 +237,13 @@ For groups of buttons that should look identical (e.g. three secondary buttons s
 <v-btn variant="flat" color="error" size="small">Delete</v-btn>
 
 <!-- Destructive (inline) -->
-<v-btn variant="text" color="error" size="small">Remove</v-btn>
+<v-btn variant="text" color="error" size="small">
+  <v-icon start>mdi-delete</v-icon>
+  Remove
+</v-btn>
+
+<!-- Informational accent -->
+<v-btn variant="text" color="info" size="small">View Log</v-btn>
 
 <!-- Icon-only -->
 <v-btn variant="text" icon size="small">

--- a/codebaseDocumentation/BUTTON_CONVENTIONS.md
+++ b/codebaseDocumentation/BUTTON_CONVENTIONS.md
@@ -141,7 +141,35 @@ For destructive confirm dialogs:
 </v-card-actions>
 ```
 
-## Toolbar buttons
+## Stacked action panels — unify shape
+
+When buttons are stacked vertically (or arranged in a tight row) with **roughly equal emphasis** — for example, a floating action panel acting on selected items — prefer a unified shape across all of them and signal role differences through **color**, not variant.
+
+Mixed variants in a stacked row look ragged:
+
+```vue
+<!-- Don't: three different button shapes stacked together -->
+<v-btn variant="text" color="error">Delete Selected</v-btn>
+<v-btn variant="outlined" color="primary">Tag Selected</v-btn>
+<v-btn variant="text">Deselect All</v-btn>
+```
+
+Pick one shape (usually `outlined`) and vary color:
+
+```vue
+<!-- Do: same shape, color carries the role signal -->
+<v-btn variant="outlined" color="error" size="small">Delete Selected</v-btn>
+<v-btn variant="outlined" color="primary" size="small">Tag Selected</v-btn>
+<v-btn variant="outlined" color="primary" size="small">Deselect All</v-btn>
+```
+
+This rule applies **within** a tight cluster — across the page, the 5-role taxonomy still drives variant choice.
+
+## Toolbar buttons — same row, same shape
+
+Toolbars and tight horizontal clusters of buttons follow the same shape-unification rule as stacked panels. If a row has Share + Copy link + Delete, all three should be **outlined** with color carrying the role signal (`primary` for neutral secondaries, `error` for destructive). A single primary CTA in the same row can break the shape rule (e.g. View is `flat success` next to outlined Share/Copy link) — but a destructive `text error` next to an `outlined primary` looks ragged.
+
+Concretely: avoid `variant="text" color="error"` for the *Delete X* button when it lives in a toolbar alongside outlined buttons. Use `variant="outlined" color="error"` instead. Reserve `variant="text" color="error"` for row-level inline destructive triggers that don't share a row with outlined buttons.
 
 When buttons sit in a `v-toolbar` with a mix of secondary actions and a primary CTA:
 
@@ -197,6 +225,14 @@ For groups of buttons that should look identical (e.g. three secondary buttons s
   <v-icon>mdi-pencil</v-icon>
 </v-btn>
 ```
+
+## Theme interactions
+
+`src/style.scss` themes the `tonal` variant to look like a translucent "glass" button (Linear-inspired). It does **not** mute `flat color="primary"` — that variant must render as a solid filled button so primary CTAs read as prominent. If you find yourself adding `!important` rules to a button-color combination in `style.scss`, check that you're not muting a CTA variant by accident; only `tonal` should look translucent.
+
+A pale-looking `flat color="primary"` button in the running app usually means one of two things:
+1. The button is `:disabled` — Vuetify reduces opacity, and `style.scss` additionally applies a grayscale filter so disabled buttons read as clearly off (the opacity drop alone is too subtle on the dark theme).
+2. There's a stale theme override (`.v-btn.bg-primary { background: rgba(...) }`) — remove it.
 
 ## Migrating existing buttons
 

--- a/codebaseDocumentation/BUTTON_CONVENTIONS.md
+++ b/codebaseDocumentation/BUTTON_CONVENTIONS.md
@@ -1,0 +1,210 @@
+# Button Conventions
+
+How `<v-btn>` (Vuetify 4) should be styled across NimbusImage.
+
+## Why this exists
+
+A 2026 audit of 300 button instances found:
+
+- **70%** of buttons omitted `variant`, falling back to Vuetify's implicit `elevated` default.
+- **70%** omitted `size`, falling back to the default (larger) size.
+- Literal colors (`red`, `green`, `orange`, `grey`) were used alongside semantic tokens (`error`, `success`, `warning`, `secondary`) for the same intents.
+- No agreed convention for "primary CTA" vs "secondary" vs "destructive" — every author picked props ad hoc.
+
+These conventions standardize button roles so the visual hierarchy on every page reads the same way.
+
+## The five button roles
+
+### 1. Primary
+
+The single main action of a view, dialog, or section — the thing the user is most likely to want.
+
+```vue
+<v-btn variant="flat" color="primary" size="small" @click="save">
+  Save
+</v-btn>
+```
+
+For positive/affirmative CTAs (View, Go, Start), use `color="success"`:
+
+```vue
+<v-btn variant="flat" color="success" size="small" @click="goToView">
+  <v-icon start>mdi-eye</v-icon>
+  View
+</v-btn>
+```
+
+**Rule of thumb:** at most one primary button per surface.
+
+### 2. Secondary
+
+Supporting actions next to a primary action, or independent actions that aren't the main CTA.
+
+```vue
+<v-btn variant="outlined" color="primary" size="small" @click="share">
+  <v-icon start>mdi-share-variant</v-icon>
+  Share
+</v-btn>
+```
+
+### 3. Tertiary / text
+
+Low-emphasis actions: Cancel buttons, inline actions, link-like buttons.
+
+```vue
+<v-btn variant="text" size="small" @click="cancel">Cancel</v-btn>
+```
+
+### 4. Destructive
+
+Irreversible or risky actions: delete, remove, revoke.
+
+**Confirmed** (the irreversible button inside a confirmation dialog, or in a primary-action slot):
+
+```vue
+<v-btn variant="flat" color="error" size="small" @click="confirmDelete">
+  Delete
+</v-btn>
+```
+
+**Inline trigger** (the button the user clicks to open the confirm dialog or initiate a soft removal):
+
+```vue
+<v-btn variant="text" color="error" size="small" @click="askDelete">
+  <v-icon start>mdi-delete</v-icon>
+  Remove
+</v-btn>
+```
+
+### 5. Icon-only
+
+Toolbar icons and row actions where the icon is self-explanatory.
+
+```vue
+<v-btn variant="text" icon size="small" @click="edit">
+  <v-icon>mdi-pencil</v-icon>
+</v-btn>
+```
+
+Wrap any icon-only button whose meaning isn't 100% obvious in a tooltip:
+
+```vue
+<v-tooltip text="Edit annotation">
+  <template #activator="{ props }">
+    <v-btn v-bind="props" variant="text" icon size="small" @click="edit">
+      <v-icon>mdi-pencil</v-icon>
+    </v-btn>
+  </template>
+</v-tooltip>
+```
+
+## Sizing
+
+| Size | When |
+|---|---|
+| `size="small"` | **Default for almost everything.** Toolbar buttons, dialog actions, list actions, secondary CTAs. |
+| `size="default"` | Reserved for true page-level hero CTAs. Use sparingly. |
+| `size="x-small"` | Tight inline contexts (dense tables, chip-like buttons). |
+
+`size` should never be omitted — Vuetify's implicit default is too large for our density.
+
+## Color tokens — semantic, not literal
+
+| Don't | Do | Why |
+|---|---|---|
+| `color="red"` | `color="error"` | Theme-aware: respects dark/light, matches other error UI. |
+| `color="green"` | `color="success"` | Same. |
+| `color="orange"` | `color="warning"` | Same. |
+| `color="grey"` / `color="white"` | omit, or `color="secondary"` | Theme-aware. |
+
+Literal CSS color names (`red`, `green`, `orange`) don't shift with the theme — semantic tokens (`error`, `success`, `warning`) do, and they match the rest of the design system.
+
+## Dialog action bars
+
+Always `[text Cancel] [flat/outlined Confirm]`. Never two filled buttons.
+
+```vue
+<v-card-actions class="button-bar">
+  <v-btn variant="text" size="small" @click="close">Cancel</v-btn>
+  <v-btn variant="flat" color="primary" size="small" @click="save">Save</v-btn>
+</v-card-actions>
+```
+
+For destructive confirm dialogs:
+
+```vue
+<v-card-actions class="button-bar">
+  <v-btn variant="text" size="small" @click="close">Cancel</v-btn>
+  <v-btn variant="flat" color="error" size="small" @click="confirmDelete">
+    Remove
+  </v-btn>
+</v-card-actions>
+```
+
+## Toolbar buttons
+
+When buttons sit in a `v-toolbar` with a mix of secondary actions and a primary CTA:
+
+```vue
+<v-toolbar>
+  <v-toolbar-title>Dataset</v-toolbar-title>
+  <v-spacer />
+  <v-btn variant="outlined" color="primary" size="small">Share</v-btn>
+  <v-btn variant="outlined" color="primary" size="small">Copy link</v-btn>
+  <v-btn variant="flat" color="success" size="small">
+    <v-icon start>mdi-eye</v-icon>
+    View
+  </v-btn>
+</v-toolbar>
+```
+
+All buttons at the same size so heights match; secondary actions outlined; the single primary CTA filled.
+
+## `:to` vs `@click`
+
+A `v-btn` with `:to` renders as an `<a>`; one with `@click` renders as a `<button>`. They look identical *if* both inherit the page font — `src/style.scss` ensures form elements inherit `font-family`. If you ever see size/font drift between two visually-identical buttons in the same row, check that they're both `<a>` or both `<button>`, or that the font-inherit rule still exists.
+
+For groups of buttons that should look identical (e.g. three secondary buttons stacked in a card), prefer using the same action type for all of them — either all `:to`-based or all `@click`-based with `router.push` — so they render with the same tag.
+
+## Always-required props
+
+- **`size`** — never omit. Default to `small`.
+- **`variant`** — never omit. Vuetify's implicit `elevated` default looks generic and doesn't fit the Linear-inspired theme.
+
+## Quick reference
+
+```vue
+<!-- Primary CTA -->
+<v-btn variant="flat" color="primary" size="small">Save</v-btn>
+
+<!-- Primary positive CTA -->
+<v-btn variant="flat" color="success" size="small">View</v-btn>
+
+<!-- Secondary -->
+<v-btn variant="outlined" color="primary" size="small">Share</v-btn>
+
+<!-- Tertiary -->
+<v-btn variant="text" size="small">Cancel</v-btn>
+
+<!-- Destructive (confirmed) -->
+<v-btn variant="flat" color="error" size="small">Delete</v-btn>
+
+<!-- Destructive (inline) -->
+<v-btn variant="text" color="error" size="small">Remove</v-btn>
+
+<!-- Icon-only -->
+<v-btn variant="text" icon size="small">
+  <v-icon>mdi-pencil</v-icon>
+</v-btn>
+```
+
+## Migrating existing buttons
+
+When you touch a file with old-style buttons, normalize them as part of the change:
+
+1. Add `variant=` if it's missing (decide which role applies).
+2. Add `size="small"` if it's missing.
+3. Replace literal colors (`red`/`green`/`orange`) with semantic tokens.
+4. If multiple buttons in the same row use different heights/styles for the same role, unify them.
+
+Don't open a separate refactor PR for the whole codebase — let the conventions propagate naturally as files get touched. The initial sweep (commit `button-consistency`) handled the high-traffic cases.

--- a/src/App.vue
+++ b/src/App.vue
@@ -94,11 +94,13 @@
         <template v-slot:activator="{ props: activatorProps }">
           <v-btn
             v-bind="activatorProps"
+            variant="flat"
             color="primary"
+            size="small"
             class="ml-4"
-            @click="goToNewDataset"
             :disabled="!store.isLoggedIn || !store.girderUser"
             :loading="isUploadLoading"
+            @click="goToNewDataset"
           >
             Upload Data
           </v-btn>
@@ -112,12 +114,13 @@
           <template v-slot:activator="{ props: activatorProps }">
             <v-btn
               v-bind="activatorProps"
-              class="ml-4"
-              :color="annotationPanel ? 'primary' : undefined"
-              :variant="annotationPanel ? 'tonal' : 'text'"
-              @click.stop="toggleRightPanel('annotationPanel')"
               id="object-list-button-tourstep"
               v-tour-trigger="'object-list-button-tourtrigger'"
+              :variant="annotationPanel ? 'outlined' : 'text'"
+              :color="annotationPanel ? 'primary' : undefined"
+              size="small"
+              class="ml-4"
+              @click.stop="toggleRightPanel('annotationPanel')"
             >
               Object list
             </v-btn>
@@ -130,12 +133,13 @@
           <template v-slot:activator="{ props: activatorProps }">
             <v-btn
               v-bind="activatorProps"
-              class="ml-4"
-              :color="snapshotPanel ? 'primary' : undefined"
-              :variant="snapshotPanel ? 'tonal' : 'text'"
-              @click.stop="toggleRightPanel('snapshotPanel')"
               id="snapshots-button-tourstep"
               v-tour-trigger="'snapshots-button-tourtrigger'"
+              :variant="snapshotPanel ? 'outlined' : 'text'"
+              :color="snapshotPanel ? 'primary' : undefined"
+              size="small"
+              class="ml-4"
+              @click.stop="toggleRightPanel('snapshotPanel')"
             >
               Snapshots
             </v-btn>
@@ -145,12 +149,13 @@
           <template v-slot:activator="{ props: activatorProps }">
             <v-btn
               v-bind="activatorProps"
-              class="ml-4"
-              :color="settingsPanel ? 'primary' : undefined"
-              :variant="settingsPanel ? 'tonal' : 'text'"
-              @click.stop="toggleRightPanel('settingsPanel')"
               id="settings-button-tourstep"
               v-tour-trigger="'settings-button-tourtrigger'"
+              :variant="settingsPanel ? 'outlined' : 'text'"
+              :color="settingsPanel ? 'primary' : undefined"
+              size="small"
+              class="ml-4"
+              @click.stop="toggleRightPanel('settingsPanel')"
             >
               Settings
             </v-btn>
@@ -161,10 +166,12 @@
         <v-menu>
           <template v-slot:activator="{ props: activatorProps }">
             <v-btn
-              icon
               v-bind="activatorProps"
               id="help-button-tourstep"
               v-tour-trigger="'help-button-tourtrigger'"
+              variant="text"
+              icon
+              size="small"
             >
               <v-icon>mdi-help-circle-outline</v-icon>
             </v-btn>
@@ -236,10 +243,12 @@
           <template v-slot:activator="{ props: activatorProps }">
             <v-btn
               v-bind="activatorProps"
-              icon
-              @click="chatbotOpen = !chatbotOpen"
               id="chat-button-tourstep"
               v-tour-trigger="'chat-button-tourtrigger'"
+              variant="text"
+              icon
+              size="small"
+              @click="chatbotOpen = !chatbotOpen"
             >
               <v-icon>mdi-chat</v-icon>
             </v-btn>

--- a/src/components/AddCollectionToProjectDialog.vue
+++ b/src/components/AddCollectionToProjectDialog.vue
@@ -91,9 +91,11 @@
 
       <v-card-actions>
         <v-spacer />
-        <v-btn variant="text" @click="cancel">Cancel</v-btn>
+        <v-btn variant="text" size="small" @click="cancel">Cancel</v-btn>
         <v-btn
+          variant="flat"
           color="primary"
+          size="small"
           :disabled="!canAdd"
           :loading="adding"
           @click="addToProject"

--- a/src/components/AddCollectionToProjectFilterDialog.vue
+++ b/src/components/AddCollectionToProjectFilterDialog.vue
@@ -28,6 +28,7 @@
             <v-btn
               v-bind="activatorProps"
               variant="outlined"
+              color="primary"
               size="small"
               class="ml-2"
             >
@@ -101,10 +102,12 @@
       </v-list>
     </v-card-text>
     <v-card-actions class="ma-2">
-      <v-btn variant="text" @click="$emit('done')">Cancel</v-btn>
+      <v-btn variant="text" size="small" @click="$emit('done')">Cancel</v-btn>
       <v-spacer />
       <v-btn
+        variant="flat"
         color="primary"
+        size="small"
         :disabled="selectedCollections.length === 0"
         :loading="adding"
         @click="confirmAdd"
@@ -127,10 +130,19 @@
           their permissions to match the project's access settings.
         </v-card-text>
         <v-card-actions class="justify-end" style="gap: 8px">
-          <v-btn variant="text" @click="showPermissionConfirm = false"
+          <v-btn
+            variant="text"
+            size="small"
+            @click="showPermissionConfirm = false"
             >Cancel</v-btn
           >
-          <v-btn color="primary" @click="addCollections">Continue</v-btn>
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            @click="addCollections"
+            >Continue</v-btn
+          >
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/components/AddDatasetToCollection.vue
+++ b/src/components/AddDatasetToCollection.vue
@@ -57,7 +57,9 @@
         <v-card-actions class="ma-2">
           <v-spacer />
           <v-btn
-            color="green"
+            variant="flat"
+            color="success"
+            size="small"
             :disabled="!canAddDatasetToCollection"
             @click="addDatasetToCollection"
           >

--- a/src/components/AddDatasetToProjectDialog.vue
+++ b/src/components/AddDatasetToProjectDialog.vue
@@ -45,10 +45,12 @@
       </v-alert>
     </v-card-text>
     <v-card-actions class="ma-2">
-      <v-btn variant="text" @click="$emit('done')">Cancel</v-btn>
+      <v-btn variant="text" size="small" @click="$emit('done')">Cancel</v-btn>
       <v-spacer />
       <v-btn
+        variant="flat"
         color="primary"
+        size="small"
         :disabled="selectedDatasets.length === 0"
         :loading="adding"
         @click="confirmAdd"
@@ -71,10 +73,19 @@
           permissions to match the project's access settings.
         </v-card-text>
         <v-card-actions class="justify-end" style="gap: 8px">
-          <v-btn variant="text" @click="showPermissionConfirm = false"
+          <v-btn
+            variant="text"
+            size="small"
+            @click="showPermissionConfirm = false"
             >Cancel</v-btn
           >
-          <v-btn color="primary" @click="addDatasets">Continue</v-btn>
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            @click="addDatasets"
+            >Continue</v-btn
+          >
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/components/AddToProjectDialog.vue
+++ b/src/components/AddToProjectDialog.vue
@@ -86,9 +86,11 @@
 
       <v-card-actions>
         <v-spacer />
-        <v-btn variant="text" @click="cancel">Cancel</v-btn>
+        <v-btn variant="text" size="small" @click="cancel">Cancel</v-btn>
         <v-btn
+          variant="flat"
           color="primary"
+          size="small"
           :disabled="!canAdd"
           :loading="adding"
           @click="addToProject"

--- a/src/components/AnnotationActionPanel.vue
+++ b/src/components/AnnotationActionPanel.vue
@@ -2,7 +2,7 @@
   <div class="action-panel">
     <div class="selected-count">{{ selectedCount }} objects selected</div>
     <v-btn
-      variant="text"
+      variant="outlined"
       color="error"
       size="small"
       class="ma-1"
@@ -13,7 +13,7 @@
       Delete Selected
     </v-btn>
     <v-btn
-      variant="text"
+      variant="outlined"
       color="error"
       size="small"
       class="ma-1"
@@ -25,6 +25,7 @@
     </v-btn>
     <v-btn
       variant="outlined"
+      color="primary"
       size="small"
       class="ma-1"
       :disabled="!isLoggedIn"
@@ -35,6 +36,7 @@
     </v-btn>
     <v-btn
       variant="outlined"
+      color="primary"
       size="small"
       class="ma-1"
       :disabled="!isLoggedIn"
@@ -45,6 +47,7 @@
     </v-btn>
     <v-btn
       variant="outlined"
+      color="primary"
       size="small"
       class="ma-1"
       @click="copyAnnotationIds"
@@ -55,7 +58,8 @@
       Copy Selected IDs
     </v-btn>
     <v-btn
-      variant="text"
+      variant="outlined"
+      color="primary"
       size="small"
       class="ma-1"
       @click="$emit('deselect-all')"

--- a/src/components/AnnotationActionPanel.vue
+++ b/src/components/AnnotationActionPanel.vue
@@ -2,6 +2,8 @@
   <div class="action-panel">
     <div class="selected-count">{{ selectedCount }} objects selected</div>
     <v-btn
+      variant="text"
+      color="error"
       size="small"
       class="ma-1"
       :disabled="!isLoggedIn"
@@ -11,6 +13,8 @@
       Delete Selected
     </v-btn>
     <v-btn
+      variant="text"
+      color="error"
       size="small"
       class="ma-1"
       :disabled="!isLoggedIn"
@@ -20,6 +24,7 @@
       Delete Unselected
     </v-btn>
     <v-btn
+      variant="outlined"
       size="small"
       class="ma-1"
       :disabled="!isLoggedIn"
@@ -29,6 +34,7 @@
       Tag Selected
     </v-btn>
     <v-btn
+      variant="outlined"
       size="small"
       class="ma-1"
       :disabled="!isLoggedIn"
@@ -37,13 +43,23 @@
       <v-icon start size="small">mdi-palette</v-icon>
       Color Selected
     </v-btn>
-    <v-btn size="small" class="ma-1" @click="copyAnnotationIds">
+    <v-btn
+      variant="outlined"
+      size="small"
+      class="ma-1"
+      @click="copyAnnotationIds"
+    >
       <v-icon start size="small" :color="copySuccess ? 'success' : undefined">
         {{ copySuccess ? "mdi-check" : "mdi-content-copy" }}
       </v-icon>
       Copy Selected IDs
     </v-btn>
-    <v-btn size="small" class="ma-1" @click="$emit('deselect-all')">
+    <v-btn
+      variant="text"
+      size="small"
+      class="ma-1"
+      @click="$emit('deselect-all')"
+    >
       <v-icon start size="small">mdi-select-off</v-icon>
       Deselect All
     </v-btn>

--- a/src/components/AnnotationBrowser/AnnotationActions.vue
+++ b/src/components/AnnotationBrowser/AnnotationActions.vue
@@ -5,7 +5,14 @@
       <v-container>
         <v-row>
           <v-col class="pa-1">
-            <v-btn :disabled="!undoEntry || isDoing" @click="undo" block>
+            <v-btn
+              variant="outlined"
+              color="primary"
+              size="small"
+              :disabled="!undoEntry || isDoing"
+              block
+              @click="undo"
+            >
               <template v-if="undoEntry">
                 Undo {{ undoEntry.actionName }}
               </template>
@@ -13,7 +20,14 @@
             </v-btn>
           </v-col>
           <v-col class="pa-1">
-            <v-btn :disabled="!redoEntry || isDoing" @click="redo" block>
+            <v-btn
+              variant="outlined"
+              color="primary"
+              size="small"
+              :disabled="!redoEntry || isDoing"
+              block
+              @click="redo"
+            >
               <template v-if="redoEntry">
                 Redo {{ redoEntry.actionName }}
               </template>
@@ -28,10 +42,24 @@
         </v-row>
         <v-row>
           <v-col class="pa-1">
-            <v-btn v-if="selectionFilterEnabled" @click="clearSelection" block>
+            <v-btn
+              v-if="selectionFilterEnabled"
+              variant="outlined"
+              color="primary"
+              size="small"
+              block
+              @click="clearSelection"
+            >
               Clear selection filter
             </v-btn>
-            <v-btn v-else @click="filterBySelection" block>
+            <v-btn
+              v-else
+              variant="outlined"
+              color="primary"
+              size="small"
+              block
+              @click="filterBySelection"
+            >
               Use selection as filter
             </v-btn>
           </v-col>

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -2,6 +2,9 @@
   <v-dialog v-model="dialog">
     <template v-slot:activator="{ props: activatorProps }">
       <v-btn
+        variant="outlined"
+        color="primary"
+        size="small"
         v-bind="{ ...activatorProps, ...$attrs }"
         v-description="{
           section: 'Object list actions',
@@ -178,7 +181,9 @@
               {{ displayText }}
               <template v-slot:append>
                 <v-btn
+                  variant="text"
                   icon
+                  size="small"
                   title="Copy to clipboard"
                   @click="copyCSVText"
                   :disabled="!canUseClipboard"
@@ -235,14 +240,21 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn @click="dialog = false" variant="text" :disabled="bulkExporting">
+        <v-btn
+          variant="text"
+          size="small"
+          :disabled="bulkExporting"
+          @click="dialog = false"
+        >
           Close
         </v-btn>
         <v-btn
+          variant="flat"
+          color="success"
+          size="small"
           @click="download"
           :disabled="!canDownload"
           :loading="isDownloading || bulkExporting"
-          color="success"
           :min-width="isDownloading || bulkExporting ? 260 : undefined"
         >
           <template v-slot:loader>

--- a/src/components/AnnotationBrowser/AnnotationExport.vue
+++ b/src/components/AnnotationBrowser/AnnotationExport.vue
@@ -2,6 +2,9 @@
   <v-dialog v-model="dialog">
     <template v-slot:activator="{ props: activatorProps }">
       <v-btn
+        variant="outlined"
+        color="primary"
+        size="small"
         v-bind="{ ...activatorProps, ...$attrs }"
         v-description="{
           section: 'Object list actions',
@@ -115,10 +118,19 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn @click="dialog = false" :disabled="exporting"> Cancel </v-btn>
         <v-btn
-          @click="submit"
+          variant="text"
+          size="small"
+          @click="dialog = false"
+          :disabled="exporting"
+        >
+          Cancel
+        </v-btn>
+        <v-btn
+          variant="flat"
           color="primary"
+          size="small"
+          @click="submit"
           :disabled="!canSubmit"
           :loading="exporting"
         >

--- a/src/components/AnnotationBrowser/AnnotationIdFilters.vue
+++ b/src/components/AnnotationBrowser/AnnotationIdFilters.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <v-btn size="small" @click="openNewFilterDialog"
+    <v-btn
+      variant="outlined"
+      color="primary"
+      size="small"
+      @click="openNewFilterDialog"
       >Annotation ID filter</v-btn
     >
     <div class="d-flex flex-column">
@@ -14,10 +18,16 @@
           :model-value="filter.enabled"
           @click="toggleEnabled(filter.id)"
         />
-        <v-btn variant="text" @click="editFilter(filter)">
+        <v-btn variant="text" size="small" @click="editFilter(filter)">
           {{ filter.id }} ({{ filter.annotationIds.length }} IDs)
         </v-btn>
-        <v-btn class="mx-2" icon size="small" @click="removeFilter(filter.id)">
+        <v-btn
+          class="mx-2"
+          variant="text"
+          icon
+          size="small"
+          @click="removeFilter(filter.id)"
+        >
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </div>
@@ -37,8 +47,15 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="dialog = false">Cancel</v-btn>
-          <v-btn color="primary" variant="text" @click="saveFilter">
+          <v-btn variant="text" size="small" @click="dialog = false">
+            Cancel
+          </v-btn>
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            @click="saveFilter"
+          >
             {{ editingFilter ? "Update" : "Add Filter" }}
           </v-btn>
         </v-card-actions>

--- a/src/components/AnnotationBrowser/AnnotationImport.vue
+++ b/src/components/AnnotationBrowser/AnnotationImport.vue
@@ -3,8 +3,10 @@
     <template v-slot:activator="{ props: activatorProps }">
       <v-btn
         v-bind="{ ...activatorProps, ...$attrs }"
+        variant="outlined"
+        size="small"
         :disabled="!isLoggedIn"
-        :color="showSuccess ? 'success' : undefined"
+        :color="showSuccess ? 'success' : 'primary'"
         v-description="{
           section: 'Object list actions',
           title: 'Import from JSON',
@@ -89,22 +91,25 @@
                 <v-card-actions>
                   <v-spacer />
                   <v-btn
-                    @click="
-                      overwriteAnnotations = true;
-                      overwriteAnnotationsDialog = false;
-                    "
-                    color="warning"
-                  >
-                    Overwrite
-                  </v-btn>
-                  <v-btn
+                    variant="text"
+                    size="small"
                     @click="
                       overwriteAnnotations = false;
                       overwriteAnnotationsDialog = false;
                     "
-                    color="primary"
                   >
                     Cancel
+                  </v-btn>
+                  <v-btn
+                    variant="flat"
+                    color="error"
+                    size="small"
+                    @click="
+                      overwriteAnnotations = true;
+                      overwriteAnnotationsDialog = false;
+                    "
+                  >
+                    Overwrite
                   </v-btn>
                 </v-card-actions>
               </v-card>
@@ -119,22 +124,25 @@
                 <v-card-actions>
                   <v-spacer />
                   <v-btn
-                    @click="
-                      overwriteProperties = true;
-                      overwritePropertiesDialog = false;
-                    "
-                    color="warning"
-                  >
-                    Overwrite
-                  </v-btn>
-                  <v-btn
+                    variant="text"
+                    size="small"
                     @click="
                       overwriteProperties = false;
                       overwritePropertiesDialog = false;
                     "
-                    color="primary"
                   >
                     Cancel
+                  </v-btn>
+                  <v-btn
+                    variant="flat"
+                    color="error"
+                    size="small"
+                    @click="
+                      overwriteProperties = true;
+                      overwritePropertiesDialog = false;
+                    "
+                  >
+                    Overwrite
                   </v-btn>
                 </v-card-actions>
               </v-card>
@@ -145,7 +153,9 @@
       <v-card-actions v-if="isJsonLoaded">
         <v-spacer />
         <v-progress-circular v-if="isImporting" indeterminate />
-        <v-btn @click="submit" color="primary"> Import selection </v-btn>
+        <v-btn variant="flat" color="primary" size="small" @click="submit">
+          Import selection
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -7,20 +7,26 @@
         <v-row>
           <v-col class="pa-0 mx-1">
             <v-btn
+              variant="text"
               color="error"
               size="small"
-              variant="outlined"
               :loading="isDeletingAnnotations"
               :disabled="!isLoggedIn || isDeletingAnnotations"
               @click.stop="deleteSelected"
             >
+              <v-icon start>mdi-delete</v-icon>
               Delete Selected
             </v-btn>
           </v-col>
           <v-col class="pa-0 mx-1">
             <v-menu>
               <template v-slot:activator="{ props: activatorProps }">
-                <v-btn size="small" v-bind="activatorProps">
+                <v-btn
+                  variant="outlined"
+                  color="primary"
+                  size="small"
+                  v-bind="activatorProps"
+                >
                   More Actions
                   <v-icon size="small" end>mdi-chevron-down</v-icon>
                 </v-btn>
@@ -74,7 +80,13 @@
           </v-card-title>
           <v-card-actions>
             <v-spacer />
-            <v-btn @click="annotationFilteredDialog = false">OK</v-btn>
+            <v-btn
+              variant="flat"
+              color="primary"
+              size="small"
+              @click="annotationFilteredDialog = false"
+              >OK</v-btn
+            >
           </v-card-actions>
         </v-card>
       </v-dialog>

--- a/src/components/AnnotationBrowser/AnnotationProperties.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties.vue
@@ -7,9 +7,9 @@
       Properties
       <v-spacer />
       <v-btn
+        variant="flat"
         color="primary"
-        dark
-        size="default"
+        size="small"
         @click.stop="showAnalyzeDialog = true"
         id="measure-objects-button-tourstep"
         v-tour-trigger="'measure-objects-button-tourtrigger'"
@@ -88,7 +88,8 @@
           </v-tooltip>
           <v-btn
             v-if="batchProgress"
-            color="orange"
+            variant="outlined"
+            color="warning"
             size="small"
             class="ml-4"
             @click="cancelBatch"
@@ -97,6 +98,8 @@
           </v-btn>
           <v-spacer />
           <v-btn
+            variant="text"
+            size="small"
             @click="onDialogClose(false)"
             id="measure-objects-close-button-tourstep"
             v-tour-trigger="'measure-objects-close-button-tourtrigger'"

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyBody.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyBody.vue
@@ -34,8 +34,10 @@
         <template v-slot:activator="{ props: activatorProps }">
           <v-btn
             v-bind="activatorProps"
+            variant="text"
+            color="error"
+            size="small"
             @click.stop="deleteComputedValues = true"
-            color="red"
           >
             Delete property
           </v-btn>
@@ -68,8 +70,13 @@
           </v-card-text>
           <v-card-actions>
             <v-spacer />
+            <v-btn variant="text" size="small" @click="deleteDialog = false"
+              >Cancel</v-btn
+            >
             <v-btn
-              color="red"
+              variant="flat"
+              color="error"
+              size="small"
               @click="
                 () => {
                   deleteProperty();
@@ -78,7 +85,6 @@
               "
               >Delete</v-btn
             >
-            <v-btn color="primary" @click="deleteDialog = false">Cancel</v-btn>
           </v-card-actions>
         </v-card>
       </v-dialog>
@@ -92,13 +98,24 @@
           <v-spacer></v-spacer>
           <v-tooltip location="bottom">
             <template v-slot:activator="{ props: activatorProps }">
-              <v-btn icon v-bind="activatorProps" @click="copyLogToClipboard">
+              <v-btn
+                v-bind="activatorProps"
+                variant="text"
+                icon
+                size="small"
+                @click="copyLogToClipboard"
+              >
                 <v-icon>mdi-content-copy</v-icon>
               </v-btn>
             </template>
             <span>Copy to clipboard</span>
           </v-tooltip>
-          <v-btn icon @click="showLogDialog = false">
+          <v-btn
+            variant="text"
+            icon
+            size="small"
+            @click="showLogDialog = false"
+          >
             <v-icon>mdi-close</v-icon>
           </v-btn>
         </v-card-title>
@@ -107,7 +124,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" variant="text" @click="showLogDialog = false"
+          <v-btn variant="text" size="small" @click="showLogDialog = false"
             >Close</v-btn
           >
         </v-card-actions>

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
@@ -99,6 +99,7 @@
         <v-spacer></v-spacer>
         <v-btn
           class="mr-2"
+          variant="flat"
           color="primary"
           size="small"
           @click="createProperty"
@@ -107,7 +108,7 @@
         >
           Create Property
         </v-btn>
-        <v-btn class="mr-2" color="warning" size="small" @click="reset"
+        <v-btn class="mr-2" variant="text" size="small" @click="reset"
           >Reset</v-btn
         >
       </div>

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyFilterHistogram.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyFilterHistogram.vue
@@ -16,11 +16,17 @@
         density="compact"
         @update:model-value="updateViewMode"
       >
-        <v-btn value="range" size="small">Histogram</v-btn>
-        <v-btn value="values" size="small">Values</v-btn>
+        <v-btn variant="text" value="range" size="small">Histogram</v-btn>
+        <v-btn variant="text" value="values" size="small">Values</v-btn>
       </v-btn-toggle>
       <v-spacer></v-spacer>
-      <v-btn icon size="small" class="mr-2" @click="removeFilter">
+      <v-btn
+        variant="text"
+        icon
+        size="small"
+        class="mr-2"
+        @click="removeFilter"
+      >
         <v-icon>mdi-close</v-icon>
       </v-btn>
     </v-row>

--- a/src/components/AnnotationBrowser/DeleteConnections.vue
+++ b/src/components/AnnotationBrowser/DeleteConnections.vue
@@ -2,6 +2,9 @@
   <v-dialog v-model="dialog">
     <template v-slot:activator="{ props: activatorProps }">
       <v-btn
+        variant="text"
+        color="error"
+        size="small"
         v-bind="{ ...activatorProps, ...$attrs }"
         :disabled="!isLoggedIn"
         v-description="{
@@ -34,8 +37,15 @@
       </v-card-text>
       <v-card-actions :disabled="deleting">
         <v-spacer />
-        <v-btn @click.prevent="cancel" color="warning"> Cancel </v-btn>
-        <v-btn @click.prevent="submit" color="primary">
+        <v-btn variant="text" size="small" @click.prevent="cancel">
+          Cancel
+        </v-btn>
+        <v-btn
+          variant="flat"
+          color="error"
+          size="small"
+          @click.prevent="submit"
+        >
           Submit: delete connections
         </v-btn>
       </v-card-actions>

--- a/src/components/AnnotationBrowser/IndexConversionDialog.vue
+++ b/src/components/AnnotationBrowser/IndexConversionDialog.vue
@@ -2,6 +2,9 @@
   <v-dialog v-model="dialog">
     <template v-slot:activator="{ props: activatorProps }">
       <v-btn
+        variant="outlined"
+        color="primary"
+        size="small"
         v-bind="{ ...activatorProps, ...$attrs }"
         v-description="{
           section: 'Object list actions',
@@ -54,7 +57,12 @@
                     No labels detected; index only
                   </div>
                 </div>
-                <v-btn color="primary" @click="downloadXY">
+                <v-btn
+                  variant="flat"
+                  color="primary"
+                  size="small"
+                  @click="downloadXY"
+                >
                   <v-icon start>mdi-download</v-icon>
                   Download XY CSV
                 </v-btn>
@@ -73,7 +81,12 @@
                     No labels detected; index only
                   </div>
                 </div>
-                <v-btn color="primary" @click="downloadZ">
+                <v-btn
+                  variant="flat"
+                  color="primary"
+                  size="small"
+                  @click="downloadZ"
+                >
                   <v-icon start>mdi-download</v-icon>
                   Download Z CSV
                 </v-btn>
@@ -95,7 +108,12 @@
                     No labels detected; index only
                   </div>
                 </div>
-                <v-btn color="primary" @click="downloadTime">
+                <v-btn
+                  variant="flat"
+                  color="primary"
+                  size="small"
+                  @click="downloadTime"
+                >
                   <v-icon start>mdi-download</v-icon>
                   Download Time CSV
                 </v-btn>
@@ -111,7 +129,7 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn @click="dialog = false" variant="text">Close</v-btn>
+        <v-btn variant="text" size="small" @click="dialog = false">Close</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/components/AnnotationBrowser/PropertyFilterSelector.vue
+++ b/src/components/AnnotationBrowser/PropertyFilterSelector.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
-    <v-btn class="filter-element" size="small" @click="dialog = true">
+    <v-btn
+      class="filter-element"
+      variant="outlined"
+      color="primary"
+      size="small"
+      @click="dialog = true"
+    >
       Property value filter
     </v-btn>
     <v-dialog v-model="dialog" max-width="500px">
@@ -31,7 +37,9 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn variant="text" @click="dialog = false">Close</v-btn>
+          <v-btn variant="text" size="small" @click="dialog = false"
+            >Close</v-btn
+          >
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/components/AnnotationBrowser/ROIFilters.vue
+++ b/src/components/AnnotationBrowser/ROIFilters.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
-    <v-btn size="small" @click="addNewFilter"> Region filter </v-btn>
+    <v-btn
+      variant="outlined"
+      color="primary"
+      size="small"
+      @click="addNewFilter"
+    >
+      Region filter
+    </v-btn>
     <div class="d-flex flex-column">
       <div
         v-for="filter in filters"
@@ -13,7 +20,13 @@
           @click="toggleEnabled(filter.id)"
         />
         {{ filter.id }}
-        <v-btn class="mx-2" icon size="small" @click="removeFilter(filter.id)">
+        <v-btn
+          class="mx-2"
+          variant="text"
+          icon
+          size="small"
+          @click="removeFilter(filter.id)"
+        >
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </div>

--- a/src/components/AnnotationContextMenu.vue
+++ b/src/components/AnnotationContextMenu.vue
@@ -48,10 +48,19 @@
         </div>
       </v-card-text>
       <v-card-actions>
-        <v-btn color="error" @click="deleteAnnotation"> Delete Object </v-btn>
+        <v-btn
+          variant="text"
+          color="error"
+          size="small"
+          @click="deleteAnnotation"
+        >
+          Delete Object
+        </v-btn>
         <v-spacer></v-spacer>
-        <v-btn color="secondary" @click="cancel"> Cancel </v-btn>
-        <v-btn color="primary" @click="save"> Apply </v-btn>
+        <v-btn variant="text" size="small" @click="cancel"> Cancel </v-btn>
+        <v-btn variant="flat" color="primary" size="small" @click="save">
+          Apply
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-menu>

--- a/src/components/AnnotationWorkerMenu.vue
+++ b/src/components/AnnotationWorkerMenu.vue
@@ -7,8 +7,8 @@
           <template v-slot:activator="{ props: activatorProps }">
             <v-btn
               v-bind="activatorProps"
+              variant="text"
               size="small"
-              variant="tonal"
               class="worker-action-btn"
               @click="resetInterfaceValues()"
             >
@@ -21,8 +21,8 @@
           <template v-slot:activator="{ props: activatorProps }">
             <v-btn
               v-bind="activatorProps"
+              variant="text"
               size="small"
-              variant="tonal"
               class="worker-action-btn"
               @click="updateInterface(true)"
             >
@@ -81,13 +81,23 @@
           />
         </v-row>
         <v-row>
-          <v-btn @click="preview" v-if="hasPreview">Preview</v-btn>
-          <v-btn variant="tonal" @click="emit('close')">Close</v-btn>
+          <v-btn
+            v-if="hasPreview"
+            variant="outlined"
+            color="primary"
+            size="small"
+            @click="preview"
+            >Preview</v-btn
+          >
+          <v-btn variant="text" size="small" @click="emit('close')"
+            >Close</v-btn
+          >
           <v-spacer></v-spacer>
           <v-btn
             v-if="localJobLog"
             variant="text"
             color="info"
+            size="small"
             class="mr-2"
             @click="showLogDialog = true"
           >
@@ -95,10 +105,11 @@
             Log
           </v-btn>
           <v-btn
-            @click="compute"
             v-if="!running"
-            variant="tonal"
+            variant="flat"
             color="primary"
+            size="small"
+            @click="compute"
           >
             <v-icon v-if="previousRunStatus === false" start>mdi-close</v-icon>
             <v-icon v-if="previousRunStatus === true" start>mdi-check</v-icon>
@@ -106,10 +117,11 @@
           </v-btn>
           <v-btn
             v-else
-            @click="cancel"
-            variant="tonal"
-            color="orange"
+            variant="text"
+            color="warning"
+            size="small"
             :disabled="!currentJob && !batchCancelFunction"
+            @click="cancel"
           >
             <v-progress-circular size="16" indeterminate class="mr-2" />
             Cancel{{ batchCancelFunction ? " All" : "" }}
@@ -182,13 +194,24 @@
           <v-spacer></v-spacer>
           <v-tooltip location="bottom">
             <template v-slot:activator="{ props: activatorProps }">
-              <v-btn icon v-bind="activatorProps" @click="copyLogToClipboard">
+              <v-btn
+                v-bind="activatorProps"
+                variant="text"
+                icon
+                size="small"
+                @click="copyLogToClipboard"
+              >
                 <v-icon>mdi-content-copy</v-icon>
               </v-btn>
             </template>
             <span>Copy to clipboard</span>
           </v-tooltip>
-          <v-btn icon @click="showLogDialog = false">
+          <v-btn
+            variant="text"
+            icon
+            size="small"
+            @click="showLogDialog = false"
+          >
             <v-icon>mdi-close</v-icon>
           </v-btn>
         </v-card-title>
@@ -197,7 +220,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" variant="text" @click="showLogDialog = false"
+          <v-btn variant="text" size="small" @click="showLogDialog = false"
             >Close</v-btn
           >
         </v-card-actions>

--- a/src/components/ChatComponent.vue
+++ b/src/components/ChatComponent.vue
@@ -65,6 +65,7 @@
                 class="current-image"
               />
               <v-btn
+                variant="text"
                 icon
                 size="small"
                 class="remove-image"

--- a/src/components/CollectionNavigator.vue
+++ b/src/components/CollectionNavigator.vue
@@ -120,7 +120,9 @@
     </v-card-text>
 
     <v-card-actions class="collection-navigator-actions">
-      <v-btn color="warning" class="mr-4" @click="cancel">Cancel</v-btn>
+      <v-btn variant="text" size="small" class="mr-4" @click="cancel"
+        >Cancel</v-btn
+      >
       <v-spacer />
       <span v-if="selectedConfigurations.length" class="text-caption mr-3">
         Selected {{ selectedConfigurations.length }} collection{{
@@ -129,7 +131,9 @@
       </span>
       <v-btn
         :disabled="selectedConfigurations.length === 0"
+        variant="flat"
         color="primary"
+        size="small"
         class="mr-4"
         @click="submit"
       >

--- a/src/components/ColorSelectionDialog.vue
+++ b/src/components/ColorSelectionDialog.vue
@@ -15,8 +15,16 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn color="warning" @click="showDialog = false"> Cancel </v-btn>
-        <v-btn color="primary" :disabled="!isLoggedIn" @click="submit">
+        <v-btn variant="text" size="small" @click="showDialog = false">
+          Cancel
+        </v-btn>
+        <v-btn
+          variant="flat"
+          color="primary"
+          size="small"
+          :disabled="!isLoggedIn"
+          @click="submit"
+        >
           Apply color
         </v-btn>
       </v-card-actions>

--- a/src/components/ConfigurationSelect.vue
+++ b/src/components/ConfigurationSelect.vue
@@ -30,10 +30,14 @@
       No compatible collection were found for this dataset.
     </v-alert>
     <div class="button-bar">
-      <v-btn color="warning" class="mr-4" @click="cancel">Cancel</v-btn>
+      <v-btn variant="text" size="small" class="mr-4" @click="cancel"
+        >Cancel</v-btn
+      >
       <v-btn
         :disabled="selectedConfigurations.length <= 0"
+        variant="flat"
         color="primary"
+        size="small"
         class="mr-4"
         @click="submit"
       >

--- a/src/components/ContrastHistogram.vue
+++ b/src/components/ContrastHistogram.vue
@@ -71,25 +71,28 @@
     </div>
     <div class="toolbar">
       <v-btn
+        variant="outlined"
+        color="primary"
         size="x-small"
         @click="reset"
-        color="secondary"
         title="Reset to histogram limits"
       >
         Reset
       </v-btn>
       <v-btn
+        variant="outlined"
+        color="primary"
         size="x-small"
         @click="revertSaved"
-        color="secondary"
         title="Revert to saved points"
       >
         Revert to saved
       </v-btn>
       <v-btn
+        variant="flat"
+        color="primary"
         size="x-small"
         @click="saveCurrent"
-        color="secondary"
         title="Save current points"
         >Save</v-btn
       >

--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -37,6 +37,8 @@
               v-bind="activatorProps"
               :disabled="selected.length === 0"
               variant="outlined"
+              color="primary"
+              size="small"
               class="ghost-button"
             >
               Actions
@@ -60,6 +62,8 @@
           @click="fileInput?.click()"
           :disabled="shouldDisableSingleFileUpload"
           variant="outlined"
+          color="primary"
+          size="small"
         >
           <v-icon start>mdi-upload</v-icon>
           Upload Non-Image File

--- a/src/components/DisplayLayer.vue
+++ b/src/components/DisplayLayer.vue
@@ -108,9 +108,15 @@
                 :offset="1"
               />
               <div class="buttons">
-                <v-btn color="warning" size="small" @click="removeLayer"
-                  >Delete layer</v-btn
+                <v-btn
+                  variant="text"
+                  color="error"
+                  size="small"
+                  @click="removeLayer"
                 >
+                  <v-icon start>mdi-delete</v-icon>
+                  Delete layer
+                </v-btn>
               </div>
             </v-expansion-panel-text>
           </v-expansion-panel>

--- a/src/components/FileItemRow.vue
+++ b/src/components/FileItemRow.vue
@@ -23,8 +23,9 @@
         <v-btn
           v-bind="activatorProps"
           v-if="debouncedChipsPerItemId[item._id]?.type === 'dataset'"
-          size="x-small"
+          variant="text"
           icon
+          size="x-small"
           class="ml-1"
           @click.stop="shareDialogVisible = true"
         >

--- a/src/components/FileManagerOptions.vue
+++ b/src/components/FileManagerOptions.vue
@@ -31,7 +31,21 @@
         <v-card-actions class="d-flex">
           <v-spacer />
           <v-progress-circular v-if="isLoading" indeterminate />
-          <v-btn color="red" @click="deleteItems" :disabled="disableOptions">
+          <v-btn
+            variant="text"
+            size="small"
+            @click="deleteDialog = false"
+            :disabled="disableOptions"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            variant="flat"
+            color="error"
+            size="small"
+            @click="deleteItems"
+            :disabled="disableOptions"
+          >
             <template v-if="isLoading">
               Deleting {{ items.length }} item{{
                 items.length === 1 ? "" : "s"
@@ -40,13 +54,6 @@
             <template v-else>
               Delete {{ items.length }} item{{ items.length === 1 ? "" : "s" }}
             </template>
-          </v-btn>
-          <v-btn
-            color="primary"
-            @click="deleteDialog = false"
-            :disabled="disableOptions"
-          >
-            Cancel
           </v-btn>
         </v-card-actions>
       </v-card>
@@ -80,7 +87,13 @@
               <div class="d-flex">
                 <v-spacer />
                 <v-progress-circular v-if="isLoading" indeterminate />
-                <v-btn type="submit" color="primary" :disabled="disableOptions">
+                <v-btn
+                  type="submit"
+                  variant="flat"
+                  color="primary"
+                  size="small"
+                  :disabled="disableOptions"
+                >
                   Submit
                 </v-btn>
               </div>
@@ -108,19 +121,23 @@
               <v-progress-circular v-if="isLoading" indeterminate />
               <v-spacer />
               <v-btn
-                @click="moveFolderToAssetstorResolve?.(true)"
-                :disabled="isLoading"
-                class="mx-2"
-                color="primary"
-              >
-                Confirm
-              </v-btn>
-              <v-btn
+                variant="text"
+                size="small"
                 @click="moveFolderToAssetstorResolve?.(false)"
                 class="mx-2"
                 :disabled="isLoading"
               >
                 Cancel
+              </v-btn>
+              <v-btn
+                variant="flat"
+                color="primary"
+                size="small"
+                @click="moveFolderToAssetstorResolve?.(true)"
+                :disabled="isLoading"
+                class="mx-2"
+              >
+                Confirm
               </v-btn>
             </v-card-text>
           </v-card>

--- a/src/components/GirderLocationChooser.vue
+++ b/src/components/GirderLocationChooser.vue
@@ -11,7 +11,13 @@
     >
       <div class="d-flex">
         <slot name="activator" v-bind="{ props: activatorProps }">
-          <v-btn v-bind="activatorProps" :disabled="disabled">
+          <v-btn
+            v-bind="activatorProps"
+            :disabled="disabled"
+            variant="outlined"
+            color="primary"
+            size="small"
+          >
             Choose...
           </v-btn>
         </slot>
@@ -38,13 +44,19 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn @click.prevent="dialogInternal = false" color="warning">
+        <v-btn
+          @click.prevent="dialogInternal = false"
+          variant="text"
+          size="small"
+        >
           Cancel
         </v-btn>
         <v-btn
           @click.prevent="select"
           :disabled="!isFolderSelected"
+          variant="flat"
           color="primary"
+          size="small"
         >
           Select
         </v-btn>

--- a/src/components/HotkeySelection.vue
+++ b/src/components/HotkeySelection.vue
@@ -4,6 +4,8 @@
       {{ hotkey === null ? "No hotkey yet" : `Hotkey: ${hotkey}` }}
     </span>
     <v-btn
+      variant="outlined"
+      color="primary"
       size="small"
       class="mr-2"
       @click="editHotkey()"
@@ -17,7 +19,7 @@
       />
       {{ isRecordingHotkey ? "Recording..." : "Record" }}
     </v-btn>
-    <v-btn size="small" @click="hotkey = null"> Clear </v-btn>
+    <v-btn variant="text" size="small" @click="hotkey = null"> Clear </v-btn>
   </div>
 </template>
 

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -13,7 +13,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn class="ma-2" @click="scaleDialog = false">Close</v-btn>
+          <v-btn
+            variant="text"
+            size="small"
+            class="ma-2"
+            @click="scaleDialog = false"
+            >Close</v-btn
+          >
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -93,10 +99,11 @@
     <div class="bottom-right-container">
       <v-btn
         v-if="submitPendingAnnotation"
+        variant="text"
+        size="small"
         @click.capture.stop="
           submitPendingAnnotation && submitPendingAnnotation(false)
         "
-        size="small"
       >
         Cancel (ctrl-Z)
       </v-btn>
@@ -127,6 +134,7 @@
       <template #activator="{ props: activatorProps }">
         <v-btn
           id="layer-info-tourstep"
+          variant="text"
           icon
           size="small"
           v-bind="activatorProps"
@@ -141,6 +149,7 @@
     </v-menu>
     <v-btn
       id="lock-view-tourstep"
+      variant="text"
       icon
       size="small"
       class="lock-view-btn"
@@ -158,6 +167,7 @@
     </v-btn>
     <v-btn
       id="reset-rotation-tourstep"
+      variant="text"
       icon
       size="small"
       class="reset-rotation-btn"

--- a/src/components/JobsLogs.vue
+++ b/src/components/JobsLogs.vue
@@ -77,7 +77,7 @@
                 <template #[`item.actions`]="{ item }">
                   <v-btn
                     variant="text"
-                    color="primary"
+                    color="info"
                     size="small"
                     @click="viewJobLog(item)"
                   >

--- a/src/components/JobsLogs.vue
+++ b/src/components/JobsLogs.vue
@@ -4,7 +4,9 @@
     <v-expansion-panel-text>
       <v-container>
         <v-btn
+          variant="outlined"
           color="primary"
+          size="small"
           @click="showJobs"
           v-description="{
             section: 'Jobs and Logs',
@@ -74,9 +76,9 @@
                 </template>
                 <template #[`item.actions`]="{ item }">
                   <v-btn
-                    size="small"
                     variant="text"
-                    color="info"
+                    color="primary"
+                    size="small"
                     @click="viewJobLog(item)"
                   >
                     <v-icon size="small" start>mdi-text-box-outline</v-icon>
@@ -139,10 +141,7 @@
             </v-card-text>
             <v-card-actions>
               <v-spacer></v-spacer>
-              <v-btn
-                color="primary"
-                variant="text"
-                @click="showLogDialog = false"
+              <v-btn variant="text" size="small" @click="showLogDialog = false"
                 >Close</v-btn
               >
             </v-card-actions>

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -21,6 +21,7 @@
           </template>
           <template #append v-if="listItem.name !== DEFAULT_LARGE_IMAGE_SOURCE">
             <v-btn
+              variant="text"
               icon
               size="small"
               color="error"

--- a/src/components/MovieDialog.vue
+++ b/src/components/MovieDialog.vue
@@ -132,9 +132,13 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn variant="text" @click="dialog = false"> Cancel </v-btn>
+        <v-btn variant="text" size="small" @click="dialog = false">
+          Cancel
+        </v-btn>
         <v-btn
+          variant="flat"
           color="primary"
+          size="small"
           @click="handleDownload"
           :disabled="!!warningText"
         >

--- a/src/components/ProjectList.vue
+++ b/src/components/ProjectList.vue
@@ -14,6 +14,7 @@
       </div>
       <v-btn
         v-if="store.isLoggedIn"
+        variant="flat"
         color="primary"
         size="small"
         class="ml-2"
@@ -94,7 +95,7 @@
           <template #append>
             <v-menu>
               <template #activator="{ props: activatorProps }">
-                <v-btn icon size="small" variant="text" v-bind="activatorProps">
+                <v-btn v-bind="activatorProps" variant="text" icon size="small">
                   <v-icon size="small">mdi-dots-vertical</v-icon>
                 </v-btn>
               </template>
@@ -142,9 +143,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="showCreateDialog = false">Cancel</v-btn>
+          <v-btn variant="text" size="small" @click="showCreateDialog = false"
+            >Cancel</v-btn
+          >
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             :disabled="!newProjectName.trim()"
             :loading="creating"
             @click="createProject"
@@ -176,9 +181,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="showEditDialog = false">Cancel</v-btn>
+          <v-btn variant="text" size="small" @click="showEditDialog = false"
+            >Cancel</v-btn
+          >
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             :disabled="!editProjectName.trim()"
             :loading="saving"
             @click="saveProject"
@@ -199,8 +208,16 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="showDeleteDialog = false">Cancel</v-btn>
-          <v-btn color="error" :loading="deleting" @click="deleteProject">
+          <v-btn variant="text" size="small" @click="showDeleteDialog = false"
+            >Cancel</v-btn
+          >
+          <v-btn
+            variant="flat"
+            color="error"
+            size="small"
+            :loading="deleting"
+            @click="deleteProject"
+          >
             Delete
           </v-btn>
         </v-card-actions>

--- a/src/components/SamToolMenu.vue
+++ b/src/components/SamToolMenu.vue
@@ -7,10 +7,20 @@
       <v-checkbox label="Turbo mode" v-model="turboMode" />
       <div v-if="!turboMode">
         <div>
-          <v-btn class="my-1" @click="undo" :disabled="prompts.length === 0">
+          <v-btn
+            variant="outlined"
+            color="primary"
+            size="small"
+            class="my-1"
+            @click="undo"
+            :disabled="prompts.length === 0"
+          >
             Undo last prompt
           </v-btn>
           <v-btn
+            variant="outlined"
+            color="primary"
+            size="small"
             class="my-1"
             @click="redo"
             :disabled="promptHistory.length === 0"
@@ -18,13 +28,23 @@
             Redo last prompt
           </v-btn>
           <v-btn
+            variant="outlined"
+            color="primary"
+            size="small"
             class="my-1"
             @click="resetPrompts"
             :disabled="prompts.length === 0"
           >
             Reset prompts
           </v-btn>
-          <v-btn class="my-1" @click="submit" :disabled="!outputCoordinates">
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            class="my-1"
+            @click="submit"
+            :disabled="!outputCoordinates"
+          >
             Submit annotation
           </v-btn>
         </div>

--- a/src/components/ScaleSettings.vue
+++ b/src/components/ScaleSettings.vue
@@ -24,23 +24,29 @@
         <template v-if="!configurationOnly">
           <div>
             <v-btn
-              class="ma-1 d-flex"
+              variant="outlined"
+              color="primary"
               size="small"
+              class="ma-1 d-flex"
               @click="resetFromDataset(item.key)"
             >
               Reset from dataset
             </v-btn>
             <v-btn
-              class="ma-1 d-flex"
+              variant="outlined"
+              color="primary"
               size="small"
+              class="ma-1 d-flex"
               :disabled="!viewScales[item.key]"
               @click="revertToCollection(item.key)"
             >
               Reset from collection
             </v-btn>
             <v-btn
-              class="ma-1 d-flex"
+              variant="outlined"
+              color="primary"
               size="small"
+              class="ma-1 d-flex"
               :disabled="!viewScales[item.key]"
               @click="saveInCollection(item.key)"
             >

--- a/src/components/ShareDataset.vue
+++ b/src/components/ShareDataset.vue
@@ -138,6 +138,7 @@
                       <td v-if="isResourceAdmin" class="text-center">
                         <v-btn
                           v-if="user.level !== 2"
+                          variant="text"
                           icon
                           size="small"
                           color="error"
@@ -199,7 +200,9 @@
                   </v-col>
                   <v-col cols="3">
                     <v-btn
+                      variant="flat"
                       color="primary"
+                      size="small"
                       :loading="addUserLoading"
                       :disabled="!newUserEmail || addUserLoading"
                       @click="addUser"
@@ -221,7 +224,7 @@
           tooltip="Copy shareable link to this dataset"
         />
         <v-spacer />
-        <v-btn color="primary" variant="text" @click="close">Done</v-btn>
+        <v-btn variant="text" size="small" @click="close">Done</v-btn>
       </v-card-actions>
     </v-card>
 
@@ -236,8 +239,12 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="confirmDialog = false">Cancel</v-btn>
-          <v-btn color="error" variant="text" @click="removeUser">Remove</v-btn>
+          <v-btn variant="text" size="small" @click="confirmDialog = false">
+            Cancel
+          </v-btn>
+          <v-btn variant="flat" color="error" size="small" @click="removeUser">
+            Remove
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/components/ShareProject.vue
+++ b/src/components/ShareProject.vue
@@ -99,6 +99,7 @@
                       <td class="text-center">
                         <v-btn
                           v-if="user.level !== 2"
+                          variant="text"
                           icon
                           size="small"
                           color="error"
@@ -160,7 +161,9 @@
                 </v-col>
                 <v-col cols="3">
                   <v-btn
+                    variant="flat"
                     color="primary"
+                    size="small"
                     :loading="addUserLoading"
                     :disabled="!newUserEmail || addUserLoading"
                     @click="confirmAddUser"
@@ -181,7 +184,7 @@
           tooltip="Copy shareable link to this project"
         />
         <v-spacer />
-        <v-btn color="primary" variant="text" @click="close">Done</v-btn>
+        <v-btn variant="text" size="small" @click="close">Done</v-btn>
       </v-card-actions>
     </v-card>
 
@@ -203,10 +206,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="confirmDialog = false">Cancel</v-btn>
+          <v-btn variant="text" size="small" @click="confirmDialog = false">
+            Cancel
+          </v-btn>
           <v-btn
             :color="confirmColor"
-            variant="text"
+            variant="flat"
+            size="small"
             @click="executeConfirmedAction"
           >
             {{ confirmActionLabel }}

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -13,7 +13,13 @@
           </div>
           <div class="d-flex">
             <v-spacer />
-            <v-btn @click="imageTooBigDialog = false">OK</v-btn>
+            <v-btn
+              variant="flat"
+              color="primary"
+              size="small"
+              @click="imageTooBigDialog = false"
+              >OK</v-btn
+            >
           </div>
         </v-alert>
       </v-dialog>
@@ -66,6 +72,8 @@
         </v-row>
         <v-row class="pl-3">
           <v-btn
+            variant="outlined"
+            color="primary"
             size="small"
             class="my-2"
             @click="setArea('viewport')"
@@ -73,7 +81,13 @@
           >
             Set frame to current view
           </v-btn>
-          <v-btn size="small" class="my-2" @click="setArea('full')">
+          <v-btn
+            variant="outlined"
+            color="primary"
+            size="small"
+            class="my-2"
+            @click="setArea('full')"
+          >
             Set frame to maximum view size
           </v-btn>
         </v-row>
@@ -81,7 +95,9 @@
           <v-dialog v-model="createDialog">
             <template v-slot:activator="{ props: activatorProps }">
               <v-btn
+                variant="flat"
                 color="primary"
+                size="small"
                 v-bind="activatorProps"
                 :disabled="!isLoggedIn"
                 v-description="{
@@ -135,7 +151,9 @@
                 <v-card-actions>
                   <v-spacer />
                   <v-btn
+                    variant="flat"
                     color="primary"
+                    size="small"
                     :disabled="!isSaveSnapshotValid"
                     type="submit"
                   >
@@ -191,9 +209,10 @@
           <!-- Delete icon -->
           <template v-slot:item.delete="{ item }">
             <v-btn
+              variant="text"
               icon
               size="small"
-              color="red"
+              color="error"
               @click.stop="removeSnapshot(item.name)"
             >
               <v-icon>mdi-trash-can</v-icon>
@@ -401,7 +420,10 @@
             </v-card-text>
             <v-card-actions>
               <v-spacer></v-spacer>
-              <v-btn variant="text" @click="scalebarSettingsDialog = false"
+              <v-btn
+                variant="text"
+                size="small"
+                @click="scalebarSettingsDialog = false"
                 >Close</v-btn
               >
             </v-card-actions>
@@ -412,7 +434,9 @@
 
         <div class="mb-2">
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             @click="downloadImagesForCurrentState()"
             :disabled="unroll || downloading"
           >
@@ -421,7 +445,9 @@
         </div>
         <div class="mb-2">
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             @click="downloadImagesForAllSnapshots()"
             :disabled="unroll || downloading"
           >
@@ -430,7 +456,9 @@
         </div>
         <div class="mb-2">
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             @click="downloadImagesForSelectedSnapshots()"
             :disabled="
               unroll || downloading || selectedSnapshotItems.length === 0
@@ -441,7 +469,9 @@
         </div>
         <div class="mb-2">
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             @click="snapshotWithAnnotations()"
             :disabled="unroll || downloading"
           >
@@ -450,7 +480,9 @@
         </div>
         <div class="mb-2">
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             @click="movieDialog = true"
             :disabled="unroll || downloading"
           >
@@ -469,7 +501,12 @@
       <v-divider />
 
       <div class="d-flex pa-2">
-        <v-btn color="primary" @click="screenshotViewport()">
+        <v-btn
+          variant="flat"
+          color="primary"
+          size="small"
+          @click="screenshotViewport()"
+        >
           Download Screenshot of Current Viewport
         </v-btn>
       </div>
@@ -484,13 +521,27 @@
             removed or because layer channels have changed.
           </v-card-text>
           <v-card-actions class="d-flex justify-end">
-            <v-btn @click="overwriteConfigurationLayers" color="red">
+            <v-btn
+              variant="flat"
+              color="error"
+              size="small"
+              @click="overwriteConfigurationLayers"
+            >
               Overwrite configuration layers
             </v-btn>
-            <v-btn @click="changeDatasetViewContrasts" color="secondary">
+            <v-btn
+              variant="outlined"
+              color="primary"
+              size="small"
+              @click="changeDatasetViewContrasts"
+            >
               Try to apply contrasts anyway
             </v-btn>
-            <v-btn @click="layersOverwritePanel = false" color="primary">
+            <v-btn
+              variant="text"
+              size="small"
+              @click="layersOverwritePanel = false"
+            >
               Do not change layers
             </v-btn>
           </v-card-actions>

--- a/src/components/TagCloudPicker.vue
+++ b/src/components/TagCloudPicker.vue
@@ -72,7 +72,11 @@
             </v-card-text>
             <v-card-actions>
               <v-spacer></v-spacer>
-              <v-btn color="primary" @click="applyColorToTag(tag)"
+              <v-btn
+                variant="flat"
+                color="primary"
+                size="small"
+                @click="applyColorToTag(tag)"
                 >Apply Color</v-btn
               >
             </v-card-actions>

--- a/src/components/TagSelectionDialog.vue
+++ b/src/components/TagSelectionDialog.vue
@@ -21,8 +21,16 @@
       <v-divider></v-divider>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="warning" @click="clearTags"> Clear input </v-btn>
-        <v-btn color="primary" :disabled="!isLoggedIn" @click="submit">
+        <v-btn variant="text" size="small" @click="clearTags">
+          Clear input
+        </v-btn>
+        <v-btn
+          variant="flat"
+          color="primary"
+          size="small"
+          :disabled="!isLoggedIn"
+          @click="submit"
+        >
           Add/remove tags
         </v-btn>
       </v-card-actions>

--- a/src/components/UserColorSettings.vue
+++ b/src/components/UserColorSettings.vue
@@ -38,6 +38,7 @@
                     ? displayColors[channel]
                     : '#FFFFFF'
                 "
+                variant="flat"
                 block
                 size="small"
                 @click="openColorPicker(String(channel))"
@@ -48,6 +49,7 @@
             <v-col cols="1">
               <v-btn
                 v-if="!isCustomChannel(String(channel))"
+                variant="text"
                 icon
                 size="small"
                 @click="resetColor(String(channel))"
@@ -57,6 +59,7 @@
               </v-btn>
               <v-btn
                 v-else
+                variant="text"
                 icon
                 size="small"
                 @click="resetColor(String(channel))"
@@ -73,7 +76,8 @@
         <v-col>
           <v-btn
             variant="outlined"
-            color="secondary"
+            color="primary"
+            size="small"
             @click="showAddChannelDialog = true"
             class="mb-2"
           >
@@ -85,11 +89,30 @@
 
       <v-row class="mt-2">
         <v-col>
-          <v-btn color="primary" @click="saveAndClose" :loading="saving">
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            @click="saveAndClose"
+            :loading="saving"
+          >
             Save Preferences
           </v-btn>
-          <v-btn class="ml-2" @click="resetAllColors"> Reset All </v-btn>
-          <v-btn class="ml-2" variant="text" @click="cancelChanges">
+          <v-btn
+            variant="outlined"
+            color="primary"
+            size="small"
+            class="ml-2"
+            @click="resetAllColors"
+          >
+            Reset All
+          </v-btn>
+          <v-btn
+            class="ml-2"
+            variant="text"
+            size="small"
+            @click="cancelChanges"
+          >
             Cancel
           </v-btn>
         </v-col>
@@ -109,10 +132,16 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="colorPickerDialog = false"
+          <v-btn variant="text" size="small" @click="colorPickerDialog = false"
             >Cancel</v-btn
           >
-          <v-btn color="primary" @click="applyPickerColor">Apply</v-btn>
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            @click="applyPickerColor"
+            >Apply</v-btn
+          >
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -138,7 +167,12 @@
             @keyup.enter="addNewChannel"
           >
             <template #append>
-              <v-btn icon size="small" @click="openNewChannelColorPicker">
+              <v-btn
+                variant="text"
+                icon
+                size="small"
+                @click="openNewChannelColorPicker"
+              >
                 <v-icon :color="newChannelColor">mdi-palette</v-icon>
               </v-btn>
             </template>
@@ -146,9 +180,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="cancelAddChannel">Cancel</v-btn>
+          <v-btn variant="text" size="small" @click="cancelAddChannel"
+            >Cancel</v-btn
+          >
           <v-btn
+            variant="flat"
             color="primary"
+            size="small"
             @click="addNewChannel"
             :disabled="!isNewChannelValid"
           >
@@ -167,10 +205,19 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn variant="text" @click="newChannelColorPickerDialog = false"
+          <v-btn
+            variant="text"
+            size="small"
+            @click="newChannelColorPickerDialog = false"
             >Cancel</v-btn
           >
-          <v-btn color="primary" @click="applyNewChannelColor">Apply</v-btn>
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            @click="applyNewChannelColor"
+            >Apply</v-btn
+          >
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/components/ValueSlider.vue
+++ b/src/components/ValueSlider.vue
@@ -22,8 +22,9 @@
         <span class="counter-label ml-1">/{{ max + offset }}</span>
         <div class="step-arrows ml-1">
           <v-btn
-            size="x-small"
+            variant="text"
             icon
+            size="x-small"
             class="step-btn"
             :disabled="modelValue >= max"
             @click="increment"
@@ -31,8 +32,9 @@
             <v-icon size="x-small">mdi-chevron-up</v-icon>
           </v-btn>
           <v-btn
-            size="x-small"
+            variant="text"
             icon
+            size="x-small"
             class="step-btn"
             :disabled="modelValue <= min"
             @click="decrement"

--- a/src/components/ViewerSettings.vue
+++ b/src/components/ViewerSettings.vue
@@ -130,7 +130,13 @@
 
           <v-divider class="my-4" />
 
-          <v-btn color="primary" @click="showColorDialog = true" block>
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            block
+            @click="showColorDialog = true"
+          >
             <v-icon start>mdi-palette</v-icon>
             Customize Default Channel Colors
           </v-btn>

--- a/src/components/ViewerToolbar.vue
+++ b/src/components/ViewerToolbar.vue
@@ -97,9 +97,12 @@
       <div v-if="timelapseMode" class="d-flex align-center">
         <v-btn
           class="ml-3"
+          variant="text"
+          color="error"
           size="small"
           @click="annotationStore.deleteAllTimelapseConnections"
         >
+          <v-icon start>mdi-delete</v-icon>
           Delete all timelapse connections
         </v-btn>
       </div>

--- a/src/components/ZenodoCommunityDisplay.vue
+++ b/src/components/ZenodoCommunityDisplay.vue
@@ -14,7 +14,7 @@
         id="zenodo-community-display-tourstep"
       >
         Sample Datasets
-        <v-btn icon @click="$emit('close')">
+        <v-btn variant="text" icon size="small" @click="$emit('close')">
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-card-title>

--- a/src/components/ZenodoImporter.vue
+++ b/src/components/ZenodoImporter.vue
@@ -3,7 +3,7 @@
     <v-card>
       <v-card-title class="d-flex justify-space-between align-center">
         Import Sample Dataset
-        <v-btn icon @click="$emit('close')">
+        <v-btn variant="text" icon size="small" @click="$emit('close')">
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-card-title>
@@ -76,7 +76,9 @@
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn
+          variant="flat"
           color="primary"
+          size="small"
           :disabled="!canImport || importing"
           @click="importSelectedDataset"
           id="zenodo-importer-import-dataset-tourstep"

--- a/src/components/ZenodoPublish.vue
+++ b/src/components/ZenodoPublish.vue
@@ -83,6 +83,7 @@
       <v-btn
         v-if="depositionUrl"
         variant="text"
+        size="small"
         :href="depositionUrl"
         target="_blank"
       >
@@ -95,8 +96,9 @@
       <!-- Discard draft -->
       <v-btn
         v-if="zenodoStatus === 'draft' || zenodoStatus === 'error'"
-        color="warning"
         variant="text"
+        color="warning"
+        size="small"
         :loading="discarding"
         @click="discardDraft"
       >
@@ -106,7 +108,9 @@
       <!-- Publish (mint DOI) -->
       <v-btn
         v-if="zenodoStatus === 'draft'"
+        variant="flat"
         color="success"
+        size="small"
         :loading="publishing"
         @click="confirmPublish = true"
       >
@@ -117,7 +121,9 @@
       <!-- Upload to Zenodo -->
       <v-btn
         v-if="canUpload"
+        variant="flat"
         color="primary"
+        size="small"
         :loading="uploading"
         :disabled="!hasToken"
         @click="startUpload"
@@ -149,8 +155,16 @@
           </p>
         </v-card-text>
         <v-card-actions class="d-flex justify-end gap-2">
-          <v-btn @click="confirmPublish = false">Cancel</v-btn>
-          <v-btn color="success" :loading="publishing" @click="doPublish">
+          <v-btn variant="text" size="small" @click="confirmPublish = false"
+            >Cancel</v-btn
+          >
+          <v-btn
+            variant="flat"
+            color="success"
+            size="small"
+            :loading="publishing"
+            @click="doPublish"
+          >
             Publish
           </v-btn>
         </v-card-actions>

--- a/src/components/ZenodoTokenDialog.vue
+++ b/src/components/ZenodoTokenDialog.vue
@@ -35,17 +35,26 @@
       <v-card-actions class="d-flex justify-end gap-2">
         <v-btn
           v-if="hasExistingToken"
-          color="error"
           variant="text"
+          color="error"
+          size="small"
           :loading="deleting"
           @click="removeToken"
         >
+          <v-icon start>mdi-delete</v-icon>
           Remove Token
         </v-btn>
         <v-spacer />
-        <v-btn @click="$emit('update:modelValue', false)">Cancel</v-btn>
         <v-btn
+          variant="text"
+          size="small"
+          @click="$emit('update:modelValue', false)"
+          >Cancel</v-btn
+        >
+        <v-btn
+          variant="flat"
           color="primary"
+          size="small"
           :loading="saving"
           :disabled="!token"
           @click="saveToken"

--- a/src/layout/BreadCrumbs.vue
+++ b/src/layout/BreadCrumbs.vue
@@ -44,6 +44,7 @@
             </router-link>
             <v-btn
               v-if="item.title === 'Dataset:' && showExternalLink"
+              variant="text"
               icon
               size="x-small"
               title="Open in Girder"
@@ -64,6 +65,7 @@
             </span>
             <v-btn
               v-if="item.title === 'Dataset:' && showExternalLink"
+              variant="text"
               icon
               size="x-small"
               title="Open in Girder"

--- a/src/layout/UserMenu.vue
+++ b/src/layout/UserMenu.vue
@@ -2,7 +2,12 @@
   <div>
     <v-dialog v-model="userMenu" v-if="!store.isLoggedIn" max-width="400px">
       <template #activator="{ props: activatorProps }">
-        <v-btn v-if="!store.isLoggedIn" v-bind="activatorProps" color="primary"
+        <v-btn
+          v-if="!store.isLoggedIn"
+          v-bind="activatorProps"
+          variant="flat"
+          color="primary"
+          size="small"
           >Login</v-btn
         >
       </template>
@@ -51,7 +56,7 @@
       :close-on-content-click="false"
     >
       <template #activator="{ props: activatorProps }">
-        <v-btn icon v-bind="activatorProps">
+        <v-btn variant="text" icon size="small" v-bind="activatorProps">
           <v-icon>mdi-account-circle</v-icon>
         </v-btn>
       </template>

--- a/src/layout/UserMenuLoginForm.vue
+++ b/src/layout/UserMenuLoginForm.vue
@@ -18,9 +18,12 @@
         autocomplete="current-password"
       />
       <div class="d-flex flex-column">
-        <v-btn type="submit" color="primary">Login</v-btn>
+        <v-btn type="submit" variant="flat" color="primary" size="small">
+          Login
+        </v-btn>
         <v-btn
           variant="text"
+          size="small"
           class="align-self-end my-2"
           @click="switchToSignUp"
         >
@@ -87,13 +90,16 @@
         <div class="d-flex flex-column">
           <v-btn
             type="submit"
+            variant="flat"
             color="primary"
+            size="small"
             :disabled="signupPassword !== signupPasswordVerification"
           >
             Sign up
           </v-btn>
           <v-btn
             variant="text"
+            size="small"
             class="align-self-end my-2"
             @click="switchToLogin"
           >

--- a/src/layout/UserProfileSettings.vue
+++ b/src/layout/UserProfileSettings.vue
@@ -13,7 +13,9 @@
           <h3>Girder domain:</h3>
           <p>{{ girderUrlFromApiRoot(store.girderRest.apiRoot) }}</p>
         </div>
-        <v-btn color="error" dark @click="logout"> Logout </v-btn>
+        <v-btn variant="flat" color="error" size="small" @click="logout">
+          Logout
+        </v-btn>
       </v-container>
     </v-card-text>
   </v-card>

--- a/src/style.scss
+++ b/src/style.scss
@@ -19,6 +19,17 @@ body,
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Form elements have their own UA font by default; make sure they inherit.
+   Without this, a v-btn rendered as <button> uses the browser's default font
+   while a v-btn with :to (rendered as <a>) inherits Inter — causing visual
+   inconsistency between otherwise identical v-btns. */
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
 /* Dark theme tokens */
 .v-theme--dark {
   --nimbus-border: rgba(255, 255, 255, 0.06);

--- a/src/style.scss
+++ b/src/style.scss
@@ -152,9 +152,12 @@ body {
   }
 }
 
-/* Primary-colored buttons: translucent primary accent */
-.v-btn--variant-tonal.text-primary,
-.v-btn.bg-primary {
+/* Tonal primary buttons: translucent primary accent (glass-style secondary).
+   Note: this rule must NOT target `.v-btn.bg-primary` — that selector matches
+   `variant="flat" color="primary"`, which is our prominent primary CTA and is
+   meant to render as a solid filled button. Keeping the muting confined to
+   `tonal` preserves the Linear-style glass treatment for that variant only. */
+.v-btn--variant-tonal.text-primary {
   background: rgba(var(--v-theme-primary), 0.15) !important;
   border: 1px solid rgba(var(--v-theme-primary), 0.2);
   color: rgb(var(--v-theme-primary)) !important;
@@ -162,6 +165,16 @@ body {
   &:hover {
     background: rgba(var(--v-theme-primary), 0.25) !important;
   }
+}
+
+/* Disabled buttons: clearer "not interactable" treatment.
+   Vuetify's default only drops opacity to ~38% but keeps the brand color,
+   which on dark themes can read as "subtle primary" rather than disabled.
+   Adding a grayscale filter desaturates the color so the off-state is
+   unambiguous. */
+.v-btn--disabled,
+.v-btn:disabled {
+  filter: grayscale(0.7);
 }
 
 /* Inputs: ghost outline */

--- a/src/style.scss
+++ b/src/style.scss
@@ -171,9 +171,14 @@ body {
    Vuetify's default only drops opacity to ~38% but keeps the brand color,
    which on dark themes can read as "subtle primary" rather than disabled.
    Adding a grayscale filter desaturates the color so the off-state is
-   unambiguous. */
-.v-btn--disabled,
-.v-btn:disabled {
+   unambiguous.
+
+   Targets every child of the v-btn EXCEPT `.v-btn__loader` so the loader
+   spinner keeps its color when a button is `:loading` and `:disabled` at
+   the same time (e.g., a submit button mid-flight that's also marked
+   `:disabled="loading"`). */
+.v-btn--disabled > *:not(.v-btn__loader),
+.v-btn:disabled > *:not(.v-btn__loader) {
   filter: grayscale(0.7);
 }
 

--- a/src/tools/ToolEdition.vue
+++ b/src/tools/ToolEdition.vue
@@ -22,16 +22,28 @@
       </div>
     </v-card-text>
     <v-card-actions class="py-4">
-      <v-btn @click="removeTool" color="red" class="mr-4">
+      <v-btn
+        variant="text"
+        color="error"
+        size="small"
+        class="mr-4"
+        @click="removeTool"
+      >
         Delete tool
         <v-icon class="ml-1">mdi-delete</v-icon>
       </v-btn>
       <v-spacer />
-      <v-btn @click="cancel" color="warning" class="mr-4">
+      <v-btn variant="text" size="small" class="mr-4" @click="cancel">
         Cancel
         <v-icon class="ml-1">mdi-undo</v-icon>
       </v-btn>
-      <v-btn @click="submit" color="primary" class="mr-4">
+      <v-btn
+        variant="flat"
+        color="primary"
+        size="small"
+        class="mr-4"
+        @click="submit"
+      >
         Update tool
         <v-icon class="ml-1">mdi-check</v-icon>
       </v-btn>

--- a/src/tools/creation/ToolCreation.vue
+++ b/src/tools/creation/ToolCreation.vue
@@ -50,10 +50,14 @@
           </div>
           <v-card-actions class="tool-creation-actions">
             <v-spacer />
-            <v-btn class="mr-4" color="warning" @click="close">CANCEL</v-btn>
+            <v-btn class="mr-4" variant="text" size="small" @click="close"
+              >CANCEL</v-btn
+            >
             <v-btn
               class="mr-4"
+              variant="flat"
               color="primary"
+              size="small"
               @click="createTool"
               :disabled="!selectedTemplate"
               id="tool-creation-add-tool-button-tourstep"

--- a/src/tools/creation/templates/TagAndLayerRestriction.vue
+++ b/src/tools/creation/templates/TagAndLayerRestriction.vue
@@ -10,8 +10,9 @@
           :title="`Current tags selection mode: ${
             areTagsInclusive ? 'inclusive' : 'exclusive'
           }`"
-          size="x-small"
+          variant="text"
           icon
+          size="x-small"
           @click="areTagsInclusive = !areTagsInclusive"
         >
           <v-icon>

--- a/src/tools/toolsets/Toolset.vue
+++ b/src/tools/toolsets/Toolset.vue
@@ -10,7 +10,9 @@
               <template v-slot:activator="{ props: tooltipProps }">
                 <v-btn
                   class="ml-2"
+                  variant="flat"
                   color="primary"
+                  size="small"
                   v-bind="mergeProps(dialogProps, tooltipProps)"
                   id="add-tool-tourstep"
                   v-tour-trigger="'add-tool-tourtrigger'"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -242,6 +242,7 @@
           <v-card-title class="headline d-flex align-center">
             Create dataset
             <v-btn
+              variant="text"
               icon
               size="small"
               class="ml-2"
@@ -378,12 +379,15 @@
             </v-card>
           </v-card-text>
           <v-card-actions>
-            <v-btn variant="text" @click="closeUploadDialog">Cancel</v-btn>
+            <v-btn variant="text" size="small" @click="closeUploadDialog">
+              Cancel
+            </v-btn>
             <v-spacer></v-spacer>
             <v-btn
               id="configure-dataset-button-tourstep"
               variant="outlined"
               color="primary"
+              size="small"
               v-tour-trigger="'configure-dataset-tourtrigger'"
               :disabled="!isFormValid"
               @click="handleConfigureDataset"
@@ -393,7 +397,9 @@
             </v-btn>
             <v-btn
               id="accept-defaults-button-tourstep"
+              variant="flat"
               color="primary"
+              size="small"
               v-tour-trigger="'accept-defaults-tourtrigger'"
               :disabled="!isFormValid"
               @click="handleAcceptDefaults"

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -11,7 +11,9 @@
         class="mr-2"
       />
       <v-btn
+        variant="outlined"
         color="primary"
+        size="small"
         class="mr-2"
         @click="showAddToProjectDialog = true"
         :disabled="!configuration"
@@ -21,8 +23,14 @@
       </v-btn>
       <v-dialog v-model="removeConfirm" max-width="33vw">
         <template #activator="{ props: activatorProps }">
-          <v-btn color="red" v-bind="activatorProps" :disabled="!configuration">
-            <v-icon start>mdi-close</v-icon>
+          <v-btn
+            variant="text"
+            color="error"
+            size="small"
+            v-bind="activatorProps"
+            :disabled="!configuration"
+          >
+            <v-icon start>mdi-delete</v-icon>
             Delete Collection
           </v-btn>
         </template>
@@ -31,8 +39,12 @@
             Are you sure you want to delete "{{ name }}" forever?
           </v-card-title>
           <v-card-actions class="button-bar">
-            <v-btn @click="removeConfirm = false">Cancel</v-btn>
-            <v-btn @click="remove" color="warning">Remove</v-btn>
+            <v-btn variant="text" size="small" @click="removeConfirm = false"
+              >Cancel</v-btn
+            >
+            <v-btn variant="flat" color="error" size="small" @click="remove"
+              >Remove</v-btn
+            >
           </v-card-actions>
         </v-card>
       </v-dialog>
@@ -67,8 +79,19 @@
               }}"?
             </v-card-title>
             <v-card-actions class="button-bar">
-              <v-btn @click="closeRemoveDatasetDialog()"> Cancel </v-btn>
-              <v-btn @click="removeDatasetView()" color="warning">
+              <v-btn
+                variant="text"
+                size="small"
+                @click="closeRemoveDatasetDialog()"
+              >
+                Cancel
+              </v-btn>
+              <v-btn
+                variant="flat"
+                color="error"
+                size="small"
+                @click="removeDatasetView()"
+              >
                 Remove
               </v-btn>
             </v-card-actions>
@@ -113,12 +136,19 @@
             </div>
             <span class="button-bar">
               <v-btn
-                color="warning"
+                variant="text"
+                color="error"
+                size="small"
                 v-on:click.stop="openRemoveDatasetDialog(d.datasetView)"
               >
-                <v-icon start>mdi-close</v-icon>remove
+                <v-icon start>mdi-delete</v-icon>remove
               </v-btn>
-              <v-btn color="primary" :to="toRoute(d.datasetView)">
+              <v-btn
+                variant="flat"
+                color="success"
+                size="small"
+                :to="toRoute(d.datasetView)"
+              >
                 <v-icon start>mdi-eye</v-icon>
                 view
               </v-btn>

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -581,11 +581,3 @@ defineExpose({
   align-items: center;
 }
 </style>
-
-<style lang="scss">
-.clickable-flex {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-</style>

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -7,7 +7,8 @@
         v-if="configuration"
         :route-path="`/configuration/${configuration.id}`"
         tooltip="Copy shareable link to this collection"
-        icon-only
+        label="Copy link"
+        size="small"
         class="mr-2"
       />
       <v-btn
@@ -24,7 +25,7 @@
       <v-dialog v-model="removeConfirm" max-width="33vw">
         <template #activator="{ props: activatorProps }">
           <v-btn
-            variant="text"
+            variant="outlined"
             color="error"
             size="small"
             v-bind="activatorProps"
@@ -136,12 +137,13 @@
             </div>
             <span class="button-bar">
               <v-btn
-                variant="text"
+                variant="outlined"
                 color="error"
                 size="small"
                 v-on:click.stop="openRemoveDatasetDialog(d.datasetView)"
               >
-                <v-icon start>mdi-delete</v-icon>remove
+                <v-icon start>mdi-delete</v-icon>
+                Remove
               </v-btn>
               <v-btn
                 variant="flat"
@@ -150,7 +152,7 @@
                 :to="toRoute(d.datasetView)"
               >
                 <v-icon start>mdi-eye</v-icon>
-                view
+                View
               </v-btn>
             </span>
           </v-list-item>
@@ -158,10 +160,16 @@
       </v-card-text>
       <v-card-actions class="d-block">
         <v-divider />
-        <div class="clickable-flex pa-2 body" @click="addDatasetDialog = true">
-          <v-icon class="pr-2" color="primary">mdi-plus-circle</v-icon>
+        <v-btn
+          variant="text"
+          color="primary"
+          size="small"
+          class="ma-2"
+          @click="addDatasetDialog = true"
+        >
+          <v-icon start>mdi-plus-circle</v-icon>
           Add dataset to current collection
-        </div>
+        </v-btn>
         <v-dialog
           content-class="smart-overflow"
           class="wide-dialog"

--- a/src/views/configuration/NewConfiguration.vue
+++ b/src/views/configuration/NewConfiguration.vue
@@ -11,7 +11,14 @@
       />
 
       <div class="button-bar">
-        <v-btn :disabled="!valid" color="success" class="mr-4" @click="submit">
+        <v-btn
+          :disabled="!valid"
+          variant="flat"
+          color="success"
+          size="small"
+          class="mr-4"
+          @click="submit"
+        >
           Create
         </v-btn>
       </div>

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -266,7 +266,10 @@
                     size="small"
                     variant="outlined"
                     color="primary"
-                    @click="goToImportConfiguration"
+                    :to="{
+                      name: 'importconfiguration',
+                      query: { datasetId, folderId: datasetParentId },
+                    }"
                   >
                     Add to an existing collection…
                   </v-btn>
@@ -286,7 +289,10 @@
                     size="small"
                     variant="outlined"
                     color="primary"
-                    @click="goToDuplicateImportConfiguration"
+                    :to="{
+                      name: 'duplicateimportconfiguration',
+                      query: { datasetId },
+                    }"
                   >
                     Copy existing collection…
                   </v-btn>
@@ -688,23 +694,6 @@ async function duplicateView(
   });
 }
 
-function goToImportConfiguration() {
-  router.push({
-    name: "importconfiguration",
-    query: {
-      datasetId: datasetId.value,
-      folderId: datasetParentId.value ?? undefined,
-    },
-  });
-}
-
-function goToDuplicateImportConfiguration() {
-  router.push({
-    name: "duplicateimportconfiguration",
-    query: { datasetId: datasetId.value },
-  });
-}
-
 async function goToDefaultView() {
   if (datasetViews.value.length > 0) {
     const selectedView = selectedDatasetViewId.value
@@ -900,8 +889,6 @@ defineExpose({
   closeRemoveConfigurationDialog,
   removeDatasetView,
   duplicateView,
-  goToImportConfiguration,
-  goToDuplicateImportConfiguration,
   goToDefaultView,
   createDefaultView,
   handleLocationSelected,

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -68,9 +68,9 @@
               <v-dialog v-model="removeDatasetConfirm" max-width="33vw">
                 <template #activator="{ props: activatorProps }">
                   <v-btn
+                    variant="text"
                     color="error"
                     size="small"
-                    variant="outlined"
                     v-bind="activatorProps"
                   >
                     <v-icon start>mdi-close</v-icon>
@@ -82,10 +82,21 @@
                     Are you sure to remove "{{ datasetName }}"?
                   </v-card-title>
                   <v-card-actions class="button-bar">
-                    <v-btn @click="removeDatasetConfirm = false">
+                    <v-btn
+                      variant="text"
+                      size="small"
+                      @click="removeDatasetConfirm = false"
+                    >
                       Cancel
                     </v-btn>
-                    <v-btn @click="removeDataset" color="warning">Remove</v-btn>
+                    <v-btn
+                      variant="flat"
+                      color="error"
+                      size="small"
+                      @click="removeDataset"
+                    >
+                      Remove
+                    </v-btn>
                   </v-card-actions>
                 </v-card>
               </v-dialog>
@@ -122,10 +133,19 @@
                   }}"?
                 </v-card-title>
                 <v-card-actions class="button-bar">
-                  <v-btn @click="closeRemoveConfigurationDialog()">
+                  <v-btn
+                    variant="text"
+                    size="small"
+                    @click="closeRemoveConfigurationDialog()"
+                  >
                     Cancel
                   </v-btn>
-                  <v-btn @click="removeDatasetView()" color="warning">
+                  <v-btn
+                    variant="flat"
+                    color="error"
+                    size="small"
+                    @click="removeDatasetView()"
+                  >
                     Remove
                   </v-btn>
                 </v-card-actions>
@@ -307,9 +327,13 @@
                 </v-card-text>
                 <v-card-actions>
                   <v-spacer></v-spacer>
-                  <v-btn variant="text" @click="showNewCollectionDialog = false"
-                    >Cancel</v-btn
+                  <v-btn
+                    variant="text"
+                    size="small"
+                    @click="showNewCollectionDialog = false"
                   >
+                    Cancel
+                  </v-btn>
                 </v-card-actions>
               </v-card>
             </v-dialog>
@@ -331,12 +355,19 @@
                   <v-spacer></v-spacer>
                   <v-btn
                     variant="text"
+                    size="small"
                     @click="showNewCollectionNameDialog = false"
-                    >Cancel</v-btn
                   >
-                  <v-btn color="success" @click="createNewCollection"
-                    >Create</v-btn
+                    Cancel
+                  </v-btn>
+                  <v-btn
+                    variant="flat"
+                    color="success"
+                    size="small"
+                    @click="createNewCollection"
                   >
+                    Create
+                  </v-btn>
                 </v-card-actions>
               </v-card>
             </v-dialog>

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -68,12 +68,12 @@
               <v-dialog v-model="removeDatasetConfirm" max-width="33vw">
                 <template #activator="{ props: activatorProps }">
                   <v-btn
-                    variant="text"
+                    variant="outlined"
                     color="error"
                     size="small"
                     v-bind="activatorProps"
                   >
-                    <v-icon start>mdi-close</v-icon>
+                    <v-icon start>mdi-delete</v-icon>
                     Remove Dataset
                   </v-btn>
                 </template>

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -21,11 +21,14 @@
               v-if="dataset"
               :route-path="`/dataset/${dataset.id}`"
               tooltip="Copy shareable link to this dataset"
-              icon-only
+              label="Copy link"
+              size="small"
               class="mr-2"
             />
             <v-btn
-              color="green"
+              color="success"
+              variant="flat"
+              size="small"
               @click="goToDefaultView"
               :disabled="!dataset"
               class="pulse-btn"
@@ -241,11 +244,9 @@
                     v-bind="activatorProps"
                     class="ma-1"
                     size="small"
+                    variant="outlined"
                     color="primary"
-                    :to="{
-                      name: 'importconfiguration',
-                      query: { datasetId, folderId: datasetParentId },
-                    }"
+                    @click="goToImportConfiguration"
                   >
                     Add to an existing collection…
                   </v-btn>
@@ -263,11 +264,9 @@
                     v-bind="activatorProps"
                     class="ma-1"
                     size="small"
+                    variant="outlined"
                     color="primary"
-                    :to="{
-                      name: 'duplicateimportconfiguration',
-                      query: { datasetId },
-                    }"
+                    @click="goToDuplicateImportConfiguration"
                   >
                     Copy existing collection…
                   </v-btn>
@@ -285,6 +284,7 @@
                     v-bind="activatorProps"
                     class="ma-1"
                     size="small"
+                    variant="outlined"
                     color="primary"
                     @click="showNewCollectionDialog = true"
                   >
@@ -657,6 +657,23 @@ async function duplicateView(
   });
 }
 
+function goToImportConfiguration() {
+  router.push({
+    name: "importconfiguration",
+    query: {
+      datasetId: datasetId.value,
+      folderId: datasetParentId.value ?? undefined,
+    },
+  });
+}
+
+function goToDuplicateImportConfiguration() {
+  router.push({
+    name: "duplicateimportconfiguration",
+    query: { datasetId: datasetId.value },
+  });
+}
+
 async function goToDefaultView() {
   if (datasetViews.value.length > 0) {
     const selectedView = selectedDatasetViewId.value
@@ -852,6 +869,8 @@ defineExpose({
   closeRemoveConfigurationDialog,
   removeDatasetView,
   duplicateView,
+  goToImportConfiguration,
+  goToDuplicateImportConfiguration,
   goToDefaultView,
   createDefaultView,
   handleLocationSelected,

--- a/src/views/dataset/ImportDataset.vue
+++ b/src/views/dataset/ImportDataset.vue
@@ -20,7 +20,13 @@
       </v-text-field>
 
       <div class="button-bar">
-        <v-btn :disabled="!valid" color="success" class="mr-4" @click="submit"
+        <v-btn
+          :disabled="!valid"
+          variant="flat"
+          color="success"
+          size="small"
+          class="mr-4"
+          @click="submit"
           >Import</v-btn
         >
       </div>

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -210,6 +210,8 @@
         >
         <v-spacer />
         <v-btn
+          variant="text"
+          size="small"
           @click="resetDimensionsToDefault"
           :disabled="areDimensionsSetToDefault()"
           class="ml-4"
@@ -320,6 +322,7 @@
             >
               <template v-slot:activator="{ props: activatorProps }">
                 <v-btn
+                  variant="text"
                   icon
                   size="small"
                   v-bind="activatorProps"
@@ -367,8 +370,10 @@
         <v-btn
           id="submit-button-tourstep"
           v-tour-trigger="'submit-button-tourtrigger'"
+          variant="flat"
+          color="success"
+          size="small"
           @click="submit"
-          color="green"
           :disabled="!submitEnabled() || !isRGBAssignmentValid || isUploading"
         >
           <v-progress-circular size="16" v-if="isUploading" indeterminate />
@@ -416,13 +421,24 @@
           <v-spacer></v-spacer>
           <v-tooltip location="bottom">
             <template v-slot:activator="{ props: activatorProps }">
-              <v-btn icon v-bind="activatorProps" @click="copyLogToClipboard">
+              <v-btn
+                variant="text"
+                icon
+                size="small"
+                v-bind="activatorProps"
+                @click="copyLogToClipboard"
+              >
                 <v-icon>mdi-content-copy</v-icon>
               </v-btn>
             </template>
             <span>Copy to clipboard</span>
           </v-tooltip>
-          <v-btn icon @click="showLogDialog = false">
+          <v-btn
+            variant="text"
+            icon
+            size="small"
+            @click="showLogDialog = false"
+          >
             <v-icon>mdi-close</v-icon>
           </v-btn>
         </v-card-title>
@@ -431,7 +447,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" variant="text" @click="showLogDialog = false"
+          <v-btn variant="text" size="small" @click="showLogDialog = false"
             >Close</v-btn
           >
         </v-card-actions>

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -143,6 +143,9 @@
           <v-btn
             id="upload-button-tourstep"
             v-tour-trigger="'upload-button-tourtrigger'"
+            variant="flat"
+            color="success"
+            size="small"
             :disabled="
               !valid ||
               !filesSelected ||
@@ -151,7 +154,6 @@
               invalidLocation ||
               configuring
             "
-            color="success"
             @click="submit"
           >
             Upload
@@ -291,13 +293,24 @@
           <v-spacer></v-spacer>
           <v-tooltip location="bottom">
             <template v-slot:activator="{ props: activatorProps }">
-              <v-btn icon v-bind="activatorProps" @click="copyLogToClipboard">
+              <v-btn
+                v-bind="activatorProps"
+                variant="text"
+                icon
+                size="small"
+                @click="copyLogToClipboard"
+              >
                 <v-icon>mdi-content-copy</v-icon>
               </v-btn>
             </template>
             <span>Copy to clipboard</span>
           </v-tooltip>
-          <v-btn icon @click="showLogDialog = false">
+          <v-btn
+            variant="text"
+            icon
+            size="small"
+            @click="showLogDialog = false"
+          >
             <v-icon>mdi-close</v-icon>
           </v-btn>
         </v-card-title>
@@ -306,7 +319,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" variant="text" @click="showLogDialog = false"
+          <v-btn variant="text" size="small" @click="showLogDialog = false"
             >Close</v-btn
           >
         </v-card-actions>
@@ -342,12 +355,17 @@
           </p>
         </v-card-text>
         <v-card-actions>
-          <v-btn variant="text" @click="handleStopBatch">
+          <v-btn variant="text" size="small" @click="handleStopBatch">
             <v-icon start>mdi-stop</v-icon>
             Stop and Review
           </v-btn>
           <v-spacer></v-spacer>
-          <v-btn color="primary" @click="handleContinueBatch">
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            @click="handleContinueBatch"
+          >
             <v-icon start>mdi-skip-next</v-icon>
             Skip and Continue
           </v-btn>

--- a/src/views/project/ProjectInfo.vue
+++ b/src/views/project/ProjectInfo.vue
@@ -1202,12 +1202,6 @@ defineExpose({
 </script>
 
 <style lang="scss" scoped>
-.clickable-flex {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-
 .button-bar {
   display: flex;
   align-items: center;

--- a/src/views/project/ProjectInfo.vue
+++ b/src/views/project/ProjectInfo.vue
@@ -27,7 +27,13 @@
         icon-only
         class="mr-2"
       />
-      <v-btn color="primary" class="mr-2" @click="shareDialog = true">
+      <v-btn
+        variant="outlined"
+        color="primary"
+        size="small"
+        class="mr-2"
+        @click="shareDialog = true"
+      >
         <v-icon start>mdi-share-variant</v-icon>
         Share Project
       </v-btn>
@@ -35,7 +41,9 @@
            Uncomment when Zenodo export integration is ready
       <v-btn
         v-if="canStartExport"
+        variant="flat"
         color="primary"
+        size="small"
         class="mr-2"
         @click="startExport"
       >
@@ -44,7 +52,9 @@
       </v-btn>
       <v-btn
         v-if="canMarkExported"
+        variant="flat"
         color="success"
+        size="small"
         class="mr-2"
         @click="markExported"
       >
@@ -54,7 +64,12 @@
       -->
       <v-dialog v-model="deleteConfirm" max-width="33vw">
         <template #activator="{ props: activatorProps }">
-          <v-btn color="red" v-bind="activatorProps">
+          <v-btn
+            variant="text"
+            color="error"
+            size="small"
+            v-bind="activatorProps"
+          >
             <v-icon start>mdi-delete</v-icon>
             Delete Project
           </v-btn>
@@ -68,8 +83,17 @@
             reference.
           </v-card-text>
           <v-card-actions class="button-bar">
-            <v-btn @click="deleteConfirm = false">Cancel</v-btn>
-            <v-btn @click="deleteProject" color="error">Delete</v-btn>
+            <v-btn variant="text" size="small" @click="deleteConfirm = false">
+              Cancel
+            </v-btn>
+            <v-btn
+              variant="flat"
+              color="error"
+              size="small"
+              @click="deleteProject"
+            >
+              Delete
+            </v-btn>
           </v-card-actions>
         </v-card>
       </v-dialog>
@@ -163,13 +187,17 @@
                 <span class="button-bar">
                   <v-btn
                     v-if="item.source === 'direct'"
-                    color="warning"
+                    variant="text"
+                    color="error"
+                    size="small"
                     @click="confirmRemoveDataset(item.datasetId)"
                   >
                     <v-icon start>mdi-close</v-icon>remove
                   </v-btn>
                   <v-btn
-                    color="primary"
+                    variant="flat"
+                    color="success"
+                    size="small"
                     :to="{
                       name: 'dataset',
                       params: { datasetId: item.datasetId },
@@ -250,13 +278,17 @@
                   <template #append>
                     <span class="button-bar">
                       <v-btn
-                        color="warning"
+                        variant="text"
+                        color="error"
+                        size="small"
                         @click.stop="confirmRemoveCollection(item.collectionId)"
                       >
                         <v-icon start>mdi-close</v-icon>remove
                       </v-btn>
                       <v-btn
-                        color="primary"
+                        variant="flat"
+                        color="success"
+                        size="small"
                         @click.stop="navigateToCollection(item.collectionId)"
                       >
                         <v-icon start>mdi-eye</v-icon>view
@@ -283,7 +315,9 @@
                   </span>
                 </v-list-item-title>
                 <v-btn
-                  color="primary"
+                  variant="flat"
+                  color="success"
+                  size="small"
                   :to="{
                     name: 'dataset',
                     params: { datasetId: dv.datasetId },
@@ -382,7 +416,9 @@
       <v-card-actions>
         <v-spacer />
         <v-btn
+          variant="flat"
           color="primary"
+          size="small"
           :loading="savingMetadata"
           :disabled="!hasMetadataChanges"
           @click="saveMetadata"
@@ -401,8 +437,21 @@
           itself will not be deleted.
         </v-card-text>
         <v-card-actions class="button-bar">
-          <v-btn @click="removeDatasetConfirm = false">Cancel</v-btn>
-          <v-btn @click="removeDataset" color="warning">Remove</v-btn>
+          <v-btn
+            variant="text"
+            size="small"
+            @click="removeDatasetConfirm = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            variant="flat"
+            color="error"
+            size="small"
+            @click="removeDataset"
+          >
+            Remove
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -416,8 +465,21 @@
           collection itself will not be deleted.
         </v-card-text>
         <v-card-actions class="button-bar">
-          <v-btn @click="removeCollectionConfirm = false">Cancel</v-btn>
-          <v-btn @click="removeCollection" color="warning">Remove</v-btn>
+          <v-btn
+            variant="text"
+            size="small"
+            @click="removeCollectionConfirm = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            variant="flat"
+            color="error"
+            size="small"
+            @click="removeCollection"
+          >
+            Remove
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/src/views/project/ProjectInfo.vue
+++ b/src/views/project/ProjectInfo.vue
@@ -24,7 +24,8 @@
         v-if="project"
         :route-path="`/project/${project.id}`"
         tooltip="Copy shareable link to this project"
-        icon-only
+        label="Copy link"
+        size="small"
         class="mr-2"
       />
       <v-btn
@@ -65,7 +66,7 @@
       <v-dialog v-model="deleteConfirm" max-width="33vw">
         <template #activator="{ props: activatorProps }">
           <v-btn
-            variant="text"
+            variant="outlined"
             color="error"
             size="small"
             v-bind="activatorProps"
@@ -187,12 +188,13 @@
                 <span class="button-bar">
                   <v-btn
                     v-if="item.source === 'direct'"
-                    variant="text"
+                    variant="outlined"
                     color="error"
                     size="small"
                     @click="confirmRemoveDataset(item.datasetId)"
                   >
-                    <v-icon start>mdi-close</v-icon>remove
+                    <v-icon start>mdi-delete</v-icon>
+                    Remove
                   </v-btn>
                   <v-btn
                     variant="flat"
@@ -203,7 +205,8 @@
                       params: { datasetId: item.datasetId },
                     }"
                   >
-                    <v-icon start>mdi-eye</v-icon>view
+                    <v-icon start>mdi-eye</v-icon>
+                    View
                   </v-btn>
                 </span>
               </template>
@@ -215,12 +218,18 @@
           </template>
         </v-list>
       </v-card-text>
-      <v-card-actions>
+      <v-card-actions class="d-block">
         <v-divider />
-        <div class="clickable-flex pa-2 body" @click="addDatasetDialog = true">
-          <v-icon class="pr-2" color="primary">mdi-plus-circle</v-icon>
+        <v-btn
+          variant="text"
+          color="primary"
+          size="small"
+          class="ma-2"
+          @click="addDatasetDialog = true"
+        >
+          <v-icon start>mdi-plus-circle</v-icon>
           Add dataset to project
-        </div>
+        </v-btn>
       </v-card-actions>
     </v-card>
 
@@ -278,12 +287,13 @@
                   <template #append>
                     <span class="button-bar">
                       <v-btn
-                        variant="text"
+                        variant="outlined"
                         color="error"
                         size="small"
                         @click.stop="confirmRemoveCollection(item.collectionId)"
                       >
-                        <v-icon start>mdi-close</v-icon>remove
+                        <v-icon start>mdi-delete</v-icon>
+                        Remove
                       </v-btn>
                       <v-btn
                         variant="flat"
@@ -291,7 +301,8 @@
                         size="small"
                         @click.stop="navigateToCollection(item.collectionId)"
                       >
-                        <v-icon start>mdi-eye</v-icon>view
+                        <v-icon start>mdi-eye</v-icon>
+                        View
                       </v-btn>
                     </span>
                   </template>
@@ -323,7 +334,8 @@
                     params: { datasetId: dv.datasetId },
                   }"
                 >
-                  <v-icon start>mdi-eye</v-icon>view
+                  <v-icon start>mdi-eye</v-icon>
+                  View
                 </v-btn>
               </v-list-item>
             </v-list-group>
@@ -334,15 +346,18 @@
           </template>
         </v-list>
       </v-card-text>
-      <v-card-actions>
+      <v-card-actions class="d-block">
         <v-divider />
-        <div
-          class="clickable-flex pa-2 body"
+        <v-btn
+          variant="text"
+          color="primary"
+          size="small"
+          class="ma-2"
           @click="addCollectionDialog = true"
         >
-          <v-icon class="pr-2" color="primary">mdi-plus-circle</v-icon>
+          <v-icon start>mdi-plus-circle</v-icon>
           Add collection to project
-        </div>
+        </v-btn>
       </v-card-actions>
     </v-card>
 


### PR DESCRIPTION
## Summary

- Defines a 6-role button taxonomy (primary / primary-positive / secondary / tertiary / destructive / informational / icon-only) in a new `codebaseDocumentation/BUTTON_CONVENTIONS.md` and reflects it in the `nimbus-frontend` skill so future Claude sessions follow it.
- Sweeps 295 `<v-btn>` instances across 73 files so every button has explicit `variant` and `size`, semantic color tokens, and a consistent role.
- Fixes two underlying theme issues that were making CTAs read wrong on the dark theme: `flat color="primary"` was being muted by an overly-broad `style.scss` rule (now scoped to `tonal` only), and disabled buttons now get a `grayscale(0.7)` filter so the off-state is unambiguous.
- Adds defensive rules so future button drift doesn't re-emerge: form elements inherit the page font (fixes `<a>` vs `<button>` height/font drift), and the conventions doc explicitly documents the destructive color (`error`, not `warning`) and icon (`mdi-delete`, not `mdi-close`) patterns.

## Detail

- **Toolbar pattern:** Share / Copy link / View row in DatasetInfo, ProjectInfo, ConfigurationInfo all unified — secondaries are `outlined primary`, the primary CTA is `flat success`, sizes match.
- **Stacked panels (`AnnotationActionPanel`):** unified to `outlined`; color carries the role (`error` for destructive, `primary` for neutral) so the panel reads as one consistent block.
- **List-row Remove/View pairs:** capitalized labels, `outlined error` for Remove (shape parity with `flat success` View), `mdi-delete` icon.
- **Confirm-dialog action bars:** `[text Cancel] [flat color="primary"/"error" Confirm]` everywhere; never two filled buttons.
- **\`Add to project\` / \`Add to collection\` footers:** converted from clickable \`<div>\`s to real \`<v-btn variant="text" color="primary">\`, left-aligned via \`v-card-actions class="d-block"\` for visual consistency between ProjectInfo and ConfigurationInfo.
- **Mechanical sweep:** removed all literal colors (`red`/`green`/`orange` → `error`/`success`/`warning`) and added explicit `variant` + `size` to every previously-undecorated button.

## Audit numbers (post-sweep)

- 295 v-btn instances scanned
- 0 literal color tokens remaining
- 0 buttons missing `size`
- 3 buttons missing `variant` — all v-btn-toggle children in `Home.vue`, intentional (toggle owns the styling)
- Variant distribution: text (149), flat (~93), outlined (~45)
- `pnpm tsc` clean, `pnpm lint:ci` clean

## Test plan

- [x] Reload running app and visually walk the major surfaces (DatasetInfo, ProjectInfo, ConfigurationInfo, Home, AnnotationActionPanel, dialogs throughout).
- [x] Confirm primary CTAs (`Upload Data`, `Quick Import`, `View`, `Save`, etc.) read as bright filled buttons after the `bg-primary` muting fix.
- [x] Confirm disabled buttons (`Upload to Zenodo` without a token, `Save Metadata` with no changes) read as visibly grayed-out.
- [x] Confirm Cmd/middle-click on "Add to an existing collection…" still opens in a new tab (`:to` was restored after the initial sweep regressed it).
- [x] Confirm no obvious regressions on tool panels, settings dialogs, and the file manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)