### PR TITLE
Prevent dataset owner from removing own ADMIN access

### DIFF
--- a/codebaseDocumentation/BUG_OWNER_CAN_REMOVE_SELF_FROM_DATASET.md
+++ b/codebaseDocumentation/BUG_OWNER_CAN_REMOVE_SELF_FROM_DATASET.md
@@ -1,0 +1,106 @@
+# Bug: Dataset owner can remove their own access via raw Girder ACL endpoint
+
+**Discovered:** 2026-05-18 while exercising the NimbusImage API as a non-admin user (`arjunraj`).
+**Fixed in plugin:** branch `fix/dataset-owner-cannot-remove-self` — see `server/helpers/folder_access_guard.py` and `test/test_folder_access_guard.py`.
+**Upstream Girder report:** see `UPSTREAM_GIRDER_ISSUE.md` (filed separately).
+
+## Summary
+
+The documented sharing invariant — "The dataset owner (ADMIN) cannot be removed from the access list" (`SHARING.md` line 31) — is enforceable through the NimbusImage `dataset_view/share` endpoint, but **not** through the raw Girder `PUT /folder/{id}/access` endpoint. A non-admin owner can call the raw endpoint with an ACL that omits themselves, and Girder will silently accept it, leaving the owner with `_accessLevel: -1` on their own dataset folder.
+
+## Reproduction
+
+User: non-admin, `creatorId == <me>` on the folder. Folder has `meta.subtype == 'contrastDataset'`.
+
+```python
+import nimbusimage as ni, json
+client = ni.connect()  # API key for non-admin user
+gc = client._gc
+
+DS = "<my-dataset-folder-id>"
+acl = json.dumps({"users": [], "groups": []})
+r = gc.put(f"folder/{DS}/access?access={acl}")
+# r['_accessLevel'] == -1   <-- owner has lost access
+```
+
+Subsequent `GET folder/{DS}` still returns the folder (because `public: true` was retained), but `_accessLevel: -1` means none of the standard authenticated access paths recognize the user as having any ACL entry. WRITE operations on the folder via the standard model methods will fail with the user as caller.
+
+`recurse` was not used, so descendant items/files retain whatever ACL they had.
+
+## Why this matters
+
+1. A user can accidentally lock themselves out of their own dataset and its 50k+ annotations.
+2. The documented invariant in `codebaseDocumentation/SHARING.md` does not match runtime behavior.
+3. The frontend sharing UI does not currently expose this path, but any client (CLI, Python API, automation script) using the raw Girder endpoint bypasses the safety.
+
+## Root cause
+
+The `dataset_view/share` endpoint (`server/api/datasetView.py` line 271) uses `Folder().setUserAccess(...)` which is **incremental** (one user at a time) — so it cannot remove the caller.
+
+The raw Girder endpoint `PUT /folder/{id}/access` uses `setAccessList` semantics — full ACL replacement. The NimbusImage plugin does **not** override or guard this endpoint, so any owner with ADMIN on the folder can replace the ACL with one that omits themselves.
+
+## Recommended fix
+
+Add a guard at the plugin layer that intercepts ACL changes on `contrastDataset` folders and refuses to remove the creator. Options:
+
+### Option A — Override the folder access endpoint (per-plugin route)
+
+Register a route that takes precedence over Girder's default for `folder/{id}/access` when the folder's `meta.subtype == 'contrastDataset'`. Validate that the incoming ACL still grants ADMIN to `folder.creatorId` before delegating to the model.
+
+Pro: Single point of enforcement.
+Con: Route override is sometimes fragile in Girder; needs care with method/path matching.
+
+### Option B — Model-layer hook on Folder save
+
+Wire a `model.folder.save` event listener that, on save of a `contrastDataset` folder, ensures the creator retains ADMIN in the `access.users` list. If missing, re-add it (or raise `ValidationException`).
+
+Pro: Catches every code path that saves the folder, not just one endpoint.
+Con: Event listener has to be careful not to interfere with intentional ownership transfer flows (if any exist).
+
+### Option C — API-layer helper used by all share/access paths
+
+Centralize "set folder access" in a helper in `server/helpers/` that always re-asserts the creator's ADMIN entry. Refuse to register the raw endpoint at all — but this isn't really possible since Girder ships it built-in.
+
+**Preferred:** Option B (model event hook), because the bug is about an invariant on the document itself, not a particular endpoint. Existing patterns: see `server/models/datasetView.py` for an example of plugin-level model hooks.
+
+## Test to add
+
+`devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_sharing.py` (new or existing):
+
+```python
+def test_owner_cannot_remove_self_via_raw_folder_access(user, dataset_folder):
+    # user is the creator/owner of dataset_folder (subtype=contrastDataset)
+    body = {"access": json.dumps({"users": [], "groups": []})}
+    resp = server.request(
+        path=f"/folder/{dataset_folder['_id']}/access",
+        method="PUT", user=user, params=body,
+    )
+    # Expect either:
+    #  (a) 400/403 refusing the change, OR
+    #  (b) 200 with creator still present in access.users at ADMIN level
+    refetched = Folder().load(dataset_folder['_id'], force=True)
+    assert any(
+        a['id'] == user['_id'] and a['level'] == AccessType.ADMIN
+        for a in refetched['access']['users']
+    ), "owner must retain ADMIN on contrastDataset folder"
+```
+
+## Related
+
+- `codebaseDocumentation/SHARING.md` — the doc whose invariant is violated
+- `server/api/datasetView.py` — the safe (incremental) sharing path
+- `server/helpers/access_helpers.py` — likely home for a centralized guard helper
+
+## Manual recovery for the broken folder
+
+(Recorded for the case at hand: folder `69f74239a30941949682bfa9` "HCR_ANNOTATION" needs creator ADMIN restored.)
+
+As a site admin in the Girder UI: open the folder → Access Control → add `arjunraj` as ADMIN → save (no recursion needed; the bad PUT did not recurse). Or via API as a site admin:
+
+```bash
+ADMIN_TOKEN=...
+curl -s -X PUT -H "Girder-Token: $ADMIN_TOKEN" \
+  "http://localhost:8080/api/v1/folder/69f74239a30941949682bfa9/access" \
+  --data-urlencode 'access={"users":[{"id":"69f49c2faaba948c2d7b97fd","level":2}],"groups":[]}' \
+  --data 'public=true'
+```

--- a/codebaseDocumentation/NON_ADMIN_API_BEHAVIOR.md
+++ b/codebaseDocumentation/NON_ADMIN_API_BEHAVIOR.md
@@ -1,0 +1,58 @@
+# Non-admin API behavior: token scopes and endpoint quirks
+
+Recorded 2026-05-18 while exercising the NimbusImage REST API as a non-admin user with an API key.
+
+## TL;DR
+
+The endpoints below behave in ways that look like bugs but are **core Girder**, not NimbusImage. Documenting so future debugging doesn't go around the loop again.
+
+| Endpoint | Symptom for non-admin API key | Root cause | Fix in our code? |
+|---|---|---|---|
+| `GET /job` (and friends) | `401 "user None"` when the API key has only `core.*` scopes | `girder_jobs` requires its own scope `jobs.rest.list_job` | No — `girder_jobs` plugin, not us |
+| `GET /user` (listing) | `401 "You must be logged in."` even with a valid API key | `@access.user` decorator-level scope mismatch for API keys without sufficient default scopes | No — core Girder |
+| `GET /user/me`, `GET /user/:id` | Works fine | Endpoints use `@access.public(scope=USER_INFO_READ)` which the API key satisfies | n/a |
+
+## /job endpoints — required scope
+
+From `girder_jobs/constants.py`:
+
+```python
+REST_LIST_JOB_TOKEN_SCOPE = 'jobs.rest.list_job'
+REST_CREATE_JOB_TOKEN_SCOPE = 'jobs.rest.create_job'
+```
+
+All `GET /job*` endpoints are decorated `@access.public(scope=REST_LIST_JOB_TOKEN_SCOPE)`. An API key created with the default scope set (`core.data.read`, `core.data.write`, `core.data.own`, `core.user_info.read`) will return 401 on these endpoints because none of those scopes match.
+
+**Workaround for users:** when creating the API key, select **"Allow all scopes"** (or explicitly include `jobs.rest.list_job` and `jobs.rest.create_job`). Session tokens from username/password auth automatically have all scopes, so the frontend isn't affected.
+
+**Could NimbusImage fix this?** Not really — `girder_jobs` is a Girder-maintained plugin we depend on. A PR to upstream Girder is conceivable (e.g., make `jobs.rest.list_job` implicit when `core.data.read` is present), but that's their call. For our own users, the right answer is documentation + a default-permissive API key creation flow if we want to streamline it.
+
+## /user listing — also scope-related
+
+`GET /user` (search/list) is decorated `@access.user` in core Girder. Despite the docstring being permissive, with an API key whose token scopes are limited, `getCurrentUser()` returns `None` and the endpoint 401s with `"You must be logged in."`.
+
+`GET /user/me` and `GET /user/:id` continue to work because they use `@access.public(scope=USER_INFO_READ)` which the API key has.
+
+**Practical impact:** small. The frontend uses `GET /user/:id` and the share-by-email flow (`dataset_view/share` accepts `userMailOrUsername`), so listing is rarely needed. If a tool/script needs to enumerate users, it needs a broader-scope API key.
+
+## How to verify the API key's scopes
+
+```bash
+TOKEN=$(curl -s -X POST -H "Content-Length: 0" \
+  "http://localhost:8080/api/v1/api_key/token?key=$API_KEY" \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["authToken"]["token"])')
+
+curl -s -H "Girder-Token: $TOKEN" \
+  http://localhost:8080/api/v1/token/current | python3 -m json.tool
+```
+
+The `scope` array tells you exactly which scopes the key was created with. If you don't see `jobs.rest.list_job` and you need /job access, recreate the key with "Allow all scopes" in the Girder UI.
+
+## Optional follow-up (if we want to)
+
+If we want the default API key creation in NimbusImage to "just work" for the full API surface, we could:
+
+1. Add a one-paragraph note to the Python API README (`nimbusimage/README.md`) under "Authentication" about API key scopes — quick win.
+2. Override `POST /api_key` in the plugin to default `scope=None` (= all scopes) instead of Girder's UI default — more invasive, changes user behavior.
+
+(1) is probably enough. Adding (2) would be a UX bandage; the cleaner answer is making the API key UI clearer in Girder upstream.

--- a/codebaseDocumentation/SHARING.md
+++ b/codebaseDocumentation/SHARING.md
@@ -30,6 +30,8 @@ NimbusImage uses Girder's built-in access control system with three permission l
 - Any user with READ access can view the access list (who has access and at what level)
 - The dataset owner (ADMIN) cannot be removed from the access list
 
+This last invariant is enforced by a `model.folder.save` listener installed in `server/helpers/folder_access_guard.py`. It rejects any save of a `contrastDataset` folder whose access list does not include the creator at ADMIN level. Site admins can override (recovery path). This guard plugs a gap in core Girder's `setAccessList`, which otherwise accepts any ACL including one that locks the owner out — see `BUG_OWNER_CAN_REMOVE_SELF_FROM_DATASET.md`.
+
 ## Architecture
 
 ### Resources Affected by Sharing

--- a/codebaseDocumentation/UPSTREAM_GIRDER_ISSUE.md
+++ b/codebaseDocumentation/UPSTREAM_GIRDER_ISSUE.md
@@ -1,0 +1,122 @@
+# Upstream Girder issue draft
+
+To file at https://github.com/girder/girder/issues (or as a PR).
+
+The text below is the proposed issue body. Review and edit before posting — particularly the "suggested fix" section, which proposes a change in semantics that the Girder maintainers may want to debate.
+
+---
+
+**Title:** Non–site-admin folder owner can remove their own ADMIN access via `PUT /folder/{id}/access`, locking themselves out
+
+**Affected:** at least Girder 5.x (verified against the `girder` package currently shipping with `large_image==1.34.2a166`). The relevant code paths look the same in current `master`.
+
+**Summary**
+
+`AccessControlledModel.setAccessList` (in `girder/models/model_base.py`) replaces the entire access list with whatever is passed in, validating only the per-entry shape (`id`, `level`). It does not verify that the caller remains in the resulting ACL. The `PUT /folder/{id}/access` endpoint (`girder/api/v1/folder.py:updateFolderAccess`) wires the request body directly into this method.
+
+Consequence: a non–site-admin user who has ADMIN access on a folder (typically because they created it) can call `PUT /folder/{id}/access` with an access list that omits themselves, and the request succeeds. After the call:
+
+- `Folder().load(folderId, user=originalOwner)` returns the folder with `_accessLevel: -1`.
+- If the folder is not `public`, only site admins can recover access.
+- If the folder is `public`, READ still works for everyone but WRITE is gone for the original owner.
+
+This is hard to discover via the UI but easy to hit from a script or notebook that's manipulating ACLs programmatically.
+
+**Reproduction**
+
+```bash
+# Authenticate as a non-admin user (any user with ADMIN on the folder works)
+TOKEN=$(curl -s -u user:password http://localhost:8080/api/v1/user/authentication \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["authToken"]["token"])')
+
+# Create a folder (caller is auto-granted ADMIN)
+FOLDER_ID=$(curl -s -X POST -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/folder?parentType=user&parentId=<myUserId>&name=test" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["_id"])')
+
+# Remove yourself from access
+curl -s -X PUT -H "Girder-Token: $TOKEN" \
+  "http://localhost:8080/api/v1/folder/$FOLDER_ID/access" \
+  --data-urlencode 'access={"users":[],"groups":[]}'
+
+# Re-fetch — _accessLevel is -1
+curl -s -H "Girder-Token: $TOKEN" "http://localhost:8080/api/v1/folder/$FOLDER_ID"
+```
+
+The response from the PUT is `200 OK` and includes `"_accessLevel": -1` in the returned document.
+
+**Why the existing layers don't catch this**
+
+- `Folder.setAccessList` (`girder/models/folder.py:831`) only adds `recurse`/`setPublic` logic, then delegates to `AccessControlledModel.setAccessList`.
+- `AccessControlledModel.setAccessList` (`girder/models/model_base.py:1114`) validates per-entry shape, then assigns `doc['access']` and saves.
+- The `updateFolderAccess` route requires the caller to currently hold ADMIN on the folder, but does not check the post-state.
+
+**Suggested fix**
+
+In `AccessControlledModel.setAccessList`, after building `acList`, add a check:
+
+```python
+if user is not None and not user.get('admin') and not force:
+    has_self_admin = any(
+        entry['id'] == user['_id'] and entry['level'] == AccessType.ADMIN
+        for entry in acList['users']
+    )
+    has_self_via_group = any(
+        # any group that includes the user at ADMIN level
+        ...  # group membership lookup
+        for group in acList['groups']
+    )
+    if not (has_self_admin or has_self_via_group):
+        raise ValidationException(
+            'You cannot remove your own ADMIN access from this resource.'
+            ' Have another ADMIN user remove your access instead.',
+            field='access',
+        )
+```
+
+This:
+
+- Leaves site admins unrestricted (recovery path).
+- Leaves the explicit `force=True` code path unrestricted (internal Girder code that intentionally bypasses access checks).
+- Allows ownership transfer via the standard pattern: add new owner as ADMIN, have them remove the old owner.
+- The group-membership check is the tricky part — if you don't want to walk groups, a strict "user must appear at ADMIN in `acList['users']`" rule is also defensible and simpler.
+
+**Softer alternative**
+
+If a strict rule is considered too breaking, a minimal fix that catches the worst footgun is to reject `acList['users'] == [] and acList['groups'] == []` outright (empty ACL ⇒ only site admins can access). This is rarely intentional and never recoverable by the owner.
+
+**Real-world impact**
+
+We're a downstream project (NimbusImage / `upenncontrast_annotation`) where folders represent scientific imaging datasets. A user lost ADMIN access to a dataset with ~50k annotations because a script set `access={users: [], groups: []}` while testing. The user had to ask a site admin to restore access. We've added a plugin-level guard for our `contrastDataset` folders, but the underlying issue affects every Girder deployment that exposes the access endpoint to non-site-admin users.
+
+**Workaround for downstream**
+
+```python
+from girder import events
+from girder.api import rest
+from girder.constants import AccessType
+from girder.exceptions import ValidationException
+
+def _ensure_creator_admin(event):
+    doc = event.info
+    if not isinstance(doc, dict) or '_id' not in doc:
+        return
+    # ... filter to your resource type ...
+    creator_id = doc.get('creatorId')
+    if creator_id is None:
+        return
+    access = doc.get('access') or {}
+    if not any(
+        e.get('id') == creator_id and e.get('level') == AccessType.ADMIN
+        for e in access.get('users', [])
+    ):
+        current = rest.getCurrentUser()
+        if current is None or current.get('admin'):
+            return
+        raise ValidationException(
+            'Creator must retain ADMIN access',
+            field='access',
+        )
+
+events.bind('model.folder.save', 'my-plugin.creator-admin', _ensure_creator_admin)
+```

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/__init__.py
@@ -31,6 +31,7 @@ from .server.models.datasetView import DatasetView as DatasetViewModel
 from .server.models.history import History as HistoryModel
 from .server.models.documentChange import DocumentChange as DocumentChangeModel
 from .server.models.project import Project as ProjectModel
+from .server.helpers import folder_access_guard
 
 
 # Taken from HistomicsUI
@@ -175,3 +176,8 @@ class UPennContrastAnnotationAPIPlugin(GirderPlugin):
         info["apiRoot"].zenodo = Zenodo()
         info["apiRoot"].zenodo_credentials = ZenodoCredentials()
         system.addSystemEndpoints(info["apiRoot"])
+
+        # Prevent owners from removing their own ADMIN access on
+        # `contrastDataset` folders (would orphan the dataset). See
+        # `server/helpers/folder_access_guard.py`.
+        folder_access_guard.register()

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/folder_access_guard.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/folder_access_guard.py
@@ -1,0 +1,90 @@
+"""Preserve owner access on dataset folders.
+
+Girder's core `Folder.setAccessList` (and the `PUT /folder/{id}/access`
+endpoint that calls it) accept any access list, including one that
+removes the caller. A non-admin folder owner can therefore lock
+themselves out of their own dataset — see
+`codebaseDocumentation/BUG_OWNER_CAN_REMOVE_SELF_FROM_DATASET.md`.
+
+This module installs a `model.folder.save` listener that rejects any
+save of a `contrastDataset` folder whose `access.users` does not include
+the creator at ADMIN level. Site admins can bypass the check (recovery
+path); ownership transfer is supported by updating `creatorId` in the
+same save.
+"""
+from bson import ObjectId
+
+from girder import events
+from girder.api import rest
+from girder.constants import AccessType
+from girder.exceptions import ValidationException
+
+
+CONTRAST_DATASET_SUBTYPE = "contrastDataset"
+EVENT_LISTENER_NAME = "upenn.folder.preserve_creator_admin"
+
+
+def _is_contrast_dataset(doc):
+    meta = doc.get("meta") or {}
+    return meta.get("subtype") == CONTRAST_DATASET_SUBTYPE
+
+
+def _creator_has_admin(doc):
+    creator_id = doc.get("creatorId")
+    if creator_id is None:
+        # No creator recorded — nothing to protect.
+        return True
+    creator_id = ObjectId(creator_id)
+    access = doc.get("access") or {}
+    for entry in access.get("users", []) or []:
+        if (
+            ObjectId(entry.get("id")) == creator_id
+            and entry.get("level") == AccessType.ADMIN
+        ):
+            return True
+    return False
+
+
+def _ensure_creator_admin_access(event):
+    """model.folder.save listener that enforces creator-stays-ADMIN."""
+    doc = event.info
+    if not isinstance(doc, dict):
+        return
+    if "_id" not in doc:
+        # New folder; Girder grants the creator ADMIN before the first
+        # save when `Folder.createFolder` is used. Skip — we don't want
+        # to fight folder creation paths that haven't applied access
+        # yet.
+        return
+    if not _is_contrast_dataset(doc):
+        return
+    if _creator_has_admin(doc):
+        return
+
+    # Site admins can override — recovery path. `rest.getCurrentUser`
+    # returns None outside of a REST context (workers, scripts), in
+    # which case we let the save through so internal Girder code is not
+    # blocked.
+    try:
+        current = rest.getCurrentUser()
+    except Exception:
+        current = None
+    if current is None or current.get("admin"):
+        return
+
+    raise ValidationException(
+        "Dataset creator must retain ADMIN access on the folder. "
+        "If you want to transfer ownership, add the new owner first "
+        "and then have them remove your access.",
+        field="access",
+    )
+
+
+def register():
+    """Idempotently install the folder-access guard event listener."""
+    events.unbind("model.folder.save", EVENT_LISTENER_NAME)
+    events.bind(
+        "model.folder.save",
+        EVENT_LISTENER_NAME,
+        _ensure_creator_admin_access,
+    )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_folder_access_guard.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_folder_access_guard.py
@@ -1,0 +1,151 @@
+"""Tests for the folder-access guard.
+
+The guard (see `server/helpers/folder_access_guard.py`) prevents
+non-admin folder owners from removing themselves from the access list
+of a `contrastDataset` folder. Site admins can override (recovery
+path); non-contrastDataset folders are unaffected.
+"""
+import json
+
+import pytest
+
+from pytest_girder.assertions import assertStatus, assertStatusOk
+
+from girder.constants import AccessType
+from girder.exceptions import ValidationException
+from girder.models.folder import Folder
+
+from . import girder_utilities as utilities
+from . import upenn_testing_utilities as upenn_utilities
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestFolderAccessGuard:
+    def testOwnerCannotEmptyAccessViaRestEndpoint(self, user, server):
+        """PUT /folder/{id}/access with empty users list is rejected."""
+        dataset = utilities.createFolder(
+            user, "guarded-empty", upenn_utilities.datasetMetadata
+        )
+
+        resp = server.request(
+            path=f"/folder/{dataset['_id']}/access",
+            method="PUT",
+            user=user,
+            params={"access": json.dumps({"users": [], "groups": []})},
+        )
+        assertStatus(resp, 400)
+        assert "creator" in resp.json["message"].lower()
+
+        # And the folder retains the creator's ADMIN access.
+        reloaded = Folder().load(dataset["_id"], force=True)
+        admin_entries = [
+            u for u in reloaded["access"]["users"]
+            if u["id"] == user["_id"]
+            and u["level"] == AccessType.ADMIN
+        ]
+        assert len(admin_entries) == 1
+
+    def testOwnerCannotDemoteSelfBelowAdmin(self, user, server):
+        """Owner can't downgrade their own access to READ either."""
+        dataset = utilities.createFolder(
+            user, "guarded-demote", upenn_utilities.datasetMetadata
+        )
+
+        bad_acl = {
+            "users": [{"id": str(user["_id"]), "level": AccessType.READ}],
+            "groups": [],
+        }
+        resp = server.request(
+            path=f"/folder/{dataset['_id']}/access",
+            method="PUT",
+            user=user,
+            params={"access": json.dumps(bad_acl)},
+        )
+        assertStatus(resp, 400)
+
+    def testOwnerCanShareWithOthers(self, user, admin, server):
+        """Adding a second user while keeping owner-as-ADMIN succeeds."""
+        dataset = utilities.createFolder(
+            user, "guarded-share-ok", upenn_utilities.datasetMetadata
+        )
+
+        good_acl = {
+            "users": [
+                {"id": str(user["_id"]), "level": AccessType.ADMIN},
+                {"id": str(admin["_id"]), "level": AccessType.READ},
+            ],
+            "groups": [],
+        }
+        resp = server.request(
+            path=f"/folder/{dataset['_id']}/access",
+            method="PUT",
+            user=user,
+            params={"access": json.dumps(good_acl)},
+        )
+        assertStatusOk(resp)
+
+    def testSiteAdminCanOverride(self, user, admin, server):
+        """Site admin can save a folder without the creator (recovery)."""
+        dataset = utilities.createFolder(
+            user, "guarded-admin-override",
+            upenn_utilities.datasetMetadata,
+        )
+
+        # Admin sets ACL with only themselves — bypasses the guard.
+        admin_only = {
+            "users": [{"id": str(admin["_id"]), "level": AccessType.ADMIN}],
+            "groups": [],
+        }
+        resp = server.request(
+            path=f"/folder/{dataset['_id']}/access",
+            method="PUT",
+            user=admin,
+            params={"access": json.dumps(admin_only)},
+        )
+        assertStatusOk(resp)
+
+    def testNonContrastFolderUnaffected(self, user, server):
+        """Plain Girder folders (no contrastDataset subtype) are not
+        guarded — the upstream Girder behavior is preserved."""
+        from girder.models.folder import Folder
+        # Create a folder WITHOUT contrastDataset metadata.
+        public = utilities.namedFolder(user)
+        plain = Folder().createFolder(
+            name="plain-folder", creator=user, parent=public
+        )
+
+        resp = server.request(
+            path=f"/folder/{plain['_id']}/access",
+            method="PUT",
+            user=user,
+            params={"access": json.dumps({"users": [], "groups": []})},
+        )
+        # Upstream Girder accepts this. The guard must not intercept
+        # non-contrastDataset folders.
+        assertStatusOk(resp)
+
+    def testModelLayerAlsoGuarded(self, user, admin):
+        """Direct setAccessList on a contrastDataset folder is also
+        rejected — the guard catches non-REST code paths too."""
+        from girder.api import rest
+        dataset = utilities.createFolder(
+            user, "guarded-model-layer",
+            upenn_utilities.datasetMetadata,
+        )
+
+        # Simulate a non-admin user attempting a setAccessList that
+        # excludes themselves. We have to set up a fake current user
+        # because the guard checks `rest.getCurrentUser()`.
+        original_get = rest.getCurrentUser
+        rest.getCurrentUser = lambda *a, **kw: user
+        try:
+            with pytest.raises(ValidationException):
+                Folder().setAccessList(
+                    dataset,
+                    {"users": [], "groups": []},
+                    save=True,
+                    user=user,
+                )
+        finally:
+            rest.getCurrentUser = original_get

--- a/nimbusimage/nimbusimage/sharing.py
+++ b/nimbusimage/nimbusimage/sharing.py
@@ -1,4 +1,22 @@
-"""SharingAccessor — dataset access control."""
+"""SharingAccessor — dataset access control.
+
+All access changes go through the `dataset_view/share` endpoint, which is
+**incremental** (modifies one user's access at a time). This is the only
+safe way to change a dataset's ACL from Python.
+
+DO NOT bypass this accessor by calling the raw Girder endpoint:
+
+    # WRONG — replaces the entire ACL and can lock the owner out
+    client._gc.put(f"folder/{ds.id}/access", parameters={"access": ...})
+
+The raw `PUT /folder/{id}/access` replaces the access list with whatever
+you send. If the new list omits the dataset creator, the owner is
+silently locked out (``_accessLevel`` becomes ``-1`` and only a site
+admin can recover). The backend now rejects such saves on
+``contrastDataset`` folders, but the right answer is to never reach for
+the raw endpoint in the first place. See
+``plugins/nimbusimage/references/gotchas.md``.
+"""
 
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/plugins/nimbusimage/commands/analyze.md
+++ b/plugins/nimbusimage/commands/analyze.md
@@ -165,6 +165,8 @@ access = ds.sharing.get_access()
 
 Access levels: `read`, `write`, `admin`, `remove`.
 
+> **⚠️ Never call the raw Girder access endpoint.** `ds.sharing` is the **only** safe way to change access. Specifically: **do not** call `client._gc.put(f"folder/{id}/access", ...)`. The raw endpoint replaces the entire ACL, and if the new list omits the dataset creator, the owner is silently locked out (`_accessLevel` becomes `-1`, only a site admin can recover). `ds.sharing.share()` is incremental — it can't make that mistake. If you find yourself wanting to bulk-replace an ACL, stop and ask the user; the accessor methods cover every legitimate sharing operation. See also `references/gotchas.md`.
+
 ## History
 
 Undo/redo support for annotation operations:

--- a/plugins/nimbusimage/commands/nimbusimage.md
+++ b/plugins/nimbusimage/commands/nimbusimage.md
@@ -189,3 +189,10 @@ For deeper operations, route to the appropriate skill:
 - **`/nimbus-skills:analyze`** — properties, export, connections, sharing
 
 For the full API reference for any accessor, read the corresponding reference file in the `references/` directory.
+
+## Safety: stay on the accessor layer
+
+The accessors (`ds.images`, `ds.annotations`, `ds.sharing`, etc.) are the supported surface. `client._gc` is the raw `girder-client` and exposes every Girder endpoint, including ones that can do irreversible damage if used wrong. Specifically:
+
+- **Never** call `client._gc.put(f"folder/{ds.id}/access", ...)` to change a dataset's ACL. Use `ds.sharing.share()` / `ds.sharing.set_public()` — they call the incremental `dataset_view/share` endpoint and can't accidentally lock the owner out. The raw endpoint replaces the whole ACL and has been the source of an in-the-wild lockout. See `references/gotchas.md` for the full list of `_gc` footguns.
+- If an accessor doesn't expose what you need, ask the user before reaching for `_gc`. The accessor surface is curated for a reason; adding to it is preferable to bypassing it.

--- a/plugins/nimbusimage/references/gotchas.md
+++ b/plugins/nimbusimage/references/gotchas.md
@@ -72,3 +72,45 @@ After creating a property definition with `ds.properties.create()`, you must cal
 ## Collections = Configurations
 
 In the codebase and API, "collections" and "configurations" refer to the same concept. The backend endpoint is `/upenn_collection`. The Python API uses `ds.collections`.
+
+## NEVER call raw `PUT /folder/{id}/access` — use `ds.sharing`
+
+The raw Girder access endpoint replaces the entire ACL with whatever you send. If you send a list that doesn't include the dataset creator, you lock the owner out of their own dataset (the folder's `_accessLevel` drops to `-1` and only a site admin can recover it):
+
+```python
+# WRONG — silently locks the owner out
+client._gc.put(
+    f"folder/{ds.id}/access",
+    parameters={"access": json.dumps({"users": [], "groups": []})},
+)
+
+# WRONG — same problem, the list omits the owner
+client._gc.put(
+    f"folder/{ds.id}/access",
+    parameters={"access": json.dumps({
+        "users": [{"id": colleague_id, "level": 0}],
+        "groups": [],
+    })},
+)
+```
+
+`ds.sharing` calls `dataset_view/share`, which is **incremental** — it modifies one user's access at a time and can never remove the caller by accident. Use it:
+
+```python
+# RIGHT
+ds.sharing.share("colleague@example.com", access="read")
+ds.sharing.share("former_member@example.com", access="remove")
+ds.sharing.set_public(True)
+```
+
+The backend now enforces this invariant (a `model.folder.save` listener rejects `contrastDataset` saves that omit the creator at ADMIN). **Don't go around `ds.sharing`.** If you think you need to, ask the user — there's almost always a safer path.
+
+## Generally: avoid dropping to `client._gc` (raw girder-client)
+
+The `client._gc` attribute is the underlying `girder_client.GirderClient` and lets you call any Girder endpoint. Anything on it bypasses NimbusImage's accessor layer, which exists partly to keep you out of trouble:
+
+- `ds.sharing.*` instead of `gc.put("folder/.../access")`
+- `ds.annotations.*` instead of `gc.post("upenn_annotation/...")`
+- `ds.properties.*` instead of `gc.get("annotation_property...")`
+
+If an accessor doesn't cover what you need, treat that as a signal to ask the user before reaching for `_gc`, not as license to wing it. The accessors are the supported surface; `_gc` is an escape hatch with sharp edges.


### PR DESCRIPTION
## Summary

- Adds a `model.folder.save` listener (`server/helpers/folder_access_guard.py`) that rejects saves of `contrastDataset` folders whose access list does not include the creator at ADMIN level. Site admins can override (recovery path); non-`contrastDataset` folders are unaffected so we don't change behavior for Girder's stock folders.
- Closes the gap behind a footgun in core Girder: `AccessControlledModel.setAccessList` accepts any well-shaped ACL, including one that excludes the caller. A non-admin owner could call `PUT /folder/{id}/access` with `{users:[], groups:[]}` and lock themselves out of their own dataset — notes in `codebaseDocumentation/BUG_OWNER_CAN_REMOVE_SELF_FROM_DATASET.md`.
- Includes an upstream-issue draft (`codebaseDocumentation/UPSTREAM_GIRDER_ISSUE.md`) to file at `girder/girder`.
- Also captures expected-but-confusing non-admin API behavior (job/user endpoint token-scope quirks) in `codebaseDocumentation/NON_ADMIN_API_BEHAVIOR.md`.

`codebaseDocumentation/SHARING.md` is updated to point at the new guard.

## Test plan

- [x] `tox` (full suite: 184 passed, 5:20)
- [x] `tox -- upenncontrast_annotation/test/test_folder_access_guard.py -v` (6 new tests, all pass)
- [x] flake8 clean on the new files
- [ ] Recovery path verified by site admin restoring access to a folder broken in the wild

New tests cover:
- Owner cannot empty access via REST endpoint
- Owner cannot demote self below ADMIN
- Owner can share with others while keeping self at ADMIN (positive case)
- Site admin can override (recovery path)
- Non-contrastDataset folders are unaffected
- Model-layer setAccessList is also guarded (catches non-REST code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)