### PR TITLE
Match "Download images for current location" contrast to the display

### DIFF
--- a/src/components/Snapshots.test.ts
+++ b/src/components/Snapshots.test.ts
@@ -1651,6 +1651,66 @@ describe("Snapshots.vue", () => {
       };
     });
 
+    it("downloadImagesForCurrentState builds URLs from store.layers (view contrast), not configuration.layers", async () => {
+      // store.layers is configuration.layers merged with the per-user
+      // datasetView contrast overrides — the contrast actually rendered on
+      // screen, and the same array a saved snapshot captures at save time. The
+      // "current location" download must use it too; passing configuration.layers
+      // drops live contrast overrides, so the downloaded image's contrast
+      // disagrees with both the viewer and snapshot downloads.
+      const originalStoreLayers = (store as any).layers;
+      const originalConfigLayers = (store as any).configuration.layers;
+      const viewLayers = [
+        {
+          id: "layer1",
+          name: "Layer 1",
+          channel: 0,
+          visible: true,
+          color: "#ff0000",
+          contrast: { mode: "percentile", blackPoint: 10, whitePoint: 90 },
+        },
+      ];
+      (store as any).layers = viewLayers;
+      (store as any).configuration.layers = [
+        {
+          id: "layer1",
+          name: "Layer 1",
+          channel: 0,
+          visible: true,
+          color: "#ff0000",
+          contrast: { mode: "percentile", blackPoint: 0, whitePoint: 100 },
+        },
+      ];
+      try {
+        const w = mountComponent();
+        (w.vm as any).addScalebar = false;
+        (w.vm as any).downloadMode = "layers";
+        (w.vm as any).exportLayer = "composite";
+
+        await (w.vm as any).downloadImagesForCurrentState();
+
+        expect(mockedGetLayersDownloadUrls).toHaveBeenCalledWith(
+          expect.anything(), // baseUrl
+          "composite", // exportLayer
+          viewLayers, // effective view layers, NOT configuration.layers
+          expect.anything(), // dataset
+          expect.anything(), // location
+          expect.anything(), // api
+        );
+        expect(mockedGetLayersDownloadUrls).not.toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          (store as any).configuration.layers,
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+        );
+      } finally {
+        (store as any).layers = originalStoreLayers;
+        (store as any).configuration.layers = originalConfigLayers;
+      }
+    });
+
     it("downloadImagesForAllSnapshots returns early with no configuration", async () => {
       (store as any).configuration = null;
       const w = mountComponent();

--- a/src/components/Snapshots.vue
+++ b/src/components/Snapshots.vue
@@ -1838,7 +1838,10 @@ async function downloadImagesForCurrentState() {
       boundingBox,
       datasetId,
       newName.value,
-      configuration.layers,
+      // Use store.layers (configuration.layers merged with the per-user
+      // datasetView contrast overrides) so the downloaded contrast matches
+      // what's on screen — consistent with snapshot and movie downloads.
+      store.layers,
       configuration.name,
     );
     if (!urls) {


### PR DESCRIPTION
## Problem

The contrast applied to a downloaded image differed between the two snapshot-panel download buttons:

- **"Download images for current location"** produced an image using the **shared base configuration contrast**.
- **"Download images for [selected/all] Snapshots"** produced an image using the **effective contrast that was on screen** when the snapshot was saved.

So if you adjusted contrast in the viewer and then used the two buttons, the images came out looking different — and the "current location" one didn't match what you were actually looking at.

## Root cause

The downloaded tile's style is built from the `contrast` field of whichever `layers` array each path hands to the URL builder (`getBandOption` → `toStyle`, `src/store/images.ts`).

- `downloadImagesForCurrentState` passed `configuration.layers` — the **shared base** contrast.
- `downloadImagesForSetOfSnapshots` passed `snapshot.layers`, which `saveSnapshot` captured from `store.layers`.

`store.layers` (`src/store/index.ts`) is `configuration.layers` **merged with the per-user `datasetView.layerContrasts` overrides** — the contrast actually rendered on screen. In NimbusImage, viewer contrast tweaks are stored as *view* overrides (`saveContrastInView`), **not** in the configuration. The current-location image download dropped those overrides.

The sibling current-location **movie** download already uses `store.layers` (and `saveSnapshot` captures `store.layers`), so the image download was the lone outlier.

## Fix

`downloadImagesForCurrentState` now passes `store.layers` instead of `configuration.layers`, so the current-location download uses the same effective, override-merged contrast as the display, the snapshot downloads, and the movie download. The `store.layers` getter only overrides each layer's `contrast` (id/channel/color/visible are unchanged), so layer selection and visibility are unaffected.

## Testing

- Added a `Snapshots.test.ts` regression test asserting `getLayersDownloadUrls` receives the effective view layers, not the base configuration layers. It fails before the fix, passes after.
- Full `Snapshots.test.ts` suite: 158/158 pass.
- `pnpm tsc` and `pnpm lint:ci` (zero warnings): clean.
- Full frontend suite: 2092/2092 tests pass. (10 unrelated *file*-level collection errors come from stray Playwright `.spec.ts` files vendored in the Python plugin's `.tox` virtualenv — pre-existing, identical on master.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)