### PR TITLE
Add optional Sentry error reporting gated on VITE_SENTRY_DSN

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -284,6 +284,21 @@ logWarning("Something unexpected happened");
 logError("An error occurred", error);
 ```
 
+## Error Reporting (Sentry)
+
+`@sentry/vue` is wired in `src/main.ts`, gated on `VITE_SENTRY_DSN` at build time. When the DSN is unset, no Sentry code is loaded — local installs and OSS users pay zero runtime cost. Uncaught Vue errors and async exceptions (`window.onerror`/`unhandledrejection`) are reported automatically via the Vue integration installed at init; you don't need to wrap component code in try/catch just to report errors.
+
+To capture an error or message manually from a component, dynamic-import the package so the no-DSN path stays free of any Sentry reference:
+
+```typescript
+if (import.meta.env.VITE_SENTRY_DSN) {
+  const Sentry = await import("@sentry/vue");
+  Sentry.captureException(err, { tags: { feature: "my-feature" } });
+}
+```
+
+In practice almost no component should need this — let the global handler do its job. Local testing: see `CLAUDE.md` § "Error Reporting (Sentry)" for `.env.local` setup and the `setTimeout` test recipe.
+
 ## Buttons — five-role taxonomy
 
 Every `<v-btn>` should declare an explicit **`variant`** and **`size`**. Omitting them falls back to Vuetify's `elevated` default at default size, which looks generic and out of place against the Linear-inspired theme.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -651,6 +651,27 @@ The chat system (`src/store/chat.ts`) integrates Claude for image analysis:
 - API key configured via `ANTHROPIC_API_KEY` environment variable
 - Chat UI in `ChatComponent.vue`
 
+## Error Reporting (Sentry)
+
+Front-end error reporting via `@sentry/vue` is **opt-in** and gated on `VITE_SENTRY_DSN` at build time. The init lives in `src/main.ts`, wrapped in try/catch so a failed chunk fetch (stale deploy, ad-blocker, blocked sentry.io) can never prevent `app.mount()`.
+
+When `VITE_SENTRY_DSN` is unset (the default for OSS/local installs), no Sentry code is loaded at runtime — the dynamic import is never evaluated.
+
+**Env vars** (all optional):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `VITE_SENTRY_DSN` | unset | Sentry project DSN — empty/unset → Sentry disabled |
+| `VITE_SENTRY_ENV` | `production` | Environment label in Sentry UI |
+| `VITE_SENTRY_TRACES_SAMPLE_RATE` | `0.1` | Fraction of transactions sampled (free-tier conservative) |
+| `VITE_SENTRY_RELEASE` | unset | Release tag for grouping in Sentry |
+
+Sentry DSNs are **not secrets** — they're client-side ingest URLs designed to ship in browser bundles. The DSN value itself is fine in env files. (The build-time auth token used for source-map upload is the actual secret, but we don't currently upload source maps.)
+
+**Production:** the DSN is injected by the private AWSDeploy repo (`TF_VAR_SENTRY_DSN` → `templates/startup_haproxy.tftpl` → front-end `.env` at build time). Updating the DSN requires `terraform apply -replace aws_instance.haproxy_load_balancer` since HAProxy ignores `user_data` changes.
+
+**Local testing:** create `.env.local` (already gitignored via `*.local`) with `VITE_SENTRY_DSN=...` and `VITE_SENTRY_ENV=local-dev`, then restart `pnpm run dev`. Comment out the DSN line to disable. Trigger a test event with `setTimeout(() => { throw new Error("test"); });` in the browser console — a synchronous throw from devtools is swallowed; async throws hit `window.onerror` which Sentry hooks.
+
 ## Allowed Tools
 
 The following commands are pre-approved for Claude Code to run without confirmation:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -670,7 +670,16 @@ Sentry DSNs are **not secrets** — they're client-side ingest URLs designed to 
 
 **Production:** the DSN is injected by the private AWSDeploy repo (`TF_VAR_SENTRY_DSN` → `templates/startup_haproxy.tftpl` → front-end `.env` at build time). Updating the DSN requires `terraform apply -replace aws_instance.haproxy_load_balancer` since HAProxy ignores `user_data` changes.
 
-**Local testing:** create `.env.local` (already gitignored via `*.local`) with `VITE_SENTRY_DSN=...` and `VITE_SENTRY_ENV=local-dev`, then restart `pnpm run dev`. Comment out the DSN line to disable. Trigger a test event with `setTimeout(() => { throw new Error("test"); });` in the browser console — a synchronous throw from devtools is swallowed; async throws hit `window.onerror` which Sentry hooks.
+**Local testing:** create `.env.local` (already gitignored via `*.local`) with the DSN, then restart `pnpm run dev`. Comment out the DSN line to disable without losing the value. Example:
+
+```
+# Uncomment to enable Sentry error reporting in local dev (uses free-tier quota).
+# VITE_SENTRY_DSN=https://<key>@<orgid>.ingest.us.sentry.io/<projectid>
+VITE_SENTRY_ENV=local-dev
+VITE_SENTRY_TRACES_SAMPLE_RATE=1.0
+```
+
+Get the DSN value from the Sentry project's Settings → Client Keys (DSN) page. Trigger a test event with `setTimeout(() => { throw new Error("test"); });` in the browser console — a synchronous throw from devtools is swallowed, but async throws hit `window.onerror` which Sentry hooks. Filter on `environment:local-dev` in the Sentry UI to keep your test events out of the production view.
 
 ## Allowed Tools
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@girder/components": "4.0.0",
     "@mdi/font": "^5.3.45",
+    "@sentry/vue": "^10.53.1",
     "@types/bluebird": "^3.5.42",
     "@types/d3-array": "^3.0.1",
     "@types/d3-color": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@mdi/font':
         specifier: ^5.3.45
         version: 5.9.55
+      '@sentry/vue':
+        specifier: ^10.53.1
+        version: 10.53.1(vue@3.5.28(typescript@5.9.3))
       '@types/bluebird':
         specifier: ^3.5.42
         version: 3.5.42
@@ -1649,6 +1652,43 @@ packages:
     resolution: {integrity: sha512-1q+mykKE3Vot1kaFJIDoUFv5TuW+QQVaf2FmTT9krg86pQrGStOSJJ0Zil7CFagyxDuouTepzt5Y5TVzyajOdQ==}
     cpu: [x64]
     os: [win32]
+
+  '@sentry-internal/browser-utils@10.53.1':
+    resolution: {integrity: sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.53.1':
+    resolution: {integrity: sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.53.1':
+    resolution: {integrity: sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.53.1':
+    resolution: {integrity: sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.53.1':
+    resolution: {integrity: sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.53.1':
+    resolution: {integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==}
+    engines: {node: '>=18'}
+
+  '@sentry/vue@10.53.1':
+    resolution: {integrity: sha512-s5TeBXpQogrjS+Oom3y2wfOrju4RV2+E4wQoFt/TQPyACqvQHIcmapHcxk4bAx8jggRetmM+KwpMNgl6HJB0tg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@tanstack/vue-router': ^1.64.0
+      pinia: 2.x || 3.x
+      vue: 2.x || 3.x
+    peerDependenciesMeta:
+      '@tanstack/vue-router':
+        optional: true
+      pinia:
+        optional: true
 
   '@thewtex/zstddec@0.2.0':
     resolution: {integrity: sha512-lIS+smrfa48WGlDVQSQSm0jBnwVp5XmfGJWU9q0J0fRFY9ohzK4s27Zg2SFMb1NWMp9RiANAdK+/q86EBGWR1Q==}
@@ -6431,6 +6471,40 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.9.5':
     optional: true
+
+  '@sentry-internal/browser-utils@10.53.1':
+    dependencies:
+      '@sentry/core': 10.53.1
+
+  '@sentry-internal/feedback@10.53.1':
+    dependencies:
+      '@sentry/core': 10.53.1
+
+  '@sentry-internal/replay-canvas@10.53.1':
+    dependencies:
+      '@sentry-internal/replay': 10.53.1
+      '@sentry/core': 10.53.1
+
+  '@sentry-internal/replay@10.53.1':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.53.1
+      '@sentry/core': 10.53.1
+
+  '@sentry/browser@10.53.1':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.53.1
+      '@sentry-internal/feedback': 10.53.1
+      '@sentry-internal/replay': 10.53.1
+      '@sentry-internal/replay-canvas': 10.53.1
+      '@sentry/core': 10.53.1
+
+  '@sentry/core@10.53.1': {}
+
+  '@sentry/vue@10.53.1(vue@3.5.28(typescript@5.9.3))':
+    dependencies:
+      '@sentry/browser': 10.53.1
+      '@sentry/core': 10.53.1
+      vue: 3.5.28(typescript@5.9.3)
 
   '@thewtex/zstddec@0.2.0': {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import { tourTriggerDirective } from "./plugins/tour-trigger.directive";
 // Auto-tracking is opt-in via `__nimbusMem.enable()` and adds no overhead
 // otherwise.
 import { memDiag } from "@/utils/memoryDiagnostics";
+import { logWarning } from "@/utils/log";
 import annotationStore from "./store/annotation";
 import propertiesStore from "./store/properties";
 import girderResourcesStore from "./store/girderResources";
@@ -93,7 +94,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   } catch (err) {
     // Never let telemetry initialization break the app (e.g. stale chunk
     // after deploy, blocked sentry.io domain, ad-blocker).
-    console.warn("Sentry initialization failed:", err);
+    logWarning("Sentry initialization failed:", err);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,20 +75,26 @@ const app = createApp(App);
 // Sentry DSNs are not secrets — they're rate-limited project ingest URLs and
 // are designed to ship in client bundles.
 if (import.meta.env.VITE_SENTRY_DSN) {
-  const Sentry = await import("@sentry/vue");
-  Sentry.init({
-    app,
-    dsn: import.meta.env.VITE_SENTRY_DSN,
-    environment: import.meta.env.VITE_SENTRY_ENV || "production",
-    release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
-    sendDefaultPii: true,
-    integrations: [Sentry.browserTracingIntegration({ router })],
-    // Free tier has a finite span quota — sample tracing conservatively.
-    // Override via VITE_SENTRY_TRACES_SAMPLE_RATE (0.0 to 1.0).
-    tracesSampleRate: Number(
-      import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? 0.1,
-    ),
-  });
+  try {
+    const Sentry = await import("@sentry/vue");
+    Sentry.init({
+      app,
+      dsn: import.meta.env.VITE_SENTRY_DSN,
+      environment: import.meta.env.VITE_SENTRY_ENV || "production",
+      release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
+      sendDefaultPii: true,
+      integrations: [Sentry.browserTracingIntegration({ router })],
+      // Free tier has a finite span quota — sample tracing conservatively.
+      // Override via VITE_SENTRY_TRACES_SAMPLE_RATE (0.0 to 1.0).
+      tracesSampleRate: Number(
+        import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? 0.1,
+      ),
+    });
+  } catch (err) {
+    // Never let telemetry initialization break the app (e.g. stale chunk
+    // after deploy, blocked sentry.io domain, ad-blocker).
+    console.warn("Sentry initialization failed:", err);
+  }
 }
 
 app.use(router);

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,6 +70,27 @@ memDiag.register(() => {
 
 const app = createApp(App);
 
+// Optional Sentry error/perf reporting. Only loaded and initialized when a DSN
+// is provided at build time, so local installs and OSS users pay zero cost.
+// Sentry DSNs are not secrets — they're rate-limited project ingest URLs and
+// are designed to ship in client bundles.
+if (import.meta.env.VITE_SENTRY_DSN) {
+  const Sentry = await import("@sentry/vue");
+  Sentry.init({
+    app,
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    environment: import.meta.env.VITE_SENTRY_ENV || "production",
+    release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
+    sendDefaultPii: true,
+    integrations: [Sentry.browserTracingIntegration({ router })],
+    // Free tier has a finite span quota — sample tracing conservatively.
+    // Override via VITE_SENTRY_TRACES_SAMPLE_RATE (0.0 to 1.0).
+    tracesSampleRate: Number(
+      import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? 0.1,
+    ),
+  });
+}
+
 app.use(router);
 app.use(store);
 app.use(vuetify);


### PR DESCRIPTION
## Summary
- Adds `@sentry/vue` as a dependency and conditionally initializes Sentry in `src/main.ts` only when `VITE_SENTRY_DSN` is set at build time.
- Dynamic import means local installs and OSS users without a DSN never load any Sentry code at runtime — zero overhead.
- Defaults tuned for Sentry's free (Developer) tier: `tracesSampleRate` defaults to 0.1 and is overridable via `VITE_SENTRY_TRACES_SAMPLE_RATE`. Environment label comes from `VITE_SENTRY_ENV` (default `production`). Optional release tag via `VITE_SENTRY_RELEASE`.

## Configuration

| Env var | Required | Default | Purpose |
|---|---|---|---|
| `VITE_SENTRY_DSN` | no | (unset → Sentry disabled) | Sentry project DSN |
| `VITE_SENTRY_ENV` | no | `production` | Environment label in Sentry UI |
| `VITE_SENTRY_TRACES_SAMPLE_RATE` | no | `0.1` | Fraction of transactions sampled |
| `VITE_SENTRY_RELEASE` | no | — | Release tag for source-map/version grouping |

DSNs are not secret — Sentry intentionally designs them to ship in client bundles (rate-limited, project-scoped). The wiring of the actual DSN into the deployment `.env` lives in the private AWSDeploy repo.

## Test plan
- [x] `pnpm tsc` clean
- [x] `pnpm lint src/main.ts` clean
- [x] `pnpm run build` succeeds
- [ ] After AWSDeploy companion PR merges and a prod redeploy, verify errors appear in the Sentry project dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)