### PR TITLE
build(deps): bump geojs 1.18.4 → 1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "eslint": "8.56.0",
     "eslint-plugin-prettier": "^5.1.2",
     "eslint-plugin-vue": "^9.19.2",
-    "geojs": "^1.18.4",
+    "geojs": "^1.19.1",
     "jsdom": "^24.0.0",
     "prettier": "^3.1.1",
     "pug": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,8 +252,8 @@ importers:
         specifier: ^9.19.2
         version: 9.20.1(eslint@8.56.0)
       geojs:
-        specifier: ^1.18.4
-        version: 1.18.4(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.5.6))(webpack@5.89.0(postcss@8.5.6))(wslink@1.12.4)
+        specifier: ^1.19.1
+        version: 1.19.1(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.5.6))(webpack@5.89.0(postcss@8.5.6))(wslink@1.12.4)
       jsdom:
         specifier: ^24.0.0
         version: 24.0.0(canvas@2.11.2)
@@ -2897,8 +2897,8 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  geojs@1.18.4:
-    resolution: {integrity: sha512-HsZxGayyy+blTKE0vv0xcbHDnzAEkbjSSlS6ZR6YOGuUFArVXqrDMdatyCyxYsfcSggn2WEcgCtoCOheoPVj5A==}
+  geojs@1.19.1:
+    resolution: {integrity: sha512-kdKfmM9116nEqZ2TXrnFHYK7OWrMLASx2Kod7GOV701Vbvr8jut2XwSnXcaWXN09hCHu1wNKEr+3bq5T9o3zzQ==}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3233,8 +3233,8 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
-  jquery@3.7.1:
-    resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
+  jquery@4.0.0:
+    resolution: {integrity: sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==}
 
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
@@ -7796,7 +7796,7 @@ snapshots:
   gensync@1.0.0-beta.2:
     optional: true
 
-  geojs@1.18.4(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.5.6))(webpack@5.89.0(postcss@8.5.6))(wslink@1.12.4):
+  geojs@1.19.1(@babel/preset-env@7.23.8(@babel/core@7.23.7))(autoprefixer@10.4.16(postcss@8.5.6))(webpack@5.89.0(postcss@8.5.6))(wslink@1.12.4):
     dependencies:
       '@velipso/polybool': 2.0.11
       canvas: 3.1.0
@@ -7807,7 +7807,7 @@ snapshots:
       gl-mat4: 1.2.0
       gl-vec3: 1.1.3
       gl-vec4: 1.0.1
-      jquery: 3.7.1
+      jquery: 4.0.0
       kdbush: 4.0.2
       mousetrap: 1.6.5
       proj4: 2.10.0
@@ -8206,7 +8206,7 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jquery@3.7.1: {}
+  jquery@4.0.0: {}
 
   js-beautify@1.15.4:
     dependencies:
@@ -8500,7 +8500,7 @@ snapshots:
 
   node-abi@3.74.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.1
 
   node-addon-api@7.1.1: {}
 
@@ -8892,7 +8892,7 @@ snapshots:
 
   rechoir@0.6.2:
     dependencies:
-      resolve: 1.22.8
+      resolve: 1.22.12
     optional: true
 
   reflect-metadata@0.1.14: {}
@@ -9065,8 +9065,7 @@ snapshots:
 
   semver@7.7.2: {}
 
-  semver@7.8.1:
-    optional: true
+  semver@7.8.1: {}
 
   set-blocking@2.0.0:
     optional: true
@@ -9796,7 +9795,7 @@ snapshots:
       '@oozcitak/dom': 1.15.10
       '@oozcitak/infra': 1.0.8
       '@oozcitak/util': 8.3.8
-      '@types/node': 18.19.129
+      '@types/node': 20.19.41
       js-yaml: 3.14.0
     optional: true
 


### PR DESCRIPTION
Updates geojs (the core GeoJS rendering engine behind `ImageViewer`) to the latest, 1.19.1 (minor bump from 1.18.4).

## Verification
- `pnpm tsc` ✅
- `pnpm lint:ci` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (all 116 frontend test files pass)

## ⚠️ Needs manual browser testing before merge
Automated tests don't exercise canvas/WebGL rendering, which is exactly what geojs drives. Please verify in the browser:
- Image display + channel compositing
- Annotation drawing/selection overlays
- Zoom / pan
- `unroll` grid layout and `max-merge` slice modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)