### PR TITLE
Add NimbusImage API skill guards against raw folder/access PUT

### DIFF
--- a/nimbusimage/nimbusimage/sharing.py
+++ b/nimbusimage/nimbusimage/sharing.py
@@ -1,4 +1,22 @@
-"""SharingAccessor — dataset access control."""
+"""SharingAccessor — dataset access control.
+
+All access changes go through the `dataset_view/share` endpoint, which is
+**incremental** (modifies one user's access at a time). This is the only
+safe way to change a dataset's ACL from Python.
+
+DO NOT bypass this accessor by calling the raw Girder endpoint:
+
+    # WRONG — replaces the entire ACL and can lock the owner out
+    client._gc.put(f"folder/{ds.id}/access", parameters={"access": ...})
+
+The raw `PUT /folder/{id}/access` replaces the access list with whatever
+you send. If the new list omits the dataset creator, the owner is
+silently locked out (``_accessLevel`` becomes ``-1`` and only a site
+admin can recover). The backend now rejects such saves on
+``contrastDataset`` folders, but the right answer is to never reach for
+the raw endpoint in the first place. See
+``plugins/nimbusimage/references/gotchas.md``.
+"""
 
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/plugins/nimbusimage/commands/analyze.md
+++ b/plugins/nimbusimage/commands/analyze.md
@@ -165,6 +165,8 @@ access = ds.sharing.get_access()
 
 Access levels: `read`, `write`, `admin`, `remove`.
 
+> **⚠️ Never call the raw Girder access endpoint.** `ds.sharing` is the **only** safe way to change access. Specifically: **do not** call `client._gc.put(f"folder/{id}/access", ...)`. The raw endpoint replaces the entire ACL, and if the new list omits the dataset creator, the owner is silently locked out (`_accessLevel` becomes `-1`, only a site admin can recover). `ds.sharing.share()` is incremental — it can't make that mistake. If you find yourself wanting to bulk-replace an ACL, stop and ask the user; the accessor methods cover every legitimate sharing operation. See also `references/gotchas.md`.
+
 ## History
 
 Undo/redo support for annotation operations:

--- a/plugins/nimbusimage/commands/nimbusimage.md
+++ b/plugins/nimbusimage/commands/nimbusimage.md
@@ -189,3 +189,10 @@ For deeper operations, route to the appropriate skill:
 - **`/nimbus-skills:analyze`** — properties, export, connections, sharing
 
 For the full API reference for any accessor, read the corresponding reference file in the `references/` directory.
+
+## Safety: stay on the accessor layer
+
+The accessors (`ds.images`, `ds.annotations`, `ds.sharing`, etc.) are the supported surface. `client._gc` is the raw `girder-client` and exposes every Girder endpoint, including ones that can do irreversible damage if used wrong. Specifically:
+
+- **Never** call `client._gc.put(f"folder/{ds.id}/access", ...)` to change a dataset's ACL. Use `ds.sharing.share()` / `ds.sharing.set_public()` — they call the incremental `dataset_view/share` endpoint and can't accidentally lock the owner out. The raw endpoint replaces the whole ACL and has been the source of an in-the-wild lockout. See `references/gotchas.md` for the full list of `_gc` footguns.
+- If an accessor doesn't expose what you need, ask the user before reaching for `_gc`. The accessor surface is curated for a reason; adding to it is preferable to bypassing it.

--- a/plugins/nimbusimage/references/gotchas.md
+++ b/plugins/nimbusimage/references/gotchas.md
@@ -72,3 +72,45 @@ After creating a property definition with `ds.properties.create()`, you must cal
 ## Collections = Configurations
 
 In the codebase and API, "collections" and "configurations" refer to the same concept. The backend endpoint is `/upenn_collection`. The Python API uses `ds.collections`.
+
+## NEVER call raw `PUT /folder/{id}/access` — use `ds.sharing`
+
+The raw Girder access endpoint replaces the entire ACL with whatever you send. If you send a list that doesn't include the dataset creator, you lock the owner out of their own dataset (the folder's `_accessLevel` drops to `-1` and only a site admin can recover it):
+
+```python
+# WRONG — silently locks the owner out
+client._gc.put(
+    f"folder/{ds.id}/access",
+    parameters={"access": json.dumps({"users": [], "groups": []})},
+)
+
+# WRONG — same problem, the list omits the owner
+client._gc.put(
+    f"folder/{ds.id}/access",
+    parameters={"access": json.dumps({
+        "users": [{"id": colleague_id, "level": 0}],
+        "groups": [],
+    })},
+)
+```
+
+`ds.sharing` calls `dataset_view/share`, which is **incremental** — it modifies one user's access at a time and can never remove the caller by accident. Use it:
+
+```python
+# RIGHT
+ds.sharing.share("colleague@example.com", access="read")
+ds.sharing.share("former_member@example.com", access="remove")
+ds.sharing.set_public(True)
+```
+
+The backend now enforces this invariant (a `model.folder.save` listener rejects `contrastDataset` saves that omit the creator at ADMIN). **Don't go around `ds.sharing`.** If you think you need to, ask the user — there's almost always a safer path.
+
+## Generally: avoid dropping to `client._gc` (raw girder-client)
+
+The `client._gc` attribute is the underlying `girder_client.GirderClient` and lets you call any Girder endpoint. Anything on it bypasses NimbusImage's accessor layer, which exists partly to keep you out of trouble:
+
+- `ds.sharing.*` instead of `gc.put("folder/.../access")`
+- `ds.annotations.*` instead of `gc.post("upenn_annotation/...")`
+- `ds.properties.*` instead of `gc.get("annotation_property...")`
+
+If an accessor doesn't cover what you need, treat that as a signal to ask the user before reaching for `_gc`, not as license to wing it. The accessors are the supported surface; `_gc` is an escape hatch with sharp edges.


### PR DESCRIPTION
## Summary

Documentation-only PR. Adds guards in the NimbusImage Python API skill and source so future sessions don't reach for `client._gc.put("folder/{id}/access", ...)` and lock dataset owners out.

The same commit was already included in #1165 (the parent fix). This is a docs-only spin-off so the skill changes can land independently of the backend guard if reviewers want them on a different cadence.

Touches:
- `plugins/nimbusimage/references/gotchas.md` — new "NEVER call raw `PUT /folder/{id}/access`" entry with wrong/right code, plus a broader "avoid dropping to `client._gc`" rule
- `plugins/nimbusimage/commands/analyze.md` — ⚠️ warning callout under the `## Sharing` section
- `plugins/nimbusimage/commands/nimbusimage.md` — new "Safety: stay on the accessor layer" section at end of the entry-point skill
- `nimbusimage/nimbusimage/sharing.py` — module-level docstring with the same warning, visible to anyone reading the source rather than the skill

## Test plan

- [x] Verified file changes apply cleanly off master (no merge conflicts expected with #1165 since that PR also has the same commit)
- [ ] Reviewer eyeballs the tone/links — these are advisory docs, no runtime behavior

## Background

In a recent session, an automated test of the NimbusImage REST API as a non-admin user accidentally called the raw Girder access endpoint with an empty user list, locking the owner out of their own dataset folder (`HCR_ANNOTATION`, ~50k annotations). #1165 adds a backend guard against that exact failure mode; this PR adds the corresponding warnings in the skill/docs so the mistake is unlikely to be repeated even on a system that hasn't picked up the backend change yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)