### PR TITLE
Document common nimbusimage install snags in the skill

### DIFF
--- a/plugins/nimbusimage/commands/nimbusimage.md
+++ b/plugins/nimbusimage/commands/nimbusimage.md
@@ -30,6 +30,28 @@ For Docker worker development (includes `large_image` for writing TIFF files):
 pip install nimbusimage[worker]
 ```
 
+### Install troubleshooting
+
+Two snags come up often enough that they belong here:
+
+- **`error: externally-managed-environment` (PEP 668).** Homebrew Python on macOS and most distro Pythons on Linux refuse `pip install` into the system interpreter. Use a venv:
+
+  ```bash
+  python3 -m venv ~/venvs/ni
+  source ~/venvs/ni/bin/activate
+  pip install nimbusimage
+  ```
+
+- **Phantom namespace package in the NimbusImage source repo.** The repo at `arjunrajlaboratory/NimbusImage` contains a top-level `nimbusimage/` directory (the source of the package). If you run Python from the repo root, PEP 420 namespace-package resolution will let `import nimbusimage` "succeed" with an empty module **even when nothing is installed**, so the usual `python -c "import nimbusimage"` smoke test is misleading. Verify with `__file__`:
+
+  ```python
+  import nimbusimage
+  assert nimbusimage.__file__, "nimbusimage is shadowed by a local directory"
+  print(nimbusimage.__file__)  # should point inside a site-packages dir
+  ```
+
+  If `__file__` is `None`, either `pip install nimbusimage` into a venv, or `cd` out of the NimbusImage repo before running your script.
+
 ## Connecting
 
 **Before writing any connection code, check whether the user already has credentials configured.** Follow this sequence:


### PR DESCRIPTION
## Summary
- Adds an **Install troubleshooting** subsection to `plugins/nimbusimage/commands/nimbusimage.md` covering the two install snags that came up in a real session:
  - PEP 668 (`error: externally-managed-environment`) — points users at a one-line venv recipe.
  - PEP 420 namespace-package shadow when running Python from the NimbusImage source repo, which lets `import nimbusimage` "succeed" with an empty module even when nothing is installed. Shows the `nimbusimage.__file__` check to detect it.

Pure docs change; no code or behavior touched. The package is on PyPI (`pip install nimbusimage`) — these notes just save someone the ~10-minute detour I took.

## Test plan
- [ ] Re-read the skill end-to-end to confirm the new subsection flows
- [ ] Sanity-check the venv command on a fresh shell
- [ ] Confirm the `nimbusimage.__file__` shadow test works (run from repo root without install → `__file__` is `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)