### PR TITLE
test: exclude .tox/** from vitest

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -30,7 +30,11 @@ export default mergeConfig(
     test: {
       globals: true,
       environment: "jsdom",
-      exclude: [...configDefaults.exclude, "e2e/*", "db/**"],
+      // "**/.tox/**" keeps vitest from globbing Girder's bundled *.spec.ts
+      // files that appear under .tox/ after a backend `tox` run (they import
+      // @playwright/test and aren't ours). Harmless on CI (no .tox dir), but
+      // they cause spurious failures when running `pnpm test` locally.
+      exclude: [...configDefaults.exclude, "e2e/*", "db/**", "**/.tox/**"],
       root: fileURLToPath(new URL("./", import.meta.url)),
       setupFiles: [
         fileURLToPath(new URL("./test/setup.ts", import.meta.url)),


### PR DESCRIPTION
Adds `"**/.tox/**"` to the vitest `exclude` list.

After running backend tests via `tox`, Girder's bundled `*.spec.ts` files land under `devops/girder/plugins/AnnotationPlugin/.tox/.../girder/web/tests/spec/`. Vitest's default glob picks them up; they import `@playwright/test` and fail to transform, producing ~10 spurious failing files when running `pnpm test` locally. CI never sees this (clean checkout, no `.tox`), but it's a confusing local footgun — it looks like a real test regression.

## Verification
With the 10 `.tox` spec files present on disk:
- before: `pnpm test` → 10 failed | 116 passed (126), exit 1
- after: `pnpm test` → **116 passed (116), exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)