### PR TITLE
chore: silence autoprefixer "mixed support" CSS warnings

### DIFF
--- a/build-config/silence-autoprefixer-mixed-support.cjs
+++ b/build-config/silence-autoprefixer-mixed-support.cjs
@@ -1,0 +1,14 @@
+// Drops autoprefixer's cosmetic "… value has mixed support" advisories.
+// They fire unconditionally on third-party CSS we don't control (Vuetify's
+// `align-items: start` etc.) and are harmless for our supported browsers
+// (see build.target in vite.config.js). Runs after autoprefixer and strips
+// just those warnings so the dev/build console stays clean.
+module.exports = () => ({
+  postcssPlugin: "silence-autoprefixer-mixed-support",
+  OnceExit(_root, { result }) {
+    result.messages = result.messages.filter(
+      (m) => !(m.type === "warning" && /mixed support/.test(m.text || "")),
+    );
+  },
+});
+module.exports.postcss = true;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 export default {
   plugins: {
     autoprefixer: {},
+    "./build-config/silence-autoprefixer-mixed-support.cjs": {},
   },
 };


### PR DESCRIPTION
Quiets the `[vite:css][postcss] start value has mixed support, consider using flex-start instead` warnings that show up in the dev console (and build output).

## What they are
autoprefixer emits these for `align-items: start` / `justify-content` values in **Vuetify's** CSS (e.g. `.v-time-picker-controls`) — third-party CSS we don't author. I confirmed the warning is **unconditional**: it fires regardless of browserslist targets (tested `chrome 120` only) or the `flexbox` option, and disappears only when autoprefixer is disabled entirely. It's harmless — all our supported browsers (`build.target` in vite.config.js: chrome89/edge89/firefox89/safari15) support modern box-alignment values natively.

## Fix
A small postcss plugin (`build-config/silence-autoprefixer-mixed-support.cjs`) runs after autoprefixer and strips just the `"mixed support"` warnings. autoprefixer keeps doing real prefixing; only the cosmetic advisory is dropped. No new dependency.

**Before:** build emits 1 `mixed support` warning. **After:** 0, build still succeeds.

## Note on the *other* dev-console message
The `The file does not exist at ".vite/deps/chunk-*.js" … incompatible with the dep optimizer` errors are **not** addressed here and aren't a code bug — they're Vite's dependency-optimizer cache churning (they fired right after *"Re-optimizing dependencies because lockfile has changed"* during the recent dependency-bump work) and self-heal on reload. They should stop now that the lockfile is stable; `rm -rf node_modules/.vite` clears them if they linger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)