### PR TITLE
nimbusimage: drop #780 workaround now that bulk update is fixed

### DIFF
--- a/docs/superpowers/specs/2026-03-15-nimbusimage-python-api-design.md
+++ b/docs/superpowers/specs/2026-03-15-nimbusimage-python-api-design.md
@@ -201,7 +201,7 @@ ds.annotations.create_many(annotation_list)                               # → 
 ds.annotations.create_many(annotation_list,
                            connect_to={'tags': ['cell'], 'channel': 0})   # create + auto-connect
 ds.annotations.update(annotation_id, updates)                             # → Annotation
-ds.annotations.update_many([(id1, updates1), (id2, updates2), ...])        # → list[Annotation]
+ds.annotations.update_many([(id1, updates1), (id2, updates2), ...])        # bulk update (no return)
 ds.annotations.delete(annotation_id)
 ds.annotations.delete_many([id1, id2, ...])
 ```
@@ -209,7 +209,7 @@ ds.annotations.delete_many([id1, id2, ...])
 - `list()` defaults to `limit=0` (unlimited — the server interprets 0 as no limit)
 - `create_many()` with `connect_to` does bulk create then `connect_to_nearest` (two HTTP calls); returns only the created annotations (connections are a side effect)
 - `update()` uses the single `PUT /upenn_annotation/{id}` endpoint, which returns no body — the method fetches the annotation after updating to return current state
-- `update_many()` uses `PUT /upenn_annotation/multiple` — **known bug** ([#780](https://github.com/arjunrajlaboratory/NimbusImage/issues/780)): the bulk endpoint expects `"id"` (not `"_id"`) and `"datasetId"` per entry, and may return internal server errors. Prefer single `update()` in a loop until this is fixed.
+- `update_many()` uses `PUT /upenn_annotation/multiple` and applies all updates in a single HTTP request. The endpoint accepts either `"id"` or `"_id"` per entry and returns no body, so the method returns `None` — call `get()` if you need the updated annotations back.
 - All methods accept/return `Annotation` dataclass instances
 
 ### ConnectionAccessor — `ds.connections`

--- a/nimbusimage/nimbusimage/annotations.py
+++ b/nimbusimage/nimbusimage/annotations.py
@@ -126,27 +126,23 @@ class AnnotationAccessor:
 
     def update_many(
         self, updates: list[tuple[str, dict]]
-    ) -> list[Annotation]:
-        """Update multiple annotations.
+    ) -> None:
+        """Update multiple annotations in a single HTTP request.
 
         Args:
             updates: List of (annotation_id, updates_dict) tuples.
-                Each updates_dict must include 'datasetId'.
+                Each updates_dict may include 'datasetId' (required
+                only if moving the annotation to a different dataset).
 
         Note:
-            The bulk PUT endpoint has a known bug (#780) — it expects
-            'id' (not '_id') and may return internal server errors.
-            Prefer using update() in a loop until this is fixed.
-
-        TODO: Once #780 is fixed, verify this works correctly and
-        remove the warning. The payload format may need to change
-        from '_id' to 'id' depending on the fix.
+            The bulk PUT endpoint returns no body, so this method
+            does not return the updated annotations. Call ``get()``
+            on individual IDs if you need their fresh state.
         """
         payload = [
             {"id": aid, **upd} for aid, upd in updates
         ]
-        data = self._gc.put("/upenn_annotation/multiple", json=payload)
-        return [Annotation.from_dict(d) for d in (data or [])]
+        self._gc.put("/upenn_annotation/multiple", json=payload)
 
     def delete(self, annotation_id: str) -> None:
         """Delete a single annotation."""

--- a/nimbusimage/pyproject.toml
+++ b/nimbusimage/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nimbusimage"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python API for NimbusImage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/nimbusimage/commands/annotations.md
+++ b/plugins/nimbusimage/commands/annotations.md
@@ -95,9 +95,11 @@ ds.annotations.create_many(
 # Update one annotation
 ds.annotations.update("ann_id", {"tags": ["nucleus", "verified"]})
 
-# update_many has a known bug (#780) — use individual updates for now
-for ann_id, changes in updates:
-    ds.annotations.update(ann_id, changes)
+# Bulk update (single HTTP request, no return value)
+ds.annotations.update_many([
+    (ann_id1, {"color": "rgb(255,0,0)"}),
+    (ann_id2, {"tags": ["nucleus", "verified"]}),
+])
 ```
 
 ## Deleting

--- a/plugins/nimbusimage/references/gotchas.md
+++ b/plugins/nimbusimage/references/gotchas.md
@@ -33,9 +33,9 @@ Always check with `client.get_worker_interface(image)` first.
 
 MongoDB stores `_id`, but some parts of the API expect `id`. The Python models use `id` as the Python attribute with `_id` as the alias for serialization. The `properties.compute()` method handles this remapping automatically, but be aware of it if using raw dicts.
 
-## update_many has a known bug
+## update_many returns nothing
 
-`ds.annotations.update_many()` has a known bug (#780). Use individual `update()` calls for now.
+`ds.annotations.update_many()` sends all updates in one HTTP request, but the backend endpoint returns no body — so the method returns `None`, not a list of updated annotations. If you need the fresh state, call `ds.annotations.get(id)` on the IDs you updated.
 
 ## Connection update returns 500
 


### PR DESCRIPTION
## Summary

- The backend bulk update endpoint (`PUT /upenn_annotation/multiple`) was fixed by #1082 (commit 6b1777de). It now accepts both `"id"` and `"_id"`, validates input, doesn't require `datasetId` on partial updates, and uses `findWithPermissions` for WRITE checks.
- This PR removes the stale "known bug" warnings from the nimbusimage Python API, the design spec, and the skill plugin (`commands/annotations.md`, `references/gotchas.md`).
- Verified end-to-end against `localhost:8080`: `ds.annotations.update_many([...])` applies all updates in one HTTP request.
- The endpoint returns no body, so `update_many()` is now typed `-> None`; the docstring and the gotchas entry tell callers to `ds.annotations.get(id)` if they need the fresh state.

## Behavior change

`AnnotationAccessor.update_many()` used to return `list[Annotation]` (always `[]` in practice, since the endpoint sends no body). It now returns `None`. The existing unit test (`tests/test_annotations.py::TestAnnotationUpdate::test_update_many`) only asserts the call URL, so it still passes — but any external caller that does something with the (empty) returned list will see `None` instead.

## Test plan

- [x] `pytest tests/test_annotations.py` — all 11 pass
- [x] Live test against `localhost:8080`: `ds.annotations.update_many([...])` with `color` and `tags` updates applied correctly; subsequent `ds.annotations.get(id)` confirms the new values
- [x] Bulk endpoint accepts `id`, `_id`, partial updates without `datasetId` — verified via curl
- [ ] Skim the rendered skill pages once the plugin cache picks up the new commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)