### PR TITLE
Bump Vite build target to allow top-level await (restore prod build)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -115,6 +115,10 @@ export default defineConfig(({ _, mode }) => {
       // Production specific settings
       minify: isProduction ? "esbuild" : false,
       sourcemap: !isProduction, // Useful for debugging in dev, cleaner in prod
+      // Bump above Vite's defaults (chrome87/edge88/firefox78/safari14/es2020)
+      // to versions that support top-level await, which `src/main.ts` uses
+      // to lazy-load Sentry when VITE_SENTRY_DSN is set.
+      target: ["chrome89", "edge89", "firefox89", "safari15"],
       rollupOptions: {
         output: {
           // Helps with browser caching by adding hashes to filenames


### PR DESCRIPTION
## Summary

- Restores the prod build that broke after the interaction between **PR #1164** (conditional Sentry init using `await import("@sentry/vue")`) and **AWSDeploy commit 103109b** (which started wiring `VITE_SENTRY_DSN` into the HAProxy build env).
- Sets `build.target` in `vite.config.js` to `["chrome89", "edge89", "firefox89", "safari15"]` — the minimum versions with top-level-await support — replacing Vite's defaults (`chrome87`/`edge88`/`firefox78`/`safari14`/`es2020`) which predate it.
- Drops support for browsers older than **Chrome 89 / Firefox 89 / Safari 15 / Edge 89** (all from mid-2021 or earlier). Acceptable for a WebGL/canvas-heavy scientific imaging app.
- Companion to **AWSDeploy commit 103109b** and NimbusImage **PR #1164**.

## What broke

With `VITE_SENTRY_DSN` unset (the prior default), the `if (import.meta.env.VITE_SENTRY_DSN) { ... await import("@sentry/vue") ... }` block in `src/main.ts` was dead-code-eliminated and the top-level `await` never made it into the bundle. Once the DSN got wired into prod, that branch survived tree-shaking and esbuild aborted with:

```
[vite:esbuild-transpile] Transform failed with 1 error:
ERROR: Top-level await is not available in the configured target environment
       ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
```

The build aborted, `dist/index.html` was never written, and nginx on the haproxy box served 500 to every page request.

## Verification

- `pnpm build` (no DSN): succeeds, writes `dist/index.html` + `dist/assets/`.
- `VITE_SENTRY_DSN=https://example@sentry.io/1 pnpm build`: succeeds (the path that broke prod). Produces an additional ~460 KB code-split chunk for the dynamically-imported `@sentry/vue`, confirming the dynamic import is taking the lazy-load path.
- `pnpm lint:ci`: clean.

## After merge

The haproxy instance picks up the frontend at boot via `pnpm build`. After merge, the existing haproxy instance needs to be replaced (or `pnpm build` re-run on it) to actually serve the fixed bundle.

## Test plan

- [ ] CI build passes
- [ ] After merge: replace haproxy instance (or re-run `pnpm build` on it) and confirm app.nimbusimage.com loads
- [ ] Confirm Sentry events still arrive in the prod Sentry project after a test error
- [ ] Smoke-test the app in Chrome / Firefox / Safari (latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
