### PR TITLE
Fix duplicate filename for "Download image with annotations"

### DIFF
--- a/src/components/Snapshots.test.ts
+++ b/src/components/Snapshots.test.ts
@@ -1787,6 +1787,53 @@ describe("Snapshots.vue", () => {
 
       (store as any).maps = [];
     });
+
+    it("snapshotWithAnnotations downloads cropped image with distinct filename", async () => {
+      const mockMap = {
+        gcsToDisplay: vi.fn((pt: any) => ({ x: pt.x, y: pt.y })),
+        screenshot: vi.fn().mockResolvedValue("data:image/png;base64,full"),
+        layers: vi.fn(() => []),
+      };
+      (store as any).maps = [{ map: mockMap }];
+
+      // jsdom has no canvas/image backend, so stub the 2D context, the
+      // serialization, and the Image load that snapshotWithAnnotations relies on.
+      const mockCtx = { drawImage: vi.fn() };
+      const getContextSpy = vi
+        .spyOn(HTMLCanvasElement.prototype, "getContext")
+        .mockReturnValue(mockCtx as any);
+      const toDataURLSpy = vi
+        .spyOn(HTMLCanvasElement.prototype, "toDataURL")
+        .mockReturnValue("data:image/png;base64,cropped");
+
+      class MockImage {
+        onload: (() => void) | null = null;
+        set src(_value: string) {
+          // Fire onload on the next tick, after the caller assigns it.
+          setTimeout(() => this.onload?.(), 0);
+        }
+      }
+      vi.stubGlobal("Image", MockImage);
+
+      const w = mountComponent();
+      (w.vm as any).addScalebar = false;
+
+      await (w.vm as any).snapshotWithAnnotations();
+
+      expect(mockMap.screenshot).toHaveBeenCalled();
+      expect(mockedDownloadToClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          href: "data:image/png;base64,cropped",
+          download: "image_with_annotations.png",
+        }),
+      );
+
+      // The suite uses clearAllMocks (not restoreAllMocks), so undo spies/stubs.
+      getContextSpy.mockRestore();
+      toDataURLSpy.mockRestore();
+      vi.unstubAllGlobals();
+      (store as any).maps = [];
+    });
   });
 
   // =========================================================================

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -1812,7 +1812,7 @@ async function snapshotWithAnnotations() {
 
   const params = {
     href: croppedScreenshot,
-    download: "viewport_screenshot.png",
+    download: "image_with_annotations.png",
   };
   downloadToClient(params);
 }


### PR DESCRIPTION
## Summary

The **Download image with annotations** button downloaded its cropped, annotated screenshot using the filename `viewport_screenshot.png` — identical to the default used by the **Download Screenshot of Current Viewport** button. The two downloads were indistinguishable on disk.

This gives the annotated download its own filename, `image_with_annotations.png`, matching its button label. `screenshotViewport` keeps `viewport_screenshot.png`.

## Changes

- `src/components/Snapshots.vue` — `snapshotWithAnnotations()` now downloads as `image_with_annotations.png`.
- `src/components/Snapshots.test.ts` — new test covering `snapshotWithAnnotations` that asserts the distinct filename. It stubs the canvas 2D context (`getContext`/`toDataURL`) and `new Image()` since jsdom has no canvas/image backend, and restores those stubs since the suite uses `clearAllMocks` rather than `restoreAllMocks`.

## Testing

- `pnpm test -- --run src/components/Snapshots.test.ts` — 158 passed
- `pnpm lint` — clean
- `pnpm tsc` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)