### PR TITLE
[codex] Fix stale snapshot selections

### DIFF
--- a/src/components/Snapshots.test.ts
+++ b/src/components/Snapshots.test.ts
@@ -353,6 +353,14 @@ describe("Snapshots.vue", () => {
       expect((wrapper.vm as any).selectedSnapshotItems).toEqual([]);
     });
 
+    it("clearSelectedSnapshotItems clears the table selection", () => {
+      (wrapper.vm as any).selectedSnapshotItems = [
+        { name: "Snap", datasetName: "", key: "view1:Snap", record: {} },
+      ];
+      (wrapper.vm as any).clearSelectedSnapshotItems();
+      expect((wrapper.vm as any).selectedSnapshotItems).toEqual([]);
+    });
+
     it("has correct maxPixels constant", () => {
       expect((wrapper.vm as any).maxPixels).toBe(4_000_000);
     });
@@ -827,6 +835,7 @@ describe("Snapshots.vue", () => {
       const list = (w.vm as any).snapshotList;
       expect(list).toHaveLength(2);
       expect(list[0].name).toBeDefined();
+      expect(list[0].key).toContain(":");
       expect(list[0].record).toBeDefined();
       expect(list[0].modified).toBeDefined();
     });
@@ -901,6 +910,57 @@ describe("Snapshots.vue", () => {
       (store as any).configuration = null;
       const w = mountComponent();
       expect((w.vm as any).currentSnapshot).toBeUndefined();
+    });
+
+    it("selectedSnapshots ignores stale items from another configuration", () => {
+      const current = makeSnapshot("Current", { datasetViewId: "view1" });
+      const stale = makeSnapshot("Stale", { datasetViewId: "staleView" });
+      (store as any).configuration.snapshots = [current];
+      const w = mountComponent();
+
+      (w.vm as any).selectedSnapshotItems = [
+        {
+          name: stale.name,
+          datasetName: "Old dataset",
+          key: `${stale.datasetViewId}:${stale.name}`,
+          record: stale,
+          modified: "2026-01-01",
+        },
+        {
+          name: current.name,
+          datasetName: "Current dataset",
+          key: `${current.datasetViewId}:${current.name}`,
+          record: current,
+          modified: "2026-01-01",
+        },
+      ];
+
+      expect((w.vm as any).selectedSnapshots).toEqual([current]);
+    });
+
+    it("selectedSnapshots resolves selected rows to current snapshot records", () => {
+      const current = makeSnapshot("SharedName", {
+        datasetViewId: "view1",
+        modified: 3000,
+      });
+      const staleSameKey = makeSnapshot("SharedName", {
+        datasetViewId: "view1",
+        modified: 1000,
+      });
+      (store as any).configuration.snapshots = [current];
+      const w = mountComponent();
+
+      (w.vm as any).selectedSnapshotItems = [
+        {
+          name: staleSameKey.name,
+          datasetName: "Current dataset",
+          key: `${staleSameKey.datasetViewId}:${staleSameKey.name}`,
+          record: staleSameKey,
+          modified: "2026-01-01",
+        },
+      ];
+
+      expect((w.vm as any).selectedSnapshots).toEqual([current]);
     });
 
     it("saveSnapshot calls store.addSnapshot with correct data", () => {
@@ -1508,6 +1568,65 @@ describe("Snapshots.vue", () => {
         layers: [],
         scales: { pixelSize: { value: 0.5, unit: "µm" } },
       };
+    });
+
+    it("downloadImagesForSelectedSnapshots ignores stale selected rows", async () => {
+      const makeDownloadSnapshot = (name: string, datasetViewId: string) => ({
+        name,
+        description: "",
+        tags: [],
+        created: 1000,
+        modified: 2000,
+        datasetViewId,
+        viewport: {
+          tl: { x: 0, y: 0 },
+          tr: { x: 100, y: 0 },
+          bl: { x: 0, y: 100 },
+          br: { x: 100, y: 100 },
+        },
+        rotation: 0,
+        unrollXY: false,
+        unrollZ: false,
+        unrollT: false,
+        xy: 0,
+        z: 0,
+        time: 0,
+        layerMode: "multiple",
+        layers: (store as any).layers,
+        screenshot: { bbox: { left: 0, top: 0, right: 100, bottom: 100 } },
+      });
+      const current = makeDownloadSnapshot("Current", "view1");
+      const stale = makeDownloadSnapshot("Stale", "staleView");
+      (store as any).configuration = {
+        name: "Test Config",
+        snapshots: [current],
+        layers: [],
+        scales: { pixelSize: { value: 0.5, unit: "µm" } },
+      };
+      const w = mountComponent();
+      (w.vm as any).addScalebar = false;
+      (w.vm as any).selectedSnapshotItems = [
+        {
+          name: stale.name,
+          datasetName: "Old dataset",
+          key: `${stale.datasetViewId}:${stale.name}`,
+          record: stale,
+          modified: "2026-01-01",
+        },
+        {
+          name: current.name,
+          datasetName: "Current dataset",
+          key: `${current.datasetViewId}:${current.name}`,
+          record: current,
+          modified: "2026-01-01",
+        },
+      ];
+      (store as any).api.getDatasetView.mockClear();
+
+      await (w.vm as any).downloadImagesForSelectedSnapshots();
+
+      expect((store as any).api.getDatasetView).toHaveBeenCalledTimes(1);
+      expect((store as any).api.getDatasetView).toHaveBeenCalledWith("view1");
     });
 
     it("screenshotViewport returns when no map", async () => {

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -459,9 +459,7 @@
             color="primary"
             size="small"
             @click="downloadImagesForSelectedSnapshots()"
-            :disabled="
-              unroll || downloading || selectedSnapshotItems.length === 0
-            "
+            :disabled="unroll || downloading || selectedSnapshots.length === 0"
           >
             Download images for selected Snapshots
           </v-btn>
@@ -625,6 +623,10 @@ interface ISnapshotItem {
   modified: string;
 }
 
+function snapshotKey(snapshot: ISnapshot) {
+  return `${snapshot.datasetViewId}:${snapshot.name}`;
+}
+
 function intFromString(value: string) {
   const parsedValue = parseInt("0" + value, 10);
   return Number.isNaN(parsedValue) ? 0 : parsedValue;
@@ -716,6 +718,14 @@ const manualPixelSize = ref<IScalebarSettings | null>(null);
 const addAnnotationsToMovie = ref(false);
 const pixelSizeMode = ref<PixelSizeMode>(PixelSizeMode.DATASET);
 const scalebarMode = ref<ScalebarMode>(ScalebarMode.AUTOMATIC);
+
+const snapshotSelectionScope = computed(() =>
+  [
+    store.datasetView?.datasetId || store.dataset?.id || "",
+    store.datasetView?.configurationId || store.configuration?.id || "",
+  ].join(":"),
+);
+const selectedSnapshotItemsScope = ref(snapshotSelectionScope.value);
 
 // --- Constants ---
 
@@ -954,7 +964,7 @@ const snapshotList = computed(() => {
         const item = {
           name: s.name,
           datasetName: "",
-          key: s.name,
+          key: snapshotKey(s),
           record: s,
           modified: formatDate(new Date(s.modified || s.created)),
         };
@@ -986,6 +996,21 @@ const currentSnapshot = computed((): { [key: string]: any } | undefined => {
       .filter((s: ISnapshot) => s.name === newName.value)[0];
   }
   return undefined;
+});
+
+const selectedSnapshots = computed((): ISnapshot[] => {
+  if (selectedSnapshotItemsScope.value !== snapshotSelectionScope.value) {
+    return [];
+  }
+  const currentSnapshotsByKey = new Map(
+    (store.configuration?.snapshots || []).map((snapshot) => [
+      snapshotKey(snapshot),
+      snapshot,
+    ]),
+  );
+  return selectedSnapshotItems.value
+    .map((item) => currentSnapshotsByKey.get(snapshotKey(item.record)))
+    .filter((snapshot): snapshot is ISnapshot => !!snapshot);
 });
 
 const pixelSizeUnitItems = computed(() => {
@@ -1558,6 +1583,10 @@ function resetAndCloseForm() {
   resetFormValidation();
 }
 
+function clearSelectedSnapshotItems() {
+  selectedSnapshotItems.value = [];
+}
+
 function removeSnapshot(name: string): void {
   store.removeSnapshot(name);
 }
@@ -1694,7 +1723,10 @@ async function downloadImagesForSelectedSnapshots() {
   if (!configuration) {
     return;
   }
-  const selected = selectedSnapshotItems.value.map((s) => s.record);
+  const selected = selectedSnapshots.value;
+  if (selected.length === 0) {
+    return;
+  }
   await downloadImagesForSetOfSnapshots(selected);
 }
 
@@ -2683,6 +2715,14 @@ watch(snapshotScalebarColor, () => {
   }
 });
 
+watch(selectedSnapshotItems, () => {
+  selectedSnapshotItemsScope.value = snapshotSelectionScope.value;
+});
+
+watch(snapshotSelectionScope, () => {
+  clearSelectedSnapshotItems();
+});
+
 // --- Expose ---
 
 defineExpose({
@@ -2749,6 +2789,8 @@ defineExpose({
   scalebarLengthInPixels,
   snapshotList,
   currentSnapshot,
+  selectedSnapshots,
+  snapshotSelectionScope,
   pixelSizeUnitItems,
   scalebarSettingsUnitItems,
   // Functions
@@ -2777,6 +2819,7 @@ defineExpose({
   resetFormValidation,
   saveSnapshot,
   resetAndCloseForm,
+  clearSelectedSnapshotItems,
   removeSnapshot,
   screenshotViewport,
   snapshotWithAnnotations,


### PR DESCRIPTION
## Summary

Fixes stale selected snapshot rows carrying across dataset/configuration switches in the Snapshots panel.

## Root Cause

The snapshot table selection lived in local component state and was not scoped to the active dataset/configuration. After switching datasets, the visible snapshot list could refresh while `selectedSnapshotItems` still contained row objects from the previous dataset, so "Download images for selected Snapshots" could include stale snapshots until a hard refresh cleared component state.

## Changes

- Scope selected snapshot rows to the active dataset/configuration and clear them when that scope changes.
- Resolve selected rows back to current configuration snapshot records before downloading.
- Use dataset-view-qualified snapshot keys so table selection identity is not just the snapshot name.
- Add regression tests for clearing selection, ignoring stale rows, resolving current records, and selected downloads.

## Validation

- `pnpm vitest run src/components/Snapshots.test.ts --silent` (`147` tests passed; sandbox still logs Vite websocket `EPERM` warning)
- `pnpm tsc`
- `pnpm eslint src/components/Snapshots.vue src/components/Snapshots.test.ts`