### PR TITLE
Polish Zenodo upload UI: token setup, CTAs, visible progress

### DIFF
--- a/src/components/ZenodoPublish.vue
+++ b/src/components/ZenodoPublish.vue
@@ -32,10 +32,12 @@
         <v-spacer />
         <v-btn
           v-if="hasToken"
-          variant="text"
+          variant="outlined"
+          color="primary"
           size="small"
           @click="tokenDialog = true"
         >
+          <v-icon start>mdi-key</v-icon>
           Change Token
         </v-btn>
         <v-btn
@@ -53,18 +55,24 @@
       <!-- Upload progress -->
       <!-- TODO(#1075): wire into the app-wide progress store so the bar
            remains visible after navigating away from this page. -->
-      <div v-if="zenodoStatus === 'uploading'" class="mb-3">
+      <div
+        v-if="zenodoStatus === 'uploading' || localProgress || uploading"
+        class="mb-3"
+      >
         <div class="text-body-2 mb-1">
           {{ localProgress?.message || "Upload in progress…" }}
         </div>
         <v-progress-linear
-          :indeterminate="!localProgress"
+          :indeterminate="!localProgress || localProgress.total === 0"
           :model-value="progressPercent"
           color="primary"
           height="8"
           rounded
         />
-        <div v-if="localProgress" class="text-caption text-grey mt-1">
+        <div
+          v-if="localProgress && localProgress.total > 0"
+          class="text-caption text-grey mt-1"
+        >
           {{ localProgress.current }} / {{ localProgress.total }} files
         </div>
         <div class="text-caption text-grey mt-1">
@@ -102,7 +110,8 @@
       <!-- View on Zenodo -->
       <v-btn
         v-if="depositionUrl"
-        variant="text"
+        variant="outlined"
+        color="primary"
         size="small"
         :href="depositionUrl"
         target="_blank"
@@ -111,17 +120,16 @@
         View on Zenodo
       </v-btn>
 
-      <v-spacer />
-
       <!-- Discard draft -->
       <v-btn
         v-if="zenodoStatus === 'draft' || zenodoStatus === 'error'"
-        variant="text"
-        color="warning"
+        variant="outlined"
+        color="error"
         size="small"
         :loading="discarding"
         @click="discardDraft"
       >
+        <v-icon start>mdi-delete</v-icon>
         Discard Draft
       </v-btn>
 
@@ -348,18 +356,26 @@ function trackJob(jobId: string) {
 
 async function startUpload() {
   uploading.value = true;
+  // Render the progress section immediately (indeterminate) so the user
+  // sees something while the request to kick off the job is in flight,
+  // before zenodoStatus refreshes to "uploading".
+  localProgress.value = {
+    current: 0,
+    total: 0,
+    message: "Starting upload…",
+  };
   try {
     const response = await store.zenodoAPI.uploadProject(props.project.id);
-    // Initialize local progress
     localProgress.value = {
       current: 0,
       total: response.totalFiles,
-      message: "Starting upload...",
+      message: "Starting upload…",
     };
     // Track job via SSE
     trackJob(response.jobId);
     emit("updated");
   } catch (error: any) {
+    localProgress.value = null;
     logError("Failed to start Zenodo upload", error);
   } finally {
     uploading.value = false;

--- a/src/components/ZenodoPublish.vue
+++ b/src/components/ZenodoPublish.vue
@@ -55,10 +55,7 @@
       <!-- Upload progress -->
       <!-- TODO(#1075): wire into the app-wide progress store so the bar
            remains visible after navigating away from this page. -->
-      <div
-        v-if="zenodoStatus === 'uploading' || localProgress || uploading"
-        class="mb-3"
-      >
+      <div v-if="zenodoStatus === 'uploading' || localProgress" class="mb-3">
         <div class="text-body-2 mb-1">
           {{ localProgress?.message || "Upload in progress…" }}
         </div>
@@ -147,8 +144,10 @@
       </v-btn>
 
       <!-- Upload to Zenodo -->
+      <!-- Hidden once an upload is in flight; the progress section above
+           is the single source of truth for "work is happening". -->
       <v-tooltip
-        v-if="canUpload"
+        v-if="canUpload && !localProgress"
         location="top"
         :disabled="hasToken"
         text="Configure a Zenodo token to enable upload"
@@ -160,7 +159,6 @@
               variant="flat"
               color="primary"
               size="small"
-              :loading="uploading"
               :disabled="!hasToken"
               @click="startUpload"
             >
@@ -236,7 +234,6 @@ const tokenDialog = ref(false);
 const confirmPublish = ref(false);
 const hasToken = ref(false);
 const isSandbox = ref(false);
-const uploading = ref(false);
 const publishing = ref(false);
 const discarding = ref(false);
 
@@ -355,10 +352,11 @@ function trackJob(jobId: string) {
 }
 
 async function startUpload() {
-  uploading.value = true;
   // Render the progress section immediately (indeterminate) so the user
   // sees something while the request to kick off the job is in flight,
-  // before zenodoStatus refreshes to "uploading".
+  // before zenodoStatus refreshes to "uploading". This also hides the
+  // upload button (it is gated on !localProgress), so we don't need a
+  // separate "uploading" flag.
   localProgress.value = {
     current: 0,
     total: 0,
@@ -374,11 +372,9 @@ async function startUpload() {
     // Track job via SSE
     trackJob(response.jobId);
     emit("updated");
-  } catch (error: any) {
+  } catch (error) {
     localProgress.value = null;
     logError("Failed to start Zenodo upload", error);
-  } finally {
-    uploading.value = false;
   }
 }
 
@@ -408,26 +404,15 @@ async function discardDraft() {
 }
 
 async function recoverActiveJob() {
-  // If we load the page while an upload is in progress,
-  // try to find the active job and re-subscribe to it.
-  // We fetch recent zenodo_upload jobs and filter to the
-  // one matching this project (by kwargs.projectId).
+  // If we load the page while an upload is in progress, find the
+  // active job and re-subscribe to its SSE stream.
   try {
-    const response = await store.girderRest.get("job", {
-      params: {
-        types: JSON.stringify(["zenodo_upload"]),
-        statuses: JSON.stringify([1, 2]), // queued, running
-        limit: 5,
-        sort: "created",
-        sortdir: -1,
-      },
-    });
-    const matchingJob = response.data.find(
-      (j: any) => j.kwargs?.projectId === props.project.id,
+    const activeJob = await store.zenodoAPI.findActiveUploadJob(
+      props.project.id,
     );
-    if (matchingJob) {
-      trackJob(matchingJob._id);
-      // Initialize progress from project meta
+    if (activeJob) {
+      trackJob(activeJob._id);
+      // Seed progress from project meta until the next SSE event arrives.
       const progress = zenodoMeta.value?.progress;
       if (progress) {
         localProgress.value = {

--- a/src/components/ZenodoPublish.vue
+++ b/src/components/ZenodoPublish.vue
@@ -16,40 +16,60 @@
       <!-- Token status -->
       <div class="d-flex align-center mb-3">
         <v-icon
-          :color="hasToken ? 'success' : 'grey'"
+          :color="hasToken ? 'success' : 'warning'"
           size="small"
           class="mr-2"
         >
-          {{ hasToken ? "mdi-check-circle" : "mdi-alert-circle-outline" }}
+          {{ hasToken ? "mdi-check-circle" : "mdi-alert-circle" }}
         </v-icon>
         <span class="text-body-2">
           {{
             hasToken
               ? `Zenodo token configured${isSandbox ? " (sandbox)" : ""}`
-              : "No Zenodo token configured"
+              : "No Zenodo token configured — required to upload"
           }}
         </span>
+        <v-spacer />
         <v-btn
+          v-if="hasToken"
           variant="text"
           size="small"
-          class="ml-2"
           @click="tokenDialog = true"
         >
-          {{ hasToken ? "Change" : "Configure" }}
+          Change Token
+        </v-btn>
+        <v-btn
+          v-else
+          variant="flat"
+          color="primary"
+          size="small"
+          @click="tokenDialog = true"
+        >
+          <v-icon start>mdi-key-plus</v-icon>
+          Configure Zenodo Token
         </v-btn>
       </div>
 
       <!-- Upload progress -->
-      <div v-if="zenodoStatus === 'uploading' && localProgress" class="mb-3">
-        <div class="text-body-2 mb-1">{{ localProgress.message }}</div>
+      <!-- TODO(#1075): wire into the app-wide progress store so the bar
+           remains visible after navigating away from this page. -->
+      <div v-if="zenodoStatus === 'uploading'" class="mb-3">
+        <div class="text-body-2 mb-1">
+          {{ localProgress?.message || "Upload in progress…" }}
+        </div>
         <v-progress-linear
+          :indeterminate="!localProgress"
           :model-value="progressPercent"
           color="primary"
           height="8"
           rounded
         />
-        <div class="text-caption text-grey mt-1">
+        <div v-if="localProgress" class="text-caption text-grey mt-1">
           {{ localProgress.current }} / {{ localProgress.total }} files
+        </div>
+        <div class="text-caption text-grey mt-1">
+          Uploads can take several minutes for large projects. You can keep
+          using NimbusImage in another tab while this runs.
         </div>
       </div>
 
@@ -119,22 +139,33 @@
       </v-btn>
 
       <!-- Upload to Zenodo -->
-      <v-btn
+      <v-tooltip
         v-if="canUpload"
-        variant="flat"
-        color="primary"
-        size="small"
-        :loading="uploading"
-        :disabled="!hasToken"
-        @click="startUpload"
+        location="top"
+        :disabled="hasToken"
+        text="Configure a Zenodo token to enable upload"
       >
-        <v-icon start>mdi-cloud-upload</v-icon>
-        {{
-          zenodoStatus === "published"
-            ? "Upload New Version"
-            : "Upload to Zenodo"
-        }}
-      </v-btn>
+        <template #activator="{ props: tooltipProps }">
+          <!-- span wrapper lets the tooltip activate over a disabled button -->
+          <span v-bind="tooltipProps">
+            <v-btn
+              variant="flat"
+              color="primary"
+              size="small"
+              :loading="uploading"
+              :disabled="!hasToken"
+              @click="startUpload"
+            >
+              <v-icon start>mdi-cloud-upload</v-icon>
+              {{
+                zenodoStatus === "published"
+                  ? "Upload New Version"
+                  : "Upload to Zenodo"
+              }}
+            </v-btn>
+          </span>
+        </template>
+      </v-tooltip>
     </v-card-actions>
 
     <!-- Token dialog -->

--- a/src/components/ZenodoTokenDialog.vue
+++ b/src/components/ZenodoTokenDialog.vue
@@ -7,14 +7,52 @@
     <v-card>
       <v-card-title>Zenodo API Token</v-card-title>
       <v-card-text>
-        <p class="text-body-2 mb-4">
-          Enter your Zenodo personal access token. You can create one at
-          <strong
-            >Zenodo &gt; Account Settings &gt; Applications &gt; New
-            Token</strong
-          >. Required scopes: <code>deposit:write</code> and
-          <code>deposit:actions</code>.
+        <p class="text-body-2 mb-2">
+          Paste a Zenodo personal access token. NimbusImage uses it to upload
+          this project on your behalf.
         </p>
+        <v-alert
+          type="info"
+          variant="tonal"
+          density="compact"
+          class="mb-4 zenodo-instructions"
+        >
+          <div class="text-body-2 mb-1">
+            <strong
+              >How to create a token on
+              <a :href="zenodoBaseUrl" target="_blank" rel="noopener">{{
+                zenodoHost
+              }}</a></strong
+            >
+          </div>
+          <ol class="zenodo-steps">
+            <li>
+              Click your username (top-right) →
+              <strong>Applications</strong>
+            </li>
+            <li>
+              Under <strong>Personal access tokens</strong>, click
+              <strong>+ New Token</strong>
+              (or
+              <a :href="tokensUrl" target="_blank" rel="noopener"
+                >open the token page directly</a
+              >)
+            </li>
+            <li>Give the token a name (e.g., <em>NimbusImage</em>)</li>
+            <li>
+              Check
+              <strong>all</strong>
+              of these scopes:
+              <code>deposit:actions</code>, <code>deposit:write</code>,
+              <code>user:email</code>
+            </li>
+            <li>
+              Click <strong>Create</strong>, then copy the token —
+              <strong>Zenodo only shows it once</strong>, so save a copy in your
+              password manager before pasting it below.
+            </li>
+          </ol>
+        </v-alert>
         <v-text-field
           v-model="token"
           label="API Token"
@@ -67,7 +105,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import store from "@/store";
 import { logError } from "@/utils/log";
 
@@ -86,6 +124,16 @@ const showToken = ref(false);
 const saving = ref(false);
 const deleting = ref(false);
 const hasExistingToken = ref(false);
+
+const zenodoBaseUrl = computed(() =>
+  sandbox.value ? "https://sandbox.zenodo.org" : "https://zenodo.org",
+);
+const zenodoHost = computed(() =>
+  sandbox.value ? "sandbox.zenodo.org" : "zenodo.org",
+);
+const tokensUrl = computed(
+  () => `${zenodoBaseUrl.value}/account/settings/applications/tokens/new/`,
+);
 
 async function checkExistingToken() {
   try {
@@ -145,3 +193,28 @@ onMounted(() => {
   }
 });
 </script>
+
+<style lang="scss" scoped>
+.zenodo-instructions {
+  .zenodo-steps {
+    margin: 0 0 0 1.25rem;
+    padding: 0;
+
+    li {
+      margin-bottom: 4px;
+      line-height: 1.4;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    code {
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 0.85em;
+      background: rgba(127, 127, 127, 0.15);
+    }
+  }
+}
+</style>

--- a/src/store/ZenodoAPI.ts
+++ b/src/store/ZenodoAPI.ts
@@ -1,6 +1,7 @@
 import { RestClientInstance, IGirderSelectAble } from "@/girder";
 import { logError } from "@/utils/log";
 import store from "@/store";
+import { jobStates } from "@/store/jobConstants";
 
 // --- Zenodo Publish/Credential types ---
 
@@ -36,6 +37,15 @@ export interface IZenodoPublishResponse {
   message: string;
   doi: string;
   url: string;
+}
+
+/**
+ * Minimal shape of a `zenodo_upload` Girder job, as returned by the
+ * /job listing endpoint. Only the fields the frontend reads are typed.
+ */
+export interface IZenodoUploadJob {
+  _id: string;
+  kwargs?: { projectId?: string };
 }
 
 /**
@@ -514,5 +524,29 @@ export default class ZenodoAPI {
   async discardDraft(projectId: string): Promise<{ message: string }> {
     const response = await this.client.post(`zenodo/discard/${projectId}`);
     return response.data;
+  }
+
+  /**
+   * Find an in-flight (queued or running) `zenodo_upload` job for the
+   * given project. Used by the frontend to re-subscribe to job progress
+   * after a page reload mid-upload. Returns null if none is found.
+   *
+   * The Girder /job endpoint cannot filter by `kwargs.projectId`, so we
+   * fetch the recent active zenodo_upload jobs and match client-side.
+   */
+  async findActiveUploadJob(
+    projectId: string,
+  ): Promise<IZenodoUploadJob | null> {
+    const response = await this.client.get("job", {
+      params: {
+        types: JSON.stringify(["zenodo_upload"]),
+        statuses: JSON.stringify([jobStates.queued, jobStates.running]),
+        limit: 5,
+        sort: "created",
+        sortdir: -1,
+      },
+    });
+    const jobs: IZenodoUploadJob[] = response.data;
+    return jobs.find((j) => j.kwargs?.projectId === projectId) ?? null;
   }
 }


### PR DESCRIPTION
## Summary
- **Token setup is now self-serve.** `ZenodoTokenDialog` shows a step-by-step "How to create a token" panel inline: Username → Applications → Personal access tokens → + New Token, with all three required scopes (`deposit:actions`, `deposit:write`, `user:email`) named, a direct link to the token page that swaps between zenodo.org and sandbox.zenodo.org based on the sandbox checkbox, and a reminder to save the token in a password manager since Zenodo only shows it once.
- **Configure / Change Token are real buttons.** When no token is configured, the CTA is a flat-primary "Configure Zenodo Token" with `mdi-key-plus` (and the missing-token copy reads "… — required to upload"). When a token is configured, it switches to an outlined-primary "Change Token" so it still reads as a button instead of inline text. The disabled Upload button is wrapped in a tooltip ("Configure a Zenodo token to enable upload") so users know exactly what unblocks it.
- **Visible upload progress from click to completion.** The progress section is now seeded synchronously when the user clicks Upload — they see an indeterminate bar with "Starting upload…" immediately, which switches to the determinate file-count bar once the first SSE log line arrives. A caption notes that uploads can take several minutes and the user can keep working in another tab. The Upload button hides as soon as the progress section appears, so the indeterminate bar is the single source of truth (no more duplicate spinner). A `TODO(#1075)` comment references the tracked issue for wiring this into the app-wide progress store later.
- **Action-bar layout matches the button conventions.** View on Zenodo / Discard Draft / Publish (Mint DOI) are now grouped on the right with no `v-spacer` between them. View on Zenodo is outlined-primary, Discard Draft is outlined-error with `mdi-delete`, Publish (Mint DOI) stays flat-success.
- **Cleanup carried out during the branch-review pass.** Removed the now-dead `uploading` ref; dropped `(error: any)` in `startUpload`'s catch; and moved the direct `store.girderRest.get("job", …)` call out of the component into a typed `zenodoAPI.findActiveUploadJob(projectId)` helper that uses `jobStates.queued/running` instead of magic `[1, 2]`.

## Test plan
- [x] Open a project with no Zenodo token. Confirm the card shows "No Zenodo token configured — required to upload", a flat-primary "Configure Zenodo Token" CTA, and a disabled Upload button. Hover the disabled Upload button and confirm the tooltip explains why.
- [x] Click Configure Zenodo Token. Confirm the dialog shows the 5-step instructions, the "open the token page directly" link points to `zenodo.org/account/settings/applications/tokens/new/`, the link target is `_blank`, and the reminder about saving in a password manager is visible.
- [x] Check the "Use Zenodo Sandbox" checkbox. Confirm both the host name in the heading and the direct-link URL update to `sandbox.zenodo.org`.
- [ ] Save a token. Confirm the card now shows "Zenodo token configured" with a green check, an outlined-primary "Change Token" button, and an enabled Upload button (with no tooltip on hover).
- [x] Click Upload to Zenodo. Confirm an indeterminate bar with "Starting upload…" appears immediately, the upload button hides (no duplicate spinner), and once the job reports progress the bar becomes determinate with an "X / Y files" caption. The "Uploads can take several minutes" line stays visible throughout.
- [ ] Navigate away from ProjectInfo mid-upload and back. Confirm the progress block re-renders (the new `zenodoAPI.findActiveUploadJob` call re-subscribes to the live job).
- [x] After upload completes (status = draft). Confirm View on Zenodo (outlined-primary), Discard Draft (outlined-error with trash icon), and Publish (Mint DOI) (flat-success) are grouped together on the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)