### PR TITLE
Fix 'Error fetching job log' crash for jobs with no args field

### DIFF
--- a/src/components/JobsLogs.vue
+++ b/src/components/JobsLogs.vue
@@ -319,7 +319,7 @@ async function viewJobLog(job: IJob): Promise<void> {
       `Duration: ${duration}\n` +
       `Status: ${getStatusText(jobWithLog.status)}\n` +
       `Type: ${jobWithLog.type}\n\n` +
-      `Arguments:\n${jobWithLog.args.join("\n")}\n\n` +
+      `Arguments:\n${(jobWithLog.args ?? []).join("\n")}\n\n` +
       `${getJobState(jobWithLog.status)}\n\n`;
 
     currentJobLog.value =

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1554,7 +1554,7 @@ export interface IJobTimestamp {
 export interface IJob {
   _id: string;
   _modelType: string;
-  args: string[];
+  args?: string[];
   created: string;
   status: number;
   timestamps: IJobTimestamp[];


### PR DESCRIPTION
## Problem

Some production users hit **"Error fetching job log. Please try again."** when viewing a job's log (see the dialog screenshot — `Job Log: unknown` with the generic error body). The underlying console error is:

```
TypeError: Cannot read properties of undefined (reading 'join')
```

## Root cause

`JobsLogs.vue` builds the log header with `jobWithLog.args.join("\n")` unconditionally. `getJobInfo` returns the raw `GET /job/{id}` document, and **Girder does not guarantee the `args` field exists** — it's absent on jobs created via `createLocalJob` (history/export/Zenodo) and on some older/legacy job documents. On those jobs, `.join` throws, the `try/catch` swallows it, and the user sees the generic error instead of the log.

This was invisible to `tsc` because `IJob` declared `args: string[]` as required, and it wasn't locally reproducible because it's purely data-shape dependent — every job in our local/prod accounts happened to have `args` populated.

The same function already guards `log` (`jobWithLog.log || "..."`) and `timestamps` (`job.timestamps?.find`). `args` was the one field left unguarded.

## Fix

- `JobsLogs.vue` — `(jobWithLog.args ?? []).join("\n")`, matching the existing defensive pattern for the neighboring fields.
- `model.ts` — mark `args?: string[]` optional so the type reflects reality and future code is forced to handle the missing case.

The only `job.args` access in the codebase is this one, and `tsc` + `lint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)