### PR TITLE
Add worker request rate limiting support with HTTP 429 handling

### DIFF
--- a/codebaseDocumentation/API_RATE_LIMITING_AUDIT.md
+++ b/codebaseDocumentation/API_RATE_LIMITING_AUDIT.md
@@ -14,6 +14,30 @@ This document audits the current state of protections and recommends future work
 | Property values | Client-side auto-batching | 10K entries/request | `nimbusimage/properties.py`, `annotation_client/annotations.py` |
 | MongoDB | Per-document size limit | 16 MB | MongoDB default |
 | Memcached | Max cached tile size | 8 MB | `docker-compose.yaml` |
+| Worker compute (API) | HAProxy per-user rate limit | 1 request / ~5 min | AWSDeploy `templates/startup_haproxy.tftpl` |
+
+### Worker-request rate limiting (HAProxy)
+
+The production load balancer (AWSDeploy repo) rate-limits worker-compute
+submissions from the `nimbusimage` Python client. GPU Celery workers are
+started on demand and take several minutes to spin up, so a script submitting
+jobs in a tight loop can flood the queue faster than workers come online.
+
+- **What is limited:** `POST /upenn_annotation/compute` and
+  `POST /annotation_property/{id}/compute` (the endpoints that spin up GPU
+  workers).
+- **Who is limited:** only the `nimbusimage` Python client, identified by its
+  `User-Agent: nimbusimage-python/<version>` header. The browser front-end
+  (and any `Mozilla/*` agent) is never matched, even though it authenticates
+  with the same `Girder-Token`. There is no HAProxy-level way to tell a
+  token minted from an API key apart from a login token, so the User-Agent is
+  used as the proxy signal for "programmatic API client."
+- **Scope:** keyed by `Girder-Token` (per user) via an HAProxy stick-table.
+- **Window:** configurable via the `WORKER_REQUEST_RATE_LIMIT_SECONDS`
+  Terraform variable (default 300s, ~matching worker spin-up time).
+- **Response:** HTTP 429 with a JSON body and a `Retry-After` header. The
+  client surfaces this as `nimbusimage.WorkerRateLimitError` (with
+  `.retry_after`).
 
 ## What's missing
 
@@ -31,13 +55,17 @@ These backend endpoints accept arbitrarily large arrays with no server-side limi
 
 The backend calls `saveMany()` / `removeWithQuery()` directly on the MongoDB collection with no array size validation.
 
-### No rate limiting
+### Limited rate limiting
 
-There is no rate limiting configured anywhere in the stack:
-- No per-user request throttling
-- No per-endpoint rate limits
+Worker-compute submissions from the Python API are now throttled at HAProxy
+(see "Worker-request rate limiting" above). Beyond that, there is still no
+general rate limiting in the stack:
+- No per-user request throttling on read/write data endpoints
+- No per-endpoint rate limits outside the worker-compute paths
 - No concurrent request limits
 - No nginx rate limiting (no nginx in the current docker-compose setup)
+- Note: the HAProxy worker rate limit lives only in the production deployment
+  (AWSDeploy), not in the local `docker-compose` dev stack.
 
 ### No per-user concurrent job limit
 
@@ -75,6 +103,10 @@ These protect against all clients (Python API, frontend, curl, etc.):
 2. **Add rate limiting** via nginx or a Girder plugin. Suggested starting point:
    - 100 requests/minute per user for write endpoints (POST, PUT, DELETE)
    - 1000 requests/minute per user for read endpoints (GET)
+
+   *Partially done:* worker-compute submissions are now rate-limited at HAProxy
+   in production (see above). Extending this to general read/write endpoints is
+   still open.
 
 3. **Add concurrent job limits** — max N active worker jobs per user (suggested: 5-10).
 

--- a/nimbusimage/docs/getting-started.md
+++ b/nimbusimage/docs/getting-started.md
@@ -229,6 +229,45 @@ except TimeoutError:
     print("Job timed out")
 ```
 
+### Worker request rate limiting
+
+NimbusImage runs GPU workers that are **started on demand and take several
+minutes to spin up**. To keep the job queue from being flooded, a shared
+deployment may rate-limit worker-compute submissions
+(`ds.annotations.compute()` and `ds.properties.compute()`) on a per-user
+basis. When the limit is hit, the call raises `WorkerRateLimitError`.
+
+Design your scripts to **parcel out worker requests** rather than firing many
+in a loop:
+
+- **Submit one job over a wide range, not many small jobs.** `compute()`
+  already processes a whole `assignment` range in a single job — prefer a
+  single call covering all your tiles/frames over a `for` loop of `compute()`
+  calls.
+- **Let each job finish (or run a few concurrently), then submit the next.**
+- **If you hit the limit, back off** for the `retry_after` interval the server
+  reports rather than retrying immediately.
+
+```python
+import time
+import nimbusimage as ni
+
+try:
+    job = ds.annotations.compute(
+        image="annotations/random_squares:latest",
+        assignment={"XY": "0-99", "Z": 0, "Time": "0-9"},  # one job, wide range
+    )
+    job.wait()
+except ni.WorkerRateLimitError as err:
+    wait = err.retry_after or 300
+    print(f"Rate limited; retrying in {wait}s")
+    time.sleep(wait)
+```
+
+The exact interval is set by the deployment and is not exposed by the API;
+treat any worker request as something that may be throttled and handle
+`WorkerRateLimitError` accordingly.
+
 ## Export
 
 ```python

--- a/nimbusimage/nimbusimage/__init__.py
+++ b/nimbusimage/nimbusimage/__init__.py
@@ -19,6 +19,7 @@ from nimbusimage.filters import (
     filter_by_location,
     group_by_location,
 )
+from nimbusimage.exceptions import NimbusError, WorkerRateLimitError
 from nimbusimage.models import (
     Annotation,
     Connection,
@@ -104,4 +105,7 @@ __all__ = [
     "filter_by_tags",
     "filter_by_location",
     "group_by_location",
+    # Exceptions
+    "NimbusError",
+    "WorkerRateLimitError",
 ]

--- a/nimbusimage/nimbusimage/_girder.py
+++ b/nimbusimage/nimbusimage/_girder.py
@@ -8,8 +8,23 @@ and error handling are centralized.
 from __future__ import annotations
 
 import os
+from importlib.metadata import PackageNotFoundError, version
 
 import girder_client
+import requests
+
+from nimbusimage.exceptions import WorkerRateLimitError
+
+try:
+    _VERSION = version("nimbusimage")
+except PackageNotFoundError:  # running from a source tree without install
+    _VERSION = "0+unknown"
+
+# Distinctive User-Agent so the deployment can recognize traffic from the
+# nimbusimage Python client (vs. the browser front-end, which sends a
+# "Mozilla/*" agent). The HAProxy load balancer uses this to scope worker
+# request rate limiting to programmatic API clients only.
+USER_AGENT = f"nimbusimage-python/{_VERSION}"
 
 
 def create_client(
@@ -51,6 +66,12 @@ def create_client(
 
     gc = girder_client.GirderClient(apiUrl=api_url)
 
+    # Attach a persistent session that advertises the nimbusimage client
+    # User-Agent on every request (including the API-key token exchange).
+    session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
+    gc._session = session
+
     if token is not None:
         gc.setToken(token)
     elif api_key is not None:
@@ -75,3 +96,38 @@ def create_client(
             )
 
     return gc
+
+
+def _parse_retry_after(response) -> int | None:
+    """Extract the Retry-After header (seconds) from a response, if present."""
+    if response is None:
+        return None
+    value = response.headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def submit_worker_job(gc, path: str, body: dict):
+    """POST a worker-compute request, translating rate-limit responses.
+
+    Worker-compute endpoints are rate limited per user by the deployment
+    (GPU workers take minutes to start). On HTTP 429 this raises
+    :class:`~nimbusimage.exceptions.WorkerRateLimitError` carrying the
+    server's ``Retry-After`` hint, instead of a generic ``HttpError``.
+
+    Returns the job document (unwrapped from a single-element list if the
+    backend returns one).
+    """
+    try:
+        resp = gc.post(path, json=body)
+    except girder_client.HttpError as exc:
+        if exc.status == 429:
+            raise WorkerRateLimitError(
+                retry_after=_parse_retry_after(exc.response)
+            ) from exc
+        raise
+    return resp[0] if isinstance(resp, (list, tuple)) else resp

--- a/nimbusimage/nimbusimage/annotations.py
+++ b/nimbusimage/nimbusimage/annotations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from nimbusimage._girder import submit_worker_job
 from nimbusimage.jobs import Job
 from nimbusimage.models import Annotation, Location
 
@@ -198,6 +199,14 @@ class AnnotationAccessor:
         Returns:
             A Job object. Call ``job.wait()`` to block until completion.
 
+        Raises:
+            WorkerRateLimitError: If the server rate-limits the request.
+                Worker jobs are throttled per user because GPU workers
+                take minutes to start. Submit one job over a wide
+                ``assignment`` range instead of looping over many small
+                ``compute()`` calls; if you must retry, back off for the
+                error's ``retry_after`` seconds.
+
         Note:
             The worker container uses ``WorkerClient`` from the
             ``worker_client`` package, which requires all of these keys
@@ -235,9 +244,9 @@ class AnnotationAccessor:
             "id": "",
         }
 
-        resp = self._gc.post(
+        job_data = submit_worker_job(
+            self._gc,
             f"/upenn_annotation/compute?datasetId={self._dataset_id}",
-            json=body,
+            body,
         )
-        job_data = resp[0] if isinstance(resp, (list, tuple)) else resp
         return Job(self._gc, job_data)

--- a/nimbusimage/nimbusimage/exceptions.py
+++ b/nimbusimage/nimbusimage/exceptions.py
@@ -1,0 +1,48 @@
+"""Public exception types for the NimbusImage API."""
+
+from __future__ import annotations
+
+
+class NimbusError(Exception):
+    """Base class for nimbusimage-specific errors."""
+
+
+class WorkerRateLimitError(NimbusError):
+    """Raised when the server rejects a worker request for rate limiting.
+
+    NimbusImage runs GPU workers that are started on demand and take
+    several minutes to spin up. To keep the job queue from being flooded,
+    the deployment rate-limits worker-compute submissions (e.g.
+    ``ds.annotations.compute()`` / ``ds.properties.compute()``) on a
+    per-user basis. When the limit is hit the server responds with HTTP
+    429 and this exception is raised.
+
+    The :attr:`retry_after` attribute holds the number of seconds the
+    server asked the client to wait before retrying (parsed from the
+    ``Retry-After`` response header), or ``None`` if it was not provided.
+
+    Worker jobs already process whole assignment ranges in one call, so
+    prefer submitting a single job over a wide range rather than looping
+    over many small ``compute()`` calls. If you do need to retry, back off
+    for at least :attr:`retry_after` seconds.
+    """
+
+    def __init__(
+        self,
+        retry_after: int | None = None,
+        message: str | None = None,
+    ):
+        self.retry_after = retry_after
+        if message is None:
+            wait = (
+                f"Retry after {retry_after} seconds."
+                if retry_after is not None
+                else "Retry after a short wait."
+            )
+            message = (
+                "Worker request rate limited by the server. GPU workers "
+                "take several minutes to start, so worker jobs are "
+                "throttled per user. Submit fewer, larger jobs (batch "
+                f"assignments into a single compute call). {wait}"
+            )
+        super().__init__(message)

--- a/nimbusimage/nimbusimage/properties.py
+++ b/nimbusimage/nimbusimage/properties.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from nimbusimage._girder import submit_worker_job
 from nimbusimage.jobs import Job
 from nimbusimage.models import Property
 
@@ -182,6 +183,11 @@ class PropertyAccessor:
 
         Raises:
             ValueError: If the property has no ``id`` or ``image``.
+            WorkerRateLimitError: If the server rate-limits the request.
+                Worker jobs are throttled per user because GPU workers
+                take minutes to start. Submit fewer, larger jobs rather
+                than looping over many ``compute()`` calls; if you must
+                retry, back off for the error's ``retry_after`` seconds.
         """
         if not property.id:
             raise ValueError(
@@ -206,10 +212,10 @@ class PropertyAccessor:
         if scales is not None:
             body["scales"] = scales
 
-        resp = self._gc.post(
+        job_data = submit_worker_job(
+            self._gc,
             f"/annotation_property/{property.id}/compute"
             f"?datasetId={self._dataset_id}",
-            json=body,
+            body,
         )
-        job_data = resp[0] if isinstance(resp, (list, tuple)) else resp
         return Job(self._gc, job_data)

--- a/nimbusimage/tests/test_worker_rate_limit.py
+++ b/nimbusimage/tests/test_worker_rate_limit.py
@@ -1,0 +1,73 @@
+"""Tests for worker-request rate limit handling (HTTP 429)."""
+
+from unittest.mock import MagicMock
+
+import girder_client
+import pytest
+
+from nimbusimage._girder import _parse_retry_after, submit_worker_job
+from nimbusimage.annotations import AnnotationAccessor
+from nimbusimage.exceptions import WorkerRateLimitError
+
+
+def _http_error(status, retry_after=None):
+    response = MagicMock()
+    response.headers = {} if retry_after is None else {
+        "Retry-After": str(retry_after)
+    }
+    return girder_client.HttpError(
+        status=status, text="", url="u", method="POST", response=response
+    )
+
+
+class TestParseRetryAfter:
+    def test_parses_integer_seconds(self):
+        resp = MagicMock()
+        resp.headers = {"Retry-After": "300"}
+        assert _parse_retry_after(resp) == 300
+
+    def test_missing_header_returns_none(self):
+        resp = MagicMock()
+        resp.headers = {}
+        assert _parse_retry_after(resp) is None
+
+    def test_non_integer_header_returns_none(self):
+        # HTTP-date form of Retry-After is not parsed; we just skip it.
+        resp = MagicMock()
+        resp.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        assert _parse_retry_after(resp) is None
+
+
+class TestSubmitWorkerJob:
+    def test_returns_job_dict_on_success(self, mock_gc):
+        mock_gc.post.return_value = {"_id": "job_1"}
+        assert submit_worker_job(mock_gc, "/x/compute", {}) == {"_id": "job_1"}
+
+    def test_unwraps_single_element_list(self, mock_gc):
+        mock_gc.post.return_value = [{"_id": "job_1"}]
+        assert submit_worker_job(mock_gc, "/x/compute", {}) == {"_id": "job_1"}
+
+    def test_429_raises_rate_limit_error_with_retry_after(self, mock_gc):
+        mock_gc.post.side_effect = _http_error(429, retry_after=300)
+        with pytest.raises(WorkerRateLimitError) as excinfo:
+            submit_worker_job(mock_gc, "/x/compute", {})
+        assert excinfo.value.retry_after == 300
+
+    def test_429_without_retry_after_header(self, mock_gc):
+        mock_gc.post.side_effect = _http_error(429)
+        with pytest.raises(WorkerRateLimitError) as excinfo:
+            submit_worker_job(mock_gc, "/x/compute", {})
+        assert excinfo.value.retry_after is None
+
+    def test_other_http_errors_propagate(self, mock_gc):
+        mock_gc.post.side_effect = _http_error(500)
+        with pytest.raises(girder_client.HttpError):
+            submit_worker_job(mock_gc, "/x/compute", {})
+
+
+class TestComputeRateLimit:
+    def test_annotation_compute_translates_429(self, mock_gc):
+        mock_gc.post.side_effect = _http_error(429, retry_after=300)
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+        with pytest.raises(WorkerRateLimitError):
+            accessor.compute(image="annotations/random_squares:latest")


### PR DESCRIPTION
## Summary

Implements client-side support for worker-request rate limiting in the NimbusImage Python API. When GPU worker submissions are throttled by the server (HTTP 429), the client now raises a dedicated `WorkerRateLimitError` exception with retry guidance, rather than a generic `HttpError`.

## Key Changes

- **New exception type** (`nimbusimage.exceptions.WorkerRateLimitError`): Raised when worker-compute submissions hit rate limits, carrying the server's `Retry-After` hint and user-friendly guidance about batching jobs and backing off appropriately.

- **Worker job submission wrapper** (`submit_worker_job` in `_girder.py`): Centralizes HTTP POST logic for worker endpoints, translates HTTP 429 responses to `WorkerRateLimitError`, and unwraps single-element list responses from the backend.

- **User-Agent identification** (`USER_AGENT` in `_girder.py`): Advertises the nimbusimage Python client version on all requests via a custom `User-Agent` header. This allows the HAProxy load balancer (in production) to distinguish programmatic API clients from browser traffic and apply rate limiting only to the former.

- **Retry-After parsing** (`_parse_retry_after` in `_girder.py`): Extracts the `Retry-After` header from HTTP responses, handling both integer seconds and gracefully ignoring HTTP-date formats.

- **Integration with compute endpoints**: Updated `AnnotationAccessor.compute()` and `PropertyAccessor.compute()` to use the new `submit_worker_job` wrapper, automatically translating rate-limit responses.

- **Documentation**: Added getting-started guide section on worker rate limiting with code examples, and updated the API rate-limiting audit document to describe the HAProxy-level throttling mechanism.

## Implementation Details

- The `User-Agent` header is set on a persistent `requests.Session` attached to the Girder client, ensuring it's sent on all requests including the initial API-key token exchange.
- Rate limiting is scoped per user (via `Girder-Token`) and applies only to worker-compute endpoints (`/upenn_annotation/compute` and `/annotation_property/{id}/compute`).
- The `retry_after` attribute on the exception is `None` if the server doesn't provide a `Retry-After` header; callers should use a sensible default (e.g., 300 seconds) in that case.
- Comprehensive test coverage for parsing, exception raising, and integration with the compute APIs.

https://claude.ai/code/session_01FZ3D9VBnWrAYHvwpwJgws4