### PR TITLE
Fix downloaded snapshot scalebar sizing

### DIFF
--- a/src/components/Snapshots.test.ts
+++ b/src/components/Snapshots.test.ts
@@ -1915,4 +1915,79 @@ describe("Snapshots.vue", () => {
       }
     });
   });
+
+  describe("drawScalebarOnCanvas scaling", () => {
+    // Minimal CanvasRenderingContext2D stub that records the horizontal extent
+    // of the scalebar line so we can assert on its length in canvas pixels.
+    function makeMockCtx() {
+      const calls: { moveTo: number[]; lineTo: number[] } = {
+        moveTo: [],
+        lineTo: [],
+      };
+      const ctx = {
+        strokeStyle: "",
+        fillStyle: "",
+        lineWidth: 0,
+        font: "",
+        textBaseline: "",
+        textAlign: "",
+        beginPath: vi.fn(),
+        moveTo: vi.fn((x: number) => calls.moveTo.push(x)),
+        lineTo: vi.fn((x: number) => calls.lineTo.push(x)),
+        stroke: vi.fn(),
+        fillText: vi.fn(),
+      };
+      return { ctx, calls };
+    }
+
+    function scalebarPixelLength(canvasWidth: number, canvasHeight: number) {
+      const vm = wrapper.vm as any;
+      // Manual px scalebar of 100 dataset pixels keeps the math obvious.
+      vm.scalebarMode = "manual";
+      vm.manualScalebarSettings = { length: 100, unit: TScalebarUnit.PX };
+      vm.addScalebarText = false;
+      const { ctx, calls } = makeMockCtx();
+      vm.drawScalebarOnCanvas(ctx, canvasWidth, canvasHeight);
+      // The line runs from moveTo.x to lineTo.x; its length is the difference.
+      return calls.moveTo[0] - calls.lineTo[0];
+    }
+
+    beforeEach(() => {
+      wrapper = mountComponent();
+      vi.clearAllMocks();
+    });
+
+    it("draws scalebar at native length when canvas matches dataset pixels", () => {
+      const vm = wrapper.vm as any;
+      vm.bboxLeft = 0;
+      vm.bboxRight = 1000;
+      // Canvas spans the full 1000 dataset px at 1:1 → 100 dataset px = 100 px.
+      expect(scalebarPixelLength(1000, 800)).toBeCloseTo(100);
+    });
+
+    it("scales scalebar down when the downloaded image is downsampled", () => {
+      const vm = wrapper.vm as any;
+      vm.bboxLeft = 0;
+      vm.bboxRight = 1000;
+      // A 1000-wide region rendered onto a 500-wide canvas (2x downsample, as
+      // happens when the region exceeds maxPixels) → 100 dataset px = 50 px.
+      expect(scalebarPixelLength(500, 400)).toBeCloseTo(50);
+    });
+
+    it("scales scalebar up when the canvas is in zoomed display pixels", () => {
+      const vm = wrapper.vm as any;
+      vm.bboxLeft = 0;
+      vm.bboxRight = 1000;
+      // Screenshot-based canvases are in display px; at 2x zoom a 1000 dataset
+      // px region spans 2000 canvas px → 100 dataset px = 200 px.
+      expect(scalebarPixelLength(2000, 1600)).toBeCloseTo(200);
+    });
+
+    it("falls back to native length when the bounding box has zero width", () => {
+      const vm = wrapper.vm as any;
+      vm.bboxLeft = 50;
+      vm.bboxRight = 50;
+      expect(scalebarPixelLength(800, 600)).toBeCloseTo(100);
+    });
+  });
 });

--- a/src/components/Snapshots.test.ts
+++ b/src/components/Snapshots.test.ts
@@ -1450,14 +1450,14 @@ describe("Snapshots.vue", () => {
     it("downloadUrls downloads single file directly without scalebar", async () => {
       const url = new URL("http://localhost/api/v1/test");
       url.searchParams.set("contentDispositionFilename", "test.png");
-      await (wrapper.vm as any).downloadUrls([url], false);
+      await (wrapper.vm as any).downloadUrls([{ url, scalebarSpec: null }]);
       expect(mockedDownloadToClient).toHaveBeenCalledWith({
         href: url.href,
       });
     });
 
     it("downloadUrls does nothing for empty array", async () => {
-      await (wrapper.vm as any).downloadUrls([], false);
+      await (wrapper.vm as any).downloadUrls([]);
       expect(mockedDownloadToClient).not.toHaveBeenCalled();
     });
 
@@ -1920,9 +1920,10 @@ describe("Snapshots.vue", () => {
     // Minimal CanvasRenderingContext2D stub that records the horizontal extent
     // of the scalebar line so we can assert on its length in canvas pixels.
     function makeMockCtx() {
-      const calls: { moveTo: number[]; lineTo: number[] } = {
+      const calls: { moveTo: number[]; lineTo: number[]; fillText: any[] } = {
         moveTo: [],
         lineTo: [],
+        fillText: [],
       };
       const ctx = {
         strokeStyle: "",
@@ -1935,20 +1936,28 @@ describe("Snapshots.vue", () => {
         moveTo: vi.fn((x: number) => calls.moveTo.push(x)),
         lineTo: vi.fn((x: number) => calls.lineTo.push(x)),
         stroke: vi.fn(),
-        fillText: vi.fn(),
+        fillText: vi.fn((...args: any[]) => calls.fillText.push(args)),
       };
       return { ctx, calls };
     }
 
-    function scalebarPixelLength(canvasWidth: number, canvasHeight: number) {
+    function bounds(left: number, right: number) {
+      return { left, top: 0, right, bottom: right - left };
+    }
+
+    // Draws using a spec for the given bbox width on a canvas of the given
+    // width, and returns the rendered scalebar length in canvas pixels.
+    function drawnLength(
+      bboxWidth: number,
+      canvasWidth: number,
+      manualPx = 100,
+    ) {
       const vm = wrapper.vm as any;
-      // Manual px scalebar of 100 dataset pixels keeps the math obvious.
       vm.scalebarMode = "manual";
-      vm.manualScalebarSettings = { length: 100, unit: TScalebarUnit.PX };
-      vm.addScalebarText = false;
+      vm.manualScalebarSettings = { length: manualPx, unit: TScalebarUnit.PX };
+      const spec = vm.buildScalebarSpec(bounds(0, bboxWidth));
       const { ctx, calls } = makeMockCtx();
-      vm.drawScalebarOnCanvas(ctx, canvasWidth, canvasHeight);
-      // The line runs from moveTo.x to lineTo.x; its length is the difference.
+      vm.drawScalebarOnCanvas(ctx, canvasWidth, canvasWidth * 0.8, spec);
       return calls.moveTo[0] - calls.lineTo[0];
     }
 
@@ -1958,36 +1967,109 @@ describe("Snapshots.vue", () => {
     });
 
     it("draws scalebar at native length when canvas matches dataset pixels", () => {
-      const vm = wrapper.vm as any;
-      vm.bboxLeft = 0;
-      vm.bboxRight = 1000;
       // Canvas spans the full 1000 dataset px at 1:1 → 100 dataset px = 100 px.
-      expect(scalebarPixelLength(1000, 800)).toBeCloseTo(100);
+      expect(drawnLength(1000, 1000)).toBeCloseTo(100);
     });
 
     it("scales scalebar down when the downloaded image is downsampled", () => {
-      const vm = wrapper.vm as any;
-      vm.bboxLeft = 0;
-      vm.bboxRight = 1000;
       // A 1000-wide region rendered onto a 500-wide canvas (2x downsample, as
       // happens when the region exceeds maxPixels) → 100 dataset px = 50 px.
-      expect(scalebarPixelLength(500, 400)).toBeCloseTo(50);
+      expect(drawnLength(1000, 500)).toBeCloseTo(50);
     });
 
     it("scales scalebar up when the canvas is in zoomed display pixels", () => {
-      const vm = wrapper.vm as any;
-      vm.bboxLeft = 0;
-      vm.bboxRight = 1000;
       // Screenshot-based canvases are in display px; at 2x zoom a 1000 dataset
       // px region spans 2000 canvas px → 100 dataset px = 200 px.
-      expect(scalebarPixelLength(2000, 1600)).toBeCloseTo(200);
+      expect(drawnLength(1000, 2000)).toBeCloseTo(200);
     });
 
     it("falls back to native length when the bounding box has zero width", () => {
       const vm = wrapper.vm as any;
-      vm.bboxLeft = 50;
-      vm.bboxRight = 50;
-      expect(scalebarPixelLength(800, 600)).toBeCloseTo(100);
+      vm.scalebarMode = "manual";
+      vm.manualScalebarSettings = { length: 100, unit: TScalebarUnit.PX };
+      const spec = vm.buildScalebarSpec(bounds(50, 50));
+      const { ctx, calls } = makeMockCtx();
+      vm.drawScalebarOnCanvas(ctx, 800, 600, spec);
+      expect(calls.moveTo[0] - calls.lineTo[0]).toBeCloseTo(100);
+    });
+
+    it("draws each snapshot's own label from its spec", () => {
+      const vm = wrapper.vm as any;
+      vm.scalebarMode = "manual";
+      vm.manualScalebarSettings = { length: 25, unit: TScalebarUnit.UM };
+      vm.addScalebarText = true;
+      const spec = vm.buildScalebarSpec(bounds(0, 1000));
+      const { ctx, calls } = makeMockCtx();
+      vm.drawScalebarOnCanvas(ctx, 1000, 800, spec);
+      expect(calls.fillText[0][0]).toBe("25µm");
+    });
+  });
+
+  describe("per-snapshot scalebar specs (buildScalebarSpec)", () => {
+    beforeEach(() => {
+      wrapper = mountComponent();
+      vi.clearAllMocks();
+    });
+
+    it("carries each snapshot's bounding-box width independent of the current view", () => {
+      const vm = wrapper.vm as any;
+      // Current view is wide, but the snapshot we build a spec for is narrow.
+      vm.bboxLeft = 0;
+      vm.bboxRight = 4000;
+      const spec = vm.buildScalebarSpec({
+        left: 100,
+        top: 0,
+        right: 700,
+        bottom: 600,
+      });
+      expect(spec.datasetPixelWidth).toBe(600);
+    });
+
+    it("computes different automatic scalebar lengths for different bboxes", () => {
+      const vm = wrapper.vm as any;
+      vm.scalebarMode = "automatic";
+      // Pixel size in px so the ideal length scales with the bbox width.
+      vm.pixelSizeMode = "manual";
+      vm.manualPixelSize = { length: 1, unit: TScalebarUnit.PX };
+      const small = vm.buildScalebarSpec({
+        left: 0,
+        top: 0,
+        right: 500,
+        bottom: 500,
+      });
+      const large = vm.buildScalebarSpec({
+        left: 0,
+        top: 0,
+        right: 8000,
+        bottom: 8000,
+      });
+      expect(large.lengthInDatasetPixels).toBeGreaterThan(
+        small.lengthInDatasetPixels,
+      );
+    });
+
+    it("keeps a fixed manual length across bboxes but tracks each width", () => {
+      const vm = wrapper.vm as any;
+      vm.scalebarMode = "manual";
+      vm.manualScalebarSettings = { length: 100, unit: TScalebarUnit.PX };
+      const a = vm.buildScalebarSpec({
+        left: 0,
+        top: 0,
+        right: 1000,
+        bottom: 1000,
+      });
+      const b = vm.buildScalebarSpec({
+        left: 0,
+        top: 0,
+        right: 2000,
+        bottom: 2000,
+      });
+      // Same physical length...
+      expect(a.lengthInDatasetPixels).toBe(100);
+      expect(b.lengthInDatasetPixels).toBe(100);
+      // ...but different denominators, so the drawn pixel length differs.
+      expect(a.datasetPixelWidth).toBe(1000);
+      expect(b.datasetPixelWidth).toBe(2000);
     });
   });
 });

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -2616,7 +2616,19 @@ function drawScalebarOnCanvas(
   width: number,
   height: number,
 ) {
-  const scalebarLength = scalebarLengthInPixels.value;
+  // `scalebarLengthInPixels` is expressed in dataset pixels (it is derived from
+  // the bounding-box width `bboxRight - bboxLeft`). The canvas we draw onto is
+  // rarely 1:1 with dataset pixels though: region downloads are downsampled to
+  // stay under `maxPixels`, and screenshot-based canvases are in display
+  // (screen) pixels. Both span the same horizontal extent as the bounding box,
+  // so convert dataset pixels to canvas pixels using that ratio. Without this
+  // the on-screen scalebar (drawn by GeoJS in image coordinates) and the
+  // downloaded scalebar disagree whenever the canvas isn't at native scale.
+  const datasetPixelWidth = bboxRight.value - bboxLeft.value;
+  const canvasPixelsPerDatasetPixel =
+    datasetPixelWidth > 0 ? width / datasetPixelWidth : 1;
+  const scalebarLength =
+    scalebarLengthInPixels.value * canvasPixelsPerDatasetPixel;
   const maxDim = Math.max(width, height);
 
   const padding = Math.max(10, Math.min(40, 0.02 * maxDim));

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -643,6 +643,29 @@ interface IScalebarSettings {
   unit: TScalebarUnit;
 }
 
+// Everything needed to draw a scalebar onto a download/export canvas,
+// resolved for a specific bounding box. This is computed per snapshot (and
+// once for the current view) so batch downloads of snapshots with different
+// bounding boxes each get a correctly sized scalebar instead of inheriting the
+// current view's settings.
+interface IScalebarSpec {
+  // Physical length of the scalebar expressed in dataset pixels.
+  lengthInDatasetPixels: number;
+  // Width of the rendered bounding box in dataset pixels. The output canvas
+  // spans this same horizontal extent, so it is the denominator used to convert
+  // dataset pixels into canvas pixels (handles downsampled and display-scaled
+  // canvases alike).
+  datasetPixelWidth: number;
+  // Text label drawn next to the bar, e.g. "50µm".
+  label: string;
+}
+
+// A download URL paired with the scalebar to draw onto its image (null = none).
+interface IDownloadUrlItem {
+  url: URL;
+  scalebarSpec: IScalebarSpec | null;
+}
+
 /**
  * Get the best supported video MIME type for the current browser.
  * Prioritizes MP4 (H.264) for broad compatibility, falls back to WebM for Firefox.
@@ -893,48 +916,38 @@ const pixelSize = computed((): IScalebarSettings => {
   return configurationPixelSize.value;
 });
 
-const idealScalebarLength = computed(() => {
-  const ps = pixelSize.value;
-  if (ps.unit === TScalebarUnit.PX) {
-    return guessIdealScalebar(bboxRight.value - bboxLeft.value, ps.length);
-  }
-  const pixelLengthInMeters = convertLengthToMeters(ps.length, ps.unit);
-  return guessIdealScalebar(
+const currentScalebar = computed(() =>
+  computeScalebarForBbox(
     bboxRight.value - bboxLeft.value,
-    pixelLengthInMeters,
-  );
-});
+    pixelSize.value,
+    scalebarMode.value,
+    manualScalebarSettings.value,
+  ),
+);
 
-const scalebarSettings = computed((): IScalebarSettings => {
-  if (scalebarMode.value === "manual" && manualScalebarSettings.value) {
-    return manualScalebarSettings.value;
-  }
-  const idealScalebar = idealScalebarLength.value;
-  if (!idealScalebar) {
-    return { length: 1.0, unit: TScalebarUnit.PX };
-  } else {
-    if (pixelSize.value.unit === TScalebarUnit.PX) {
-      return { length: idealScalebar, unit: TScalebarUnit.PX };
-    }
-    return convertMetersToLength(idealScalebar);
-  }
-});
+const idealScalebarLength = computed(() =>
+  idealScalebarForBbox(bboxRight.value - bboxLeft.value, pixelSize.value),
+);
 
-const scalebarLengthInPixels = computed((): number => {
-  if (scalebarSettings.value.unit === TScalebarUnit.PX) {
-    return scalebarSettings.value.length;
-  }
-  const ps = pixelSize.value;
-  if (ps.unit === TScalebarUnit.PX) {
-    return scalebarSettings.value.length;
-  }
-  const pixelLengthInMeters = convertLengthToMeters(ps.length, ps.unit);
-  const scalebarLengthInMeters = convertLengthToMeters(
-    scalebarSettings.value.length,
-    scalebarSettings.value.unit,
-  );
-  return scalebarLengthInMeters / pixelLengthInMeters;
-});
+const scalebarSettings = computed(
+  (): IScalebarSettings => currentScalebar.value.settings,
+);
+
+const scalebarLengthInPixels = computed(
+  (): number => currentScalebar.value.lengthInPixels,
+);
+
+// Spec for drawing the scalebar onto the current view's downloads (viewport
+// screenshots and movies always operate on the current bounding box).
+const currentScalebarSpec = computed(
+  (): IScalebarSpec =>
+    buildScalebarSpec({
+      left: bboxLeft.value,
+      top: bboxTop.value,
+      right: bboxRight.value,
+      bottom: bboxBottom.value,
+    }),
+);
 
 const snapshotList = computed(() => {
   const sre = new RegExp(snapshotSearch.value || "", "i");
@@ -1125,6 +1138,83 @@ function guessIdealScalebar(
   }
 
   return roundToSignificant(bestValue);
+}
+
+// Ideal automatic scalebar length for a given bounding-box width and pixel
+// size. Returned in the pixel-size's unit space (dataset pixels when the pixel
+// size is in px, otherwise meters), matching guessIdealScalebar's convention.
+function idealScalebarForBbox(
+  bboxWidthInDatasetPixels: number,
+  pixelSize: IScalebarSettings,
+): number | null {
+  const distancePerPixel =
+    pixelSize.unit === TScalebarUnit.PX
+      ? pixelSize.length
+      : convertLengthToMeters(pixelSize.length, pixelSize.unit);
+  return guessIdealScalebar(bboxWidthInDatasetPixels, distancePerPixel);
+}
+
+// Single source of truth for resolving a scalebar (display settings + length in
+// dataset pixels) from a bounding-box width, pixel size, and the chosen mode.
+// Used both for the current view's reactive computeds and for per-snapshot
+// batch downloads.
+function computeScalebarForBbox(
+  bboxWidthInDatasetPixels: number,
+  pixelSize: IScalebarSettings,
+  mode: ScalebarMode,
+  manualSettings: IScalebarSettings | null,
+): { settings: IScalebarSettings; lengthInPixels: number } {
+  let settings: IScalebarSettings;
+  if (mode === ScalebarMode.MANUAL && manualSettings) {
+    settings = manualSettings;
+  } else {
+    const ideal = idealScalebarForBbox(bboxWidthInDatasetPixels, pixelSize);
+    if (!ideal) {
+      settings = { length: 1.0, unit: TScalebarUnit.PX };
+    } else if (pixelSize.unit === TScalebarUnit.PX) {
+      settings = { length: ideal, unit: TScalebarUnit.PX };
+    } else {
+      settings = convertMetersToLength(ideal);
+    }
+  }
+
+  let lengthInPixels: number;
+  if (
+    settings.unit === TScalebarUnit.PX ||
+    pixelSize.unit === TScalebarUnit.PX
+  ) {
+    lengthInPixels = settings.length;
+  } else {
+    const pixelLengthInMeters = convertLengthToMeters(
+      pixelSize.length,
+      pixelSize.unit,
+    );
+    const scalebarLengthInMeters = convertLengthToMeters(
+      settings.length,
+      settings.unit,
+    );
+    lengthInPixels = scalebarLengthInMeters / pixelLengthInMeters;
+  }
+
+  return { settings, lengthInPixels };
+}
+
+// Build the spec needed to draw a scalebar for a specific bounding box, using
+// the currently selected pixel size and scalebar mode (those are global UI
+// choices that apply to the whole download operation).
+function buildScalebarSpec(bbox: IGeoJSBounds): IScalebarSpec {
+  const datasetPixelWidth = bbox.right - bbox.left;
+  const { settings, lengthInPixels } = computeScalebarForBbox(
+    datasetPixelWidth,
+    pixelSize.value,
+    scalebarMode.value,
+    manualScalebarSettings.value,
+  );
+  return {
+    lengthInDatasetPixels: lengthInPixels,
+    datasetPixelWidth,
+    label: `${settings.length}${settings.unit}`,
+  };
 }
 
 function prettyScalebarSettings(settings: IScalebarSettings): string {
@@ -1630,7 +1720,12 @@ async function snapshotWithAnnotations() {
   ctx.drawImage(img, topLeft.x, topLeft.y, width, height, 0, 0, width, height);
 
   if (addScalebar.value) {
-    drawScalebarOnCanvas(ctx, canvas.width, canvas.height);
+    drawScalebarOnCanvas(
+      ctx,
+      canvas.width,
+      canvas.height,
+      currentScalebarSpec.value,
+    );
   }
 
   const croppedScreenshot = canvas.toDataURL("image/png");
@@ -1674,7 +1769,10 @@ async function downloadImagesForCurrentState() {
     if (!urls) {
       return;
     }
-    await downloadUrls(urls, addScalebar.value);
+    const scalebarSpec = addScalebar.value
+      ? buildScalebarSpec(boundingBox)
+      : null;
+    await downloadUrls(urls.map((url) => ({ url, scalebarSpec })));
   } finally {
     downloading.value = false;
   }
@@ -1712,7 +1810,7 @@ async function downloadImagesForSetOfSnapshots(snapshots: ISnapshot[]) {
       return;
     }
 
-    const allUrls: URL[] = [];
+    const allUrls: IDownloadUrlItem[] = [];
     const totalSnapshots = snapshots.length;
 
     for (let i = 0; i < totalSnapshots; i++) {
@@ -1737,7 +1835,12 @@ async function downloadImagesForSetOfSnapshots(snapshots: ISnapshot[]) {
         configuration.name,
       );
       if (currentUrls) {
-        allUrls.push(...currentUrls);
+        // Each snapshot has its own bounding box, so resolve the scalebar per
+        // snapshot rather than reusing the current view's.
+        const scalebarSpec = addScalebar.value
+          ? buildScalebarSpec(snapshot.screenshot.bbox)
+          : null;
+        allUrls.push(...currentUrls.map((url) => ({ url, scalebarSpec })));
       }
     }
 
@@ -1748,7 +1851,7 @@ async function downloadImagesForSetOfSnapshots(snapshots: ISnapshot[]) {
       title: "Downloading files...",
     });
 
-    await downloadUrls(allUrls, addScalebar.value);
+    await downloadUrls(allUrls);
   } finally {
     progress.complete(progressId);
     downloading.value = false;
@@ -1838,6 +1941,7 @@ async function getUrlsForSnapshot(
 
 async function addScalebarToImageBuffer(
   data: ArrayBuffer,
+  spec: IScalebarSpec,
 ): Promise<ArrayBuffer> {
   const blob = new Blob([data], { type: "image/png" });
   const imageUrl = URL.createObjectURL(blob);
@@ -1857,7 +1961,7 @@ async function addScalebarToImageBuffer(
 
   ctx.drawImage(img, 0, 0);
 
-  drawScalebarOnCanvas(ctx, canvas.width, canvas.height);
+  drawScalebarOnCanvas(ctx, canvas.width, canvas.height, spec);
 
   URL.revokeObjectURL(imageUrl);
 
@@ -1867,29 +1971,32 @@ async function addScalebarToImageBuffer(
   return await annotatedBlob.arrayBuffer();
 }
 
-async function downloadUrls(urls: URL[], withScalebar: boolean = false) {
+// Each URL carries its own scalebar spec (or null for no scalebar) so that a
+// batch of snapshots with different bounding boxes each gets a correctly sized
+// bar rather than the current view's.
+async function downloadUrls(urls: IDownloadUrlItem[]) {
   if (urls.length <= 0) {
     return;
   }
 
   if (urls.length === 1) {
-    if (withScalebar) {
-      const { data } = await store.girderRest.get(urls[0].href, {
+    const { url, scalebarSpec } = urls[0];
+    if (scalebarSpec) {
+      const { data } = await store.girderRest.get(url.href, {
         responseType: "arraybuffer",
       });
-      const processedData = await addScalebarToImageBuffer(data);
+      const processedData = await addScalebarToImageBuffer(data, scalebarSpec);
       const blob = new Blob([processedData], { type: "image/png" });
-      const url = URL.createObjectURL(blob);
+      const objectUrl = URL.createObjectURL(blob);
       const filename =
-        urls[0].searchParams.get("contentDispositionFilename") ||
-        "snapshot.png";
+        url.searchParams.get("contentDispositionFilename") || "snapshot.png";
       downloadToClient({
-        href: url,
+        href: objectUrl,
         download: filename,
       });
-      URL.revokeObjectURL(url);
+      URL.revokeObjectURL(objectUrl);
     } else {
-      downloadToClient({ href: urls[0].href });
+      downloadToClient({ href: url.href });
     }
     return;
   }
@@ -1913,13 +2020,13 @@ async function downloadUrls(urls: URL[], withScalebar: boolean = false) {
     level: ["jpeg", "png"].includes(format.value) ? 0 : 9,
   };
   const filenames: Set<string> = new Set();
-  const filesPushed = urls.map(async (url) => {
+  const filesPushed = urls.map(async ({ url, scalebarSpec }) => {
     const { data } = await store.girderRest.get(url.href, {
       responseType: "arraybuffer",
     });
 
-    const finalData = withScalebar
-      ? await addScalebarToImageBuffer(data)
+    const finalData = scalebarSpec
+      ? await addScalebarToImageBuffer(data, scalebarSpec)
       : data;
 
     const baseFullFilename =
@@ -2116,7 +2223,7 @@ async function getUrlsForMovieWithAnnotations(
       );
 
       if (addScalebar.value) {
-        drawScalebarOnCanvas(ctx, width, height);
+        drawScalebarOnCanvas(ctx, width, height, currentScalebarSpec.value);
       }
 
       const dataUrl = canvas.toDataURL("image/png");
@@ -2265,7 +2372,12 @@ async function downloadMovieAsZippedImageSequence(
         ctx.drawImage(img, 0, 0);
 
         if (addScalebar.value) {
-          drawScalebarOnCanvas(ctx, canvas.width, canvas.height);
+          drawScalebarOnCanvas(
+            ctx,
+            canvas.width,
+            canvas.height,
+            currentScalebarSpec.value,
+          );
         }
 
         URL.revokeObjectURL(imageUrl);
@@ -2374,7 +2486,12 @@ async function downloadMovieAsGif(
             ctx.drawImage(img, 0, 0);
 
             if (addScalebar.value) {
-              drawScalebarOnCanvas(ctx, canvas.width, canvas.height);
+              drawScalebarOnCanvas(
+                ctx,
+                canvas.width,
+                canvas.height,
+                currentScalebarSpec.value,
+              );
             }
 
             if (params.shouldAddTimeStamp) {
@@ -2548,7 +2665,12 @@ async function downloadMovieAsVideo(
       });
 
       if (addScalebar.value) {
-        drawScalebarOnCanvas(ctx, canvas.width, canvas.height);
+        drawScalebarOnCanvas(
+          ctx,
+          canvas.width,
+          canvas.height,
+          currentScalebarSpec.value,
+        );
       }
 
       if (params.shouldAddTimeStamp) {
@@ -2615,20 +2737,19 @@ function drawScalebarOnCanvas(
   ctx: CanvasRenderingContext2D,
   width: number,
   height: number,
+  spec: IScalebarSpec,
 ) {
-  // `scalebarLengthInPixels` is expressed in dataset pixels (it is derived from
-  // the bounding-box width `bboxRight - bboxLeft`). The canvas we draw onto is
-  // rarely 1:1 with dataset pixels though: region downloads are downsampled to
-  // stay under `maxPixels`, and screenshot-based canvases are in display
-  // (screen) pixels. Both span the same horizontal extent as the bounding box,
-  // so convert dataset pixels to canvas pixels using that ratio. Without this
-  // the on-screen scalebar (drawn by GeoJS in image coordinates) and the
-  // downloaded scalebar disagree whenever the canvas isn't at native scale.
-  const datasetPixelWidth = bboxRight.value - bboxLeft.value;
+  // The scalebar length in `spec` is in dataset pixels. The canvas we draw onto
+  // is rarely 1:1 with dataset pixels: region downloads are downsampled to stay
+  // under `maxPixels`, and screenshot-based canvases are in display (screen)
+  // pixels. Both span the same horizontal extent as the bounding box, so
+  // convert dataset pixels to canvas pixels using that ratio. Without this the
+  // on-screen scalebar (drawn by GeoJS in image coordinates) and the downloaded
+  // scalebar disagree whenever the canvas isn't at native scale.
   const canvasPixelsPerDatasetPixel =
-    datasetPixelWidth > 0 ? width / datasetPixelWidth : 1;
+    spec.datasetPixelWidth > 0 ? width / spec.datasetPixelWidth : 1;
   const scalebarLength =
-    scalebarLengthInPixels.value * canvasPixelsPerDatasetPixel;
+    spec.lengthInDatasetPixels * canvasPixelsPerDatasetPixel;
   const maxDim = Math.max(width, height);
 
   const padding = Math.max(10, Math.min(40, 0.02 * maxDim));
@@ -2648,11 +2769,7 @@ function drawScalebarOnCanvas(
     ctx.font = `${fontSize}px Arial`;
     ctx.textBaseline = "bottom";
     ctx.textAlign = "right";
-    ctx.fillText(
-      `${scalebarSettings.value.length}${scalebarSettings.value.unit}`,
-      width - padding,
-      height - padding - lineWidth,
-    );
+    ctx.fillText(spec.label, width - padding, height - padding - lineWidth);
   }
 }
 
@@ -2759,6 +2876,7 @@ defineExpose({
   idealScalebarLength,
   scalebarSettings,
   scalebarLengthInPixels,
+  currentScalebarSpec,
   snapshotList,
   currentSnapshot,
   pixelSizeUnitItems,
@@ -2769,6 +2887,9 @@ defineExpose({
   convertLengthToMeters,
   convertMetersToLength,
   guessIdealScalebar,
+  idealScalebarForBbox,
+  computeScalebarForBbox,
+  buildScalebarSpec,
   prettyScalebarSettings,
   handlePixelSizeModeChange,
   handleScalebarModeChange,

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -925,10 +925,6 @@ const currentScalebar = computed(() =>
   ),
 );
 
-const idealScalebarLength = computed(() =>
-  idealScalebarForBbox(bboxRight.value - bboxLeft.value, pixelSize.value),
-);
-
 const scalebarSettings = computed(
   (): IScalebarSettings => currentScalebar.value.settings,
 );
@@ -2873,7 +2869,6 @@ defineExpose({
   formattedConfigurationPixelSize,
   formattedScalebarSettings,
   pixelSize,
-  idealScalebarLength,
   scalebarSettings,
   scalebarLengthInPixels,
   currentScalebarSpec,

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -916,6 +916,17 @@ const pixelSize = computed((): IScalebarSettings => {
   return configurationPixelSize.value;
 });
 
+// The current view's bounding box assembled from the bbox refs. Used wherever a
+// download/screenshot/movie operates on the current view rather than a snapshot.
+const currentBbox = computed(
+  (): IGeoJSBounds => ({
+    left: bboxLeft.value,
+    top: bboxTop.value,
+    right: bboxRight.value,
+    bottom: bboxBottom.value,
+  }),
+);
+
 const currentScalebar = computed(() =>
   computeScalebarForBbox(
     bboxRight.value - bboxLeft.value,
@@ -936,13 +947,7 @@ const scalebarLengthInPixels = computed(
 // Spec for drawing the scalebar onto the current view's downloads (viewport
 // screenshots and movies always operate on the current bounding box).
 const currentScalebarSpec = computed(
-  (): IScalebarSpec =>
-    buildScalebarSpec({
-      left: bboxLeft.value,
-      top: bboxTop.value,
-      right: bboxRight.value,
-      bottom: bboxBottom.value,
-    }),
+  (): IScalebarSpec => buildScalebarSpec(currentBbox.value),
 );
 
 const snapshotList = computed(() => {
@@ -1624,12 +1629,7 @@ function saveSnapshot(): void {
     layerMode: store.layerMode,
     layers: store.layers.map(copyLayerWithoutPrivateAttributes),
     screenshot: {
-      bbox: {
-        left: bboxLeft.value,
-        top: bboxTop.value,
-        right: bboxRight.value,
-        bottom: bboxBottom.value,
-      },
+      bbox: { ...currentBbox.value },
     },
   };
   resetAndCloseForm();
@@ -1739,12 +1739,7 @@ async function downloadImagesForCurrentState() {
     return;
   }
   const location = store.currentLocation;
-  const boundingBox = {
-    left: bboxLeft.value,
-    top: bboxTop.value,
-    right: bboxRight.value,
-    bottom: bboxBottom.value,
-  };
+  const boundingBox = currentBbox.value;
 
   downloading.value = true;
 
@@ -1765,9 +1760,7 @@ async function downloadImagesForCurrentState() {
     if (!urls) {
       return;
     }
-    const scalebarSpec = addScalebar.value
-      ? buildScalebarSpec(boundingBox)
-      : null;
+    const scalebarSpec = addScalebar.value ? currentScalebarSpec.value : null;
     await downloadUrls(urls.map((url) => ({ url, scalebarSpec })));
   } finally {
     downloading.value = false;
@@ -2257,12 +2250,7 @@ async function handleMovieDownload(params: any) {
       urls = await getUrlsForMovie(
         timePoints,
         dataset.id,
-        {
-          left: bboxLeft.value,
-          top: bboxTop.value,
-          right: bboxRight.value,
-          bottom: bboxBottom.value,
-        },
+        currentBbox.value,
         store.layers,
         store.currentLocation,
       );


### PR DESCRIPTION
## Problem

Scalebars on **downloaded** snapshots were the wrong length, even though the on-screen scalebar was accurate. The on-screen bar is drawn by GeoJS using image-coordinate vertices, so it stays correct at any zoom. The download path, however, assembles the image + scalebar on an offscreen canvas and drew the scalebar length (`scalebarLengthInPixels`, a **dataset-pixel** length) directly onto the canvas, assuming 1 canvas pixel == 1 dataset pixel.

That assumption breaks in three common cases:

1. **Region/URL downloads** are downsampled when the region exceeds `maxPixels` (4M) — `getDownloadParameters` scales the image by `sqrt(maxPixels / nPixels)` — so the canvas is smaller than the dataset-pixel region and the bar came out too long.
2. **Screenshot-based canvases** (viewport screenshot, movies with annotations) are sized in display/screen pixels, so the bar was off by the zoom factor.
3. **Batch snapshot downloads** ("download all/selected") fetched each snapshot with its own bounding box but drew the scalebar from the component's current reactive state, so every image in the batch inherited the current view's scalebar instead of one sized for that snapshot.

## Fix

- Convert the scalebar length from dataset pixels to canvas pixels using the ratio of canvas width to the bounding-box dataset-pixel width (the same extent the length is derived from). This single conversion corrects all three cases.
- Extract the scalebar math into a pure `computeScalebarForBbox(bboxWidth, pixelSize, mode, manual)` — now the single source of truth that the current-view reactive computeds delegate to (removing previously-duplicated logic).
- Add `IScalebarSpec` (length in dataset px, bounding-box dataset-px width, label) and `buildScalebarSpec(bbox)`. `drawScalebarOnCanvas` and `addScalebarToImageBuffer` now take an explicit spec instead of reading reactive globals, and `downloadUrls` carries a per-URL spec so each snapshot in a batch is drawn with its own. Current-view paths (viewport screenshot, movies) pass `currentScalebarSpec`.
- Pixel size and scalebar mode/manual settings remain global (they're configuration-/UI-level choices that apply to the whole download); only the per-snapshot bounding box varies.

## Tests

- New unit tests for `buildScalebarSpec` producing per-bbox specs (automatic lengths differ by bbox; manual length fixed but width tracked) and for spec-driven canvas drawing (native / downsampled / zoomed / zero-width, plus per-spec label).
- `pnpm tsc`, `pnpm lint` clean; 151 Snapshots tests pass.

https://claude.ai/code/session_014nateGk9h3bimGJZc54eVb

---
_Generated by [Claude Code](https://claude.ai/code/session_014nateGk9h3bimGJZc54eVb)_