### PR TITLE
Sanitize snapshot zip entries to prevent nested folders

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"dd452c21-d7c4-4767-a9ee-015bed04dc89","pid":72577,"procStart":"Sun May 24 16:57:25 2026","acquiredAt":1779960193879}

--- a/src/components/Snapshots.test.ts
+++ b/src/components/Snapshots.test.ts
@@ -141,11 +141,18 @@ vi.mock("gif.js", () => ({
 }));
 
 vi.mock("fflate", () => ({
-  Zip: vi.fn().mockImplementation(() => ({
-    add: vi.fn(),
-    end: vi.fn(),
-    ondata: null,
-  })),
+  Zip: vi.fn().mockImplementation(() => {
+    const zip = {
+      add: vi.fn(),
+      end: vi.fn(() => {
+        zip.ondata?.(null, new Uint8Array([1]), true);
+      }),
+      ondata: null as
+        | ((err: Error | null, data: Uint8Array, final: boolean) => void)
+        | null,
+    };
+    return zip;
+  }),
   ZipDeflate: vi.fn().mockImplementation(() => ({
     push: vi.fn(),
   })),
@@ -198,6 +205,7 @@ import {
   getLayersDownloadUrls,
 } from "@/utils/screenshot";
 import { downloadToClient } from "@/utils/download";
+import { ZipDeflate } from "fflate";
 import { logError } from "@/utils/log";
 import progress from "@/store/progress";
 import girderResources from "@/store/girderResources";
@@ -213,6 +221,7 @@ const mockedGetDownloadParameters = vi.mocked(getDownloadParameters);
 const mockedGetChannelsDownloadUrls = vi.mocked(getChannelsDownloadUrls);
 const mockedGetLayersDownloadUrls = vi.mocked(getLayersDownloadUrls);
 const mockedDownloadToClient = vi.mocked(downloadToClient);
+const mockedZipDeflate = vi.mocked(ZipDeflate);
 const mockedLogError = vi.mocked(logError);
 const mockedProgress = vi.mocked(progress);
 const mockedGirderResources = vi.mocked(girderResources);
@@ -1453,6 +1462,43 @@ describe("Snapshots.vue", () => {
       await (wrapper.vm as any).downloadUrls([url], false);
       expect(mockedDownloadToClient).toHaveBeenCalledWith({
         href: url.href,
+      });
+    });
+
+    it("downloadUrls sanitizes zip entry filenames", async () => {
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => "blob:snapshot"),
+      });
+      (store.girderRest.get as any)
+        .mockResolvedValueOnce({ data: new ArrayBuffer(1) })
+        .mockResolvedValueOnce({ data: new ArrayBuffer(1) });
+
+      const first = new URL("http://localhost/api/v1/first");
+      first.searchParams.set(
+        "contentDispositionFilename",
+        "snap2 - c:1/3 t:1/145.png",
+      );
+      const second = new URL("http://localhost/api/v1/second");
+      second.searchParams.set(
+        "contentDispositionFilename",
+        "snap2 - c_1_3 t_1_145.png",
+      );
+
+      await (wrapper.vm as any).downloadUrls([first, second], false);
+
+      expect(mockedZipDeflate).toHaveBeenNthCalledWith(
+        1,
+        "snap2 - c_1_3 t_1_145.png",
+        expect.any(Object),
+      );
+      expect(mockedZipDeflate).toHaveBeenNthCalledWith(
+        2,
+        "snap2 - c_1_3 t_1_145 (1).png",
+        expect.any(Object),
+      );
+      expect(mockedDownloadToClient).toHaveBeenCalledWith({
+        href: "blob:snapshot",
+        download: "snapshot.zip",
       });
     });
 

--- a/src/components/Snapshots.test.ts
+++ b/src/components/Snapshots.test.ts
@@ -1502,6 +1502,66 @@ describe("Snapshots.vue", () => {
       });
     });
 
+    it("downloadUrls assigns sanitized duplicate zip filenames in input order", async () => {
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => "blob:snapshot"),
+      });
+
+      let resolveFirst: ((value: { data: ArrayBuffer }) => void) | undefined;
+      let resolveSecond: ((value: { data: ArrayBuffer }) => void) | undefined;
+      const firstResponse = new Promise<{ data: ArrayBuffer }>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const secondResponse = new Promise<{ data: ArrayBuffer }>((resolve) => {
+        resolveSecond = resolve;
+      });
+
+      (store.girderRest.get as any).mockImplementation((href: string) =>
+        href.includes("first") ? firstResponse : secondResponse,
+      );
+
+      const first = new URL("http://localhost/api/v1/first");
+      first.searchParams.set(
+        "contentDispositionFilename",
+        "snap2 - c:1/3 t:1/145.png",
+      );
+      const second = new URL("http://localhost/api/v1/second");
+      second.searchParams.set(
+        "contentDispositionFilename",
+        "snap2 - c_1_3 t_1_145.png",
+      );
+
+      const downloadPromise = (wrapper.vm as any).downloadUrls(
+        [first, second],
+        false,
+      );
+
+      resolveSecond?.({ data: new Uint8Array([2]).buffer });
+      await Promise.resolve();
+      resolveFirst?.({ data: new Uint8Array([1]).buffer });
+      await downloadPromise;
+      (store.girderRest.get as any).mockReset();
+
+      const pushedDataByFileName = new Map(
+        mockedZipDeflate.mock.calls.map(([fileName], index) => {
+          const zipFile = mockedZipDeflate.mock.results[index].value as {
+            push: ReturnType<typeof vi.fn>;
+          };
+          return [
+            fileName,
+            Array.from(zipFile.push.mock.calls[0][0] as Uint8Array),
+          ];
+        }),
+      );
+
+      expect(pushedDataByFileName.get("snap2 - c_1_3 t_1_145.png")).toEqual([
+        1,
+      ]);
+      expect(pushedDataByFileName.get("snap2 - c_1_3 t_1_145 (1).png")).toEqual(
+        [2],
+      );
+    });
+
     it("downloadUrls does nothing for empty array", async () => {
       await (wrapper.vm as any).downloadUrls([], false);
       expect(mockedDownloadToClient).not.toHaveBeenCalled();

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -748,6 +748,27 @@ const maxPixels = 4_000_000;
 
 const nameRules = [(name: string) => !!name.trim() || "Name is required"];
 
+function sanitizeSnapshotFilename(name: string | null): string {
+  const sanitized = (name || "snapshot")
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, "_")
+    .trim();
+  return sanitized || "snapshot";
+}
+
+function getUniqueZipEntryName(name: string | null, filenames: Set<string>) {
+  const sanitizedName = sanitizeSnapshotFilename(name);
+  const pointIdx = sanitizedName.lastIndexOf(".");
+  const baseName =
+    pointIdx > 0 ? sanitizedName.slice(0, pointIdx) : sanitizedName;
+  const extension = pointIdx > 0 ? sanitizedName.slice(pointIdx) : "";
+  let fileName = sanitizedName;
+  for (let counter = 1; filenames.has(fileName); counter++) {
+    fileName = `${baseName} (${counter})${extension}`;
+  }
+  filenames.add(fileName);
+  return fileName;
+}
+
 // --- Computed properties ---
 
 const isLoggedIn = computed(() => store.isLoggedIn);
@@ -1885,7 +1906,7 @@ async function downloadUrls(urls: URL[], withScalebar: boolean = false) {
         "snapshot.png";
       downloadToClient({
         href: url,
-        download: filename,
+        download: sanitizeSnapshotFilename(filename),
       });
       URL.revokeObjectURL(url);
     } else {
@@ -1924,14 +1945,7 @@ async function downloadUrls(urls: URL[], withScalebar: boolean = false) {
 
     const baseFullFilename =
       url.searchParams.get("contentDispositionFilename") || "snapshot";
-    let fileName = baseFullFilename;
-    let pointIdx = Math.max(baseFullFilename.lastIndexOf("."), 0);
-    const baseName = baseFullFilename.slice(0, pointIdx);
-    const extension = baseFullFilename.slice(pointIdx);
-    for (let counter = 1; filenames.has(fileName); counter++) {
-      fileName = baseName + " (" + counter + ")" + extension;
-    }
-    filenames.add(fileName);
+    const fileName = getUniqueZipEntryName(baseFullFilename, filenames);
     const zipFile = new ZipDeflate(fileName, deflateOptions);
     zip.add(zipFile);
     zipFile.push(new Uint8Array(finalData), true);
@@ -2752,6 +2766,8 @@ defineExpose({
   pixelSizeUnitItems,
   scalebarSettingsUnitItems,
   // Functions
+  sanitizeSnapshotFilename,
+  getUniqueZipEntryName,
   isRotated,
   unitLengthToScalebarUnit,
   convertLengthToMeters,

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -1934,7 +1934,14 @@ async function downloadUrls(urls: URL[], withScalebar: boolean = false) {
     level: ["jpeg", "png"].includes(format.value) ? 0 : 9,
   };
   const filenames: Set<string> = new Set();
-  const filesPushed = urls.map(async (url) => {
+  const zipEntries = urls.map((url) => ({
+    url,
+    fileName: getUniqueZipEntryName(
+      url.searchParams.get("contentDispositionFilename") || "snapshot",
+      filenames,
+    ),
+  }));
+  const filesPushed = zipEntries.map(async ({ url, fileName }) => {
     const { data } = await store.girderRest.get(url.href, {
       responseType: "arraybuffer",
     });
@@ -1943,9 +1950,6 @@ async function downloadUrls(urls: URL[], withScalebar: boolean = false) {
       ? await addScalebarToImageBuffer(data)
       : data;
 
-    const baseFullFilename =
-      url.searchParams.get("contentDispositionFilename") || "snapshot";
-    const fileName = getUniqueZipEntryName(baseFullFilename, filenames);
     const zipFile = new ZipDeflate(fileName, deflateOptions);
     zip.add(zipFile);
     zipFile.push(new Uint8Array(finalData), true);


### PR DESCRIPTION
## Summary
- Sanitize snapshot download filenames before adding them to zip archives so `/` and other path-unsafe characters cannot create nested folders.
- Keep zip-entry deduplication after sanitization so collisions still get stable numeric suffixes.
- Add a focused unit test covering a channel name that would otherwise collapse into the same flattened filename.

## Testing
- `Snapshots.test.ts` unit coverage passes for the new zip filename behavior.
- Existing snapshot download tests still pass with the updated `fflate` mock.