### PR TITLE
Fix snapshot selection so 'download selected' respects selection

### DIFF
--- a/src/components/ConfigurationSelect.vue
+++ b/src/components/ConfigurationSelect.vue
@@ -6,6 +6,7 @@
       show-select
       return-object
       v-model="selectedConfigurations"
+      item-value="id"
       :items="compatibleConfigurations"
       :headers="headers"
       :search="search"

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -172,7 +172,7 @@
           :items="snapshotList"
           :headers="tableHeaders"
           :items-per-page="5"
-          item-key="key"
+          item-value="key"
           class="accent-1"
           @click:row="loadSnapshot"
           show-select


### PR DESCRIPTION
The snapshot v-data-table used the Vuetify 2 prop `item-key` to define
each row's identity. In Vuetify 4 the correct prop is `item-value`;
`item-key` is silently ignored, so Vuetify fell back to its default
identity key (`id`), which is undefined for every snapshot row. With no
distinguishable per-row identity, the selection model could not track
individual rows, causing 'Download images for selected Snapshots' to
behave as if all snapshots were selected.

Use `item-value="key"` so each row is identified by its unique snapshot
name and the selection model tracks selected rows correctly.