### PR TITLE
fix(nimbusimage): client robustness — retry, stable cursor, compute validation, clear job 401 (#1207)

### DIFF
--- a/nimbusimage/README.md
+++ b/nimbusimage/README.md
@@ -23,6 +23,8 @@ The recommended setup uses a **Girder API key**, which is persistent and doesn't
 - **nimbusimage.com (hosted):** Email **[support@cytopixel.com](mailto:support@cytopixel.com)** with your account email address to request an API key.
 - **Local/self-hosted server:** In the Girder admin UI, go to **Users** > select the user > **Edit User** > **API Keys** > create a new key and copy the key string.
 
+**Required scopes.** The simplest option is a **full-access key** (leave the scope list empty), which works for everything including polling job status. If you instead create a *scoped* key, it must include **`core.user_auth`** — without it, `job.wait()` / `job.refresh()` fail with a confusing `401 Unauthorized` even though you own the job. Add **`jobs.rest.list_job`** as well so job logs can be read. Recommended scoped-key set: `core.data.read`, `core.data.write`, `core.data.own`, `core.user_info.read`, `core.user_auth`, `jobs.rest.list_job`.
+
 Set environment variables for persistent access:
 
 ```bash

--- a/nimbusimage/nimbusimage/_girder.py
+++ b/nimbusimage/nimbusimage/_girder.py
@@ -10,6 +10,40 @@ from __future__ import annotations
 import os
 
 import girder_client
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# NIM-006: transient 502/503/504 responses happen under normal load
+# (backend saturation, proxy timeouts). Retry them with jittered
+# exponential backoff so callers don't have to hand-roll retry loops.
+#
+# Only idempotent methods are retried (urllib3's default allowed set:
+# GET/HEAD/PUT/DELETE/OPTIONS/TRACE). POST is deliberately excluded so a
+# retried compute submission can't create duplicate jobs/annotations
+# (NIM-007). raise_on_status=False lets girder_client raise its usual
+# HttpError on the final response instead of a urllib3 RetryError.
+_RETRY_TOTAL = 5
+_RETRY_STATUS_FORCELIST = (502, 503, 504)
+_RETRY_BACKOFF_FACTOR = 0.5
+_RETRY_BACKOFF_JITTER = 0.5
+
+
+def _build_retry_session() -> requests.Session:
+    """Build a requests.Session that retries transient 5xx with backoff."""
+    retry = Retry(
+        total=_RETRY_TOTAL,
+        status_forcelist=_RETRY_STATUS_FORCELIST,
+        backoff_factor=_RETRY_BACKOFF_FACTOR,
+        backoff_jitter=_RETRY_BACKOFF_JITTER,
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
 
 
 def create_client(
@@ -50,6 +84,10 @@ def create_client(
         )
 
     gc = girder_client.GirderClient(apiUrl=api_url)
+    # Route all requests (including authentication) through a session that
+    # retries transient 5xx (NIM-006). girder_client uses gc._session for
+    # every request when it is set.
+    gc._session = _build_retry_session()
 
     if token is not None:
         gc.setToken(token)

--- a/nimbusimage/nimbusimage/_girder.py
+++ b/nimbusimage/nimbusimage/_girder.py
@@ -7,6 +7,7 @@ and error handling are centralized.
 
 from __future__ import annotations
 
+import inspect
 import os
 
 import girder_client
@@ -28,17 +29,27 @@ _RETRY_STATUS_FORCELIST = (502, 503, 504)
 _RETRY_BACKOFF_FACTOR = 0.5
 _RETRY_BACKOFF_JITTER = 0.5
 
+# backoff_jitter was added in urllib3 2.0. Passing it on urllib3 1.26.x
+# raises TypeError at construction, so gate it by feature detection rather
+# than version parsing. Backoff still applies without jitter on older
+# urllib3 — we just lose the thundering-herd spread.
+_RETRY_SUPPORTS_JITTER = (
+    "backoff_jitter" in inspect.signature(Retry.__init__).parameters
+)
+
 
 def _build_retry_session() -> requests.Session:
     """Build a requests.Session that retries transient 5xx with backoff."""
-    retry = Retry(
+    retry_kwargs = dict(
         total=_RETRY_TOTAL,
         status_forcelist=_RETRY_STATUS_FORCELIST,
         backoff_factor=_RETRY_BACKOFF_FACTOR,
-        backoff_jitter=_RETRY_BACKOFF_JITTER,
         respect_retry_after_header=True,
         raise_on_status=False,
     )
+    if _RETRY_SUPPORTS_JITTER:
+        retry_kwargs["backoff_jitter"] = _RETRY_BACKOFF_JITTER
+    retry = Retry(**retry_kwargs)
     adapter = HTTPAdapter(max_retries=retry)
     session = requests.Session()
     session.mount("http://", adapter)

--- a/nimbusimage/nimbusimage/annotations.py
+++ b/nimbusimage/nimbusimage/annotations.py
@@ -27,6 +27,8 @@ class AnnotationAccessor:
         limit: int = 0,
         offset: int = 0,
         after_id: str | None = None,
+        sort: str | None = None,
+        sortdir: int = 1,
     ) -> list[Annotation]:
         """List annotations in this dataset.
 
@@ -41,7 +43,13 @@ class AnnotationAccessor:
                 cursor) for delete/modify-as-you-go loops.
             after_id: Return only annotations whose ``_id`` is greater than
                 this one (a stable cursor). When set, the server ignores
-                ``offset``. Prefer :meth:`iter_all` over passing this by hand.
+                ``offset``. Only meaningful with ``sort="_id"`` (the server
+                otherwise defaults to a non-``_id`` sort); prefer
+                :meth:`iter_all`, which sets this for you.
+            sort: Field to sort by (e.g. ``"_id"``). If omitted, the server
+                uses its own default sort, which is **not** ``_id``.
+            sortdir: Sort direction, ``1`` ascending or ``-1`` descending.
+                Only applied when ``sort`` is set.
 
         Returns:
             List of Annotation objects.
@@ -56,6 +64,8 @@ class AnnotationAccessor:
             url += f"&tags={json.dumps(tags)}"
         if after_id:
             url += f"&afterId={after_id}"
+        if sort:
+            url += f"&sort={sort}&sortdir={sortdir}"
 
         data = self._gc.get(url)
         return [Annotation.from_dict(d) for d in data]
@@ -77,10 +87,11 @@ class AnnotationAccessor:
         This is the recommended way to fetch large result sets and to drive
         delete-as-you-go cleanup loops.
 
-        Note:
-            Correctness relies on the server returning each page in
-            ascending ``_id`` order (so ``page[-1]`` is the largest ``_id``
-            in the page). This holds for annotations today.
+        The cursor's correctness requires each page to come back in
+        ascending ``_id`` order (so ``page[-1]`` is the largest ``_id`` in
+        the page). The server's default sort is **not** ``_id``, so this
+        explicitly requests ``sort="_id"`` on every page — without it the
+        cursor could skip, duplicate, or loop on records.
 
         Args:
             shape: Filter by shape ('polygon', 'point', 'line').
@@ -97,6 +108,8 @@ class AnnotationAccessor:
                 tags=tags,
                 limit=page_size,
                 after_id=after_id,
+                sort="_id",
+                sortdir=1,
             )
             if not page:
                 break

--- a/nimbusimage/nimbusimage/annotations.py
+++ b/nimbusimage/nimbusimage/annotations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 from nimbusimage.jobs import Job
@@ -25,6 +26,7 @@ class AnnotationAccessor:
         tags: list[str] | None = None,
         limit: int = 0,
         offset: int = 0,
+        after_id: str | None = None,
     ) -> list[Annotation]:
         """List annotations in this dataset.
 
@@ -32,7 +34,14 @@ class AnnotationAccessor:
             shape: Filter by shape ('polygon', 'point', 'line').
             tags: Filter by tags (JSON-encoded array sent to server).
             limit: Max results. 0 = unlimited.
-            offset: Skip this many results.
+            offset: Skip this many results. NOTE: ``offset`` is positional
+                and **not stable across mutations** — if you delete or add
+                annotations between paged calls, an offset loop will skip or
+                repeat records. Use :meth:`iter_all` (a stable ``after_id``
+                cursor) for delete/modify-as-you-go loops.
+            after_id: Return only annotations whose ``_id`` is greater than
+                this one (a stable cursor). When set, the server ignores
+                ``offset``. Prefer :meth:`iter_all` over passing this by hand.
 
         Returns:
             List of Annotation objects.
@@ -45,9 +54,60 @@ class AnnotationAccessor:
             url += f"&shape={shape}"
         if tags:
             url += f"&tags={json.dumps(tags)}"
+        if after_id:
+            url += f"&afterId={after_id}"
 
         data = self._gc.get(url)
         return [Annotation.from_dict(d) for d in data]
+
+    def iter_all(
+        self,
+        shape: str | None = None,
+        tags: list[str] | None = None,
+        page_size: int = 1000,
+    ) -> Iterator[Annotation]:
+        """Iterate over every matching annotation, one page at a time.
+
+        Walks the backend's stable ``afterId`` cursor: each page asks for
+        annotations whose ``_id`` is greater than the largest ``_id`` seen
+        so far. This is **mutation-safe** — unlike offset pagination, you
+        can delete or modify annotations as you iterate without skipping
+        records (the cursor only ever advances past IDs already yielded).
+
+        This is the recommended way to fetch large result sets and to drive
+        delete-as-you-go cleanup loops.
+
+        Note:
+            Correctness relies on the server returning each page in
+            ascending ``_id`` order (so ``page[-1]`` is the largest ``_id``
+            in the page). This holds for annotations today.
+
+        Args:
+            shape: Filter by shape ('polygon', 'point', 'line').
+            tags: Filter by tags.
+            page_size: Number of annotations to fetch per request.
+
+        Yields:
+            Annotation objects, in ascending ``_id`` order.
+        """
+        after_id: str | None = None
+        while True:
+            page = self.list(
+                shape=shape,
+                tags=tags,
+                limit=page_size,
+                after_id=after_id,
+            )
+            if not page:
+                break
+            for annotation in page:
+                yield annotation
+            after_id = page[-1].id
+            if after_id is None:
+                raise RuntimeError(
+                    "Server returned an annotation without an _id; "
+                    "cannot advance the iter_all cursor."
+                )
 
     def get(self, annotation_id: str) -> Annotation:
         """Get a single annotation by ID."""
@@ -178,11 +238,15 @@ class AnnotationAccessor:
             channel: Channel index for the worker to process.
             tags: Tags to assign to created annotations.
             location: Location (XY/Z/Time) for single-tile processing.
-                Defaults to ``Location()``.
+                Defaults to ``Location()``. Mutually exclusive with
+                ``assignment``: in batch mode the worker iterates the
+                ``assignment`` ranges and ignores ``location``/``tile``,
+                so passing both raises ``ValueError``.
             assignment: Assignment range for batch processing. Can be
                 a dict like ``{'XY': '0-2', 'Z': 0, 'Time': 0}`` or
                 range strings like ``{'XY': '0-2', 'Z': 0, 'Time': '0-4'}``.
-                Defaults to the location if not provided.
+                Defaults to the location if not provided. Do not combine
+                with ``location=`` (see above).
             worker_interface: Parameter values matching the worker's
                 interface schema (from ``client.get_worker_interface()``).
                 Keys must match exactly (e.g., ``'Square size'``, not
@@ -208,6 +272,18 @@ class AnnotationAccessor:
             connections) — omitting it causes a ``KeyError`` after
             annotations are uploaded.
         """
+        # NIM-004: in batch mode the worker iterates the ``assignment``
+        # ranges and ignores ``tile``/``location`` entirely. Silently
+        # dropping a caller-supplied location is a footgun, so reject the
+        # conflicting combination instead of ignoring one of the arguments.
+        if location is not None and assignment is not None:
+            raise ValueError(
+                "location= is ignored in batch mode; pass ranges via "
+                "assignment= only (the worker iterates assignment ranges "
+                "and ignores location/tile). Provide either a single-tile "
+                "location= or batch ranges via assignment=, not both."
+            )
+
         loc = location or Location()
         loc_dict = loc.to_dict()
         if assignment is None:

--- a/nimbusimage/nimbusimage/jobs.py
+++ b/nimbusimage/nimbusimage/jobs.py
@@ -4,10 +4,21 @@ from __future__ import annotations
 
 import sys
 import time
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import girder_client
+import girder_client
+
+# Scopes a (scoped) API key needs to poll job status. The job-status
+# endpoint is @access.public and effectively requires core.user_auth; a
+# key minted without it gets a 401 whose raw message misattributes the
+# missing scope (NIM-005).
+_JOB_SCOPE_HINT = (
+    "Could not read job status (HTTP 401). Your API key is most likely "
+    "missing the 'core.user_auth' scope, which is required to poll job "
+    "status — the raw 401 misattributes this. Provision a key that "
+    "includes 'core.user_auth' (and 'jobs.rest.list_job' so job logs can "
+    "be read too), or use a full-access key. See the nimbusimage README "
+    "(Authentication) for the required scope set."
+)
 
 # Girder job status codes
 STATUS_INACTIVE = 0
@@ -75,8 +86,19 @@ class Job:
         return self.status == STATUS_SUCCESS
 
     def refresh(self) -> None:
-        """Fetch latest job status and log from the server."""
-        self._data = self._gc.get(f"job/{self._id}")
+        """Fetch latest job status and log from the server.
+
+        Raises:
+            PermissionError: If the job-status request returns 401, which
+                almost always means the API key lacks the ``core.user_auth``
+                scope (NIM-005). The message names the likely missing scope.
+        """
+        try:
+            self._data = self._gc.get(f"job/{self._id}")
+        except girder_client.HttpError as exc:
+            if getattr(exc, "status", None) == 401:
+                raise PermissionError(_JOB_SCOPE_HINT) from exc
+            raise
         try:
             log_resp = self._gc.get(f"job/{self._id}/log")
             if isinstance(log_resp, list):
@@ -106,6 +128,9 @@ class Job:
 
         Raises:
             TimeoutError: If timeout is reached before the job finishes.
+            PermissionError: If polling returns 401 — usually a missing
+                ``core.user_auth`` scope on the API key (NIM-005). Raised
+                via :meth:`refresh`.
         """
         start = time.monotonic()
         last_log_len = 0

--- a/nimbusimage/pyproject.toml
+++ b/nimbusimage/pyproject.toml
@@ -22,8 +22,10 @@ dependencies = [
     "girder-client",
     "numpy",
     "pydantic>=2.0",
+    "requests",
     "shapely",
     "scikit-image",
+    "urllib3",
 ]
 
 [project.optional-dependencies]

--- a/nimbusimage/pyproject.toml
+++ b/nimbusimage/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nimbusimage"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python API for NimbusImage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/nimbusimage/tests/integration/test_live_annotations.py
+++ b/nimbusimage/tests/integration/test_live_annotations.py
@@ -50,6 +50,59 @@ class TestLiveAnnotations:
         ids = [a.id for a in created]
         ds.annotations.delete_many(ids)
 
+    def test_iter_all_walks_after_id_cursor(self, test_dataset):
+        """NIM-002: iter_all() pages the real afterId cursor and returns
+        every record exactly once, in ascending _id order."""
+        ds = test_dataset
+
+        anns = [
+            ni.Annotation(
+                id=None, shape="point", tags=["iterall"],
+                channel=0, location=ni.Location(),
+                coordinates=[{"x": float(i), "y": float(i)}],
+                dataset_id=ds.id,
+            )
+            for i in range(7)
+        ]
+        created = ds.annotations.create_many(anns)
+        created_ids = sorted(a.id for a in created)
+
+        try:
+            seen = [
+                a.id
+                for a in ds.annotations.iter_all(tags=["iterall"], page_size=2)
+            ]
+            assert sorted(seen) == created_ids
+            assert len(seen) == len(set(seen))  # no duplicates
+            assert seen == sorted(seen)  # ascending _id order
+        finally:
+            ds.annotations.delete_many([a.id for a in created])
+
+    def test_iter_all_safe_during_deletion(self, test_dataset):
+        """NIM-002: deleting each record as it is yielded must not skip
+        any (the offset-pagination bug the cursor fixes)."""
+        ds = test_dataset
+
+        anns = [
+            ni.Annotation(
+                id=None, shape="point", tags=["iterdel"],
+                channel=0, location=ni.Location(),
+                coordinates=[{"x": float(i), "y": float(i)}],
+                dataset_id=ds.id,
+            )
+            for i in range(7)
+        ]
+        created = ds.annotations.create_many(anns)
+        expected = sorted(a.id for a in created)
+
+        seen = []
+        for a in ds.annotations.iter_all(tags=["iterdel"], page_size=2):
+            seen.append(a.id)
+            ds.annotations.delete(a.id)
+
+        assert sorted(seen) == expected
+        assert ds.annotations.count(tags=["iterdel"]) == 0
+
     def test_update(self, test_dataset):
         ds = test_dataset
 

--- a/nimbusimage/tests/test_annotations.py
+++ b/nimbusimage/tests/test_annotations.py
@@ -25,6 +25,23 @@ class TestAnnotationListAfterId:
         call_url = mock_gc.get.call_args[0][0]
         assert "afterId" not in call_url
 
+    def test_list_passes_sort(self, mock_gc):
+        mock_gc.get.return_value = []
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        accessor.list(sort="_id", sortdir=1)
+        call_url = mock_gc.get.call_args[0][0]
+        assert "sort=_id" in call_url
+        assert "sortdir=1" in call_url
+
+    def test_list_omits_sort_by_default(self, mock_gc):
+        mock_gc.get.return_value = []
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        accessor.list()
+        call_url = mock_gc.get.call_args[0][0]
+        assert "sort=" not in call_url
+
 
 class TestAnnotationIterAll:
     """NIM-002: iter_all() walks the stable afterId cursor.
@@ -52,6 +69,45 @@ class TestAnnotationIterAll:
         assert "limit=2" in urls[0]
         assert "afterId=a2" in urls[1]
         assert "afterId=a3" in urls[2]
+
+    def test_iter_all_requests_id_sort_every_page(self, mock_gc):
+        """The afterId cursor is only correct if the server sorts by _id,
+        so iter_all must force sort=_id&sortdir=1 on every request — the
+        backend otherwise defaults to lowerName."""
+        mock_gc.get.side_effect = [
+            [{"_id": "a1", "shape": "point"}],
+            [],
+        ]
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        list(accessor.iter_all(page_size=1))
+        for call in mock_gc.get.call_args_list:
+            url = call[0][0]
+            assert "sort=_id" in url
+            assert "sortdir=1" in url
+
+    def test_iter_all_correct_when_backend_unsorted(self, mock_gc):
+        """If the server only returns _id-ordered pages when sort=_id is
+        requested (and scrambled order otherwise), iter_all must still yield
+        every record once — proving it relies on the sort param, not luck."""
+        ordered = ["a1", "a2", "a3", "a4", "a5"]
+        scrambled = ["a3", "a1", "a5", "a2", "a4"]
+
+        def fake_get(url):
+            after = None
+            if "afterId=" in url:
+                after = url.split("afterId=", 1)[1].split("&", 1)[0]
+            limit = int(url.split("limit=", 1)[1].split("&", 1)[0])
+            source = ordered if "sort=_id" in url else scrambled
+            pool = [i for i in source if after is None or i > after]
+            return [{"_id": i, "shape": "point"} for i in pool[:limit]]
+
+        mock_gc.get.side_effect = fake_get
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        seen = [a.id for a in accessor.iter_all(page_size=2)]
+        assert sorted(seen) == ordered
+        assert seen == sorted(seen)
 
     def test_iter_all_raises_if_page_item_has_no_id(self, mock_gc):
         """A missing _id would otherwise drop the cursor and infinite-loop."""

--- a/nimbusimage/tests/test_annotations.py
+++ b/nimbusimage/tests/test_annotations.py
@@ -1,7 +1,96 @@
 """Tests for AnnotationAccessor."""
 
+import pytest
+
 from nimbusimage.annotations import AnnotationAccessor
 from nimbusimage.models import Annotation, Location
+
+
+class TestAnnotationListAfterId:
+    """NIM-002: list() can take a stable _id cursor via after_id."""
+
+    def test_list_passes_after_id(self, mock_gc):
+        mock_gc.get.return_value = []
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        accessor.list(after_id="ann_042")
+        call_url = mock_gc.get.call_args[0][0]
+        assert "afterId=ann_042" in call_url
+
+    def test_list_omits_after_id_when_none(self, mock_gc):
+        mock_gc.get.return_value = []
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        accessor.list()
+        call_url = mock_gc.get.call_args[0][0]
+        assert "afterId" not in call_url
+
+
+class TestAnnotationIterAll:
+    """NIM-002: iter_all() walks the stable afterId cursor.
+
+    Unlike offset pagination, the afterId cursor is mutation-safe: it
+    always advances past the largest _id already seen, so deleting
+    records as you iterate never skips any.
+    """
+
+    def test_iter_all_walks_after_id(self, mock_gc):
+        page1 = [{"_id": "a1", "shape": "point"},
+                 {"_id": "a2", "shape": "point"}]
+        page2 = [{"_id": "a3", "shape": "point"}]
+        page3 = []
+        mock_gc.get.side_effect = [page1, page2, page3]
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        results = list(accessor.iter_all(page_size=2))
+        assert [a.id for a in results] == ["a1", "a2", "a3"]
+
+        urls = [c[0][0] for c in mock_gc.get.call_args_list]
+        assert len(urls) == 3
+        # First request has no cursor; later ones advance past last _id.
+        assert "afterId" not in urls[0]
+        assert "limit=2" in urls[0]
+        assert "afterId=a2" in urls[1]
+        assert "afterId=a3" in urls[2]
+
+    def test_iter_all_raises_if_page_item_has_no_id(self, mock_gc):
+        """A missing _id would otherwise drop the cursor and infinite-loop."""
+        mock_gc.get.return_value = [{"shape": "point"}]  # no _id
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        with pytest.raises(RuntimeError, match="_id"):
+            list(accessor.iter_all(page_size=2))
+
+    def test_iter_all_passes_filters(self, mock_gc):
+        mock_gc.get.side_effect = [[{"_id": "a1", "shape": "polygon"}], []]
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        list(accessor.iter_all(shape="polygon", tags=["nucleus"]))
+        first_url = mock_gc.get.call_args_list[0][0][0]
+        assert "shape=polygon" in first_url
+        assert "nucleus" in first_url
+
+    def test_iter_all_safe_during_deletion(self, mock_gc):
+        """Delete-as-you-go must not skip records (the NIM-002 bug)."""
+        store = ["a1", "a2", "a3", "a4", "a5"]
+
+        def fake_get(url):
+            after = None
+            if "afterId=" in url:
+                after = url.split("afterId=", 1)[1].split("&", 1)[0]
+            limit = int(url.split("limit=", 1)[1].split("&", 1)[0])
+            candidates = [i for i in store if after is None or i > after]
+            return [{"_id": i, "shape": "point"} for i in candidates[:limit]]
+
+        mock_gc.get.side_effect = fake_get
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        seen = []
+        for ann in accessor.iter_all(page_size=2):
+            seen.append(ann.id)
+            store.remove(ann.id)  # delete immediately after yielding
+
+        assert seen == ["a1", "a2", "a3", "a4", "a5"]
 
 
 class TestAnnotationList:

--- a/nimbusimage/tests/test_jobs.py
+++ b/nimbusimage/tests/test_jobs.py
@@ -69,6 +69,50 @@ class TestJobRefresh:
         assert "line 2" in job.log
 
 
+class TestJobScopeError:
+    """NIM-005: a 401 from job/{id} usually means the API key lacks the
+    'core.user_auth' scope, not that the job is missing. Re-raise with a
+    message that names the real culprit instead of the raw Girder 401.
+    """
+
+    def _http_error(self, status):
+        from girder_client import HttpError
+
+        return HttpError(
+            status=status,
+            text="not authorized",
+            url="job/j1",
+            method="GET",
+        )
+
+    def test_refresh_401_names_user_auth_scope(self):
+        gc = MagicMock()
+        gc.get.side_effect = self._http_error(401)
+        job = Job(gc, {"_id": "j1", "status": STATUS_RUNNING})
+
+        with pytest.raises(PermissionError, match="core.user_auth"):
+            job.refresh()
+
+    def test_wait_401_names_user_auth_scope(self):
+        gc = MagicMock()
+        gc.get.side_effect = self._http_error(401)
+        job = Job(gc, {"_id": "j1", "status": STATUS_RUNNING})
+
+        with pytest.raises(PermissionError, match="core.user_auth"):
+            job.wait(verbose=False)
+
+    def test_refresh_non_401_propagates_unchanged(self):
+        from girder_client import HttpError
+
+        gc = MagicMock()
+        gc.get.side_effect = self._http_error(500)
+        job = Job(gc, {"_id": "j1", "status": STATUS_RUNNING})
+
+        # A 500 is not a scope problem — don't mislabel it.
+        with pytest.raises(HttpError):
+            job.refresh()
+
+
 class TestJobWait:
     def test_wait_returns_true_on_success(self):
         gc = MagicMock()
@@ -197,6 +241,61 @@ class TestAnnotationCompute:
         ]
         for key in required:
             assert key in body, f"Missing required key: {key}"
+
+
+class TestComputeLocationValidation:
+    """NIM-004: location is silently dropped in batch mode.
+
+    Once an explicit ``assignment`` (batch ranges) is supplied, the worker
+    iterates the assignment ranges and ignores ``tile``/``location``. Passing
+    both should be an error, not a silent no-op.
+    """
+
+    def test_location_with_assignment_raises(self, mock_gc):
+        from nimbusimage.annotations import AnnotationAccessor
+        from nimbusimage.models import Location
+
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+        with pytest.raises(ValueError, match="batch mode"):
+            accessor.compute(
+                image="myworker:latest",
+                location=Location(xy=1, z=0, time=0),
+                assignment={"XY": "1-14", "Time": "1-14"},
+            )
+        # Must fail before any request is sent.
+        mock_gc.post.assert_not_called()
+
+    def test_location_alone_still_works(self, mock_gc):
+        """Single-tile mode: location backfills assignment and tile."""
+        mock_gc.post.return_value = [{"_id": "j1", "status": 1}]
+
+        from nimbusimage.annotations import AnnotationAccessor
+        from nimbusimage.models import Location
+
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+        accessor.compute(
+            image="w:latest", location=Location(xy=2, z=0, time=3)
+        )
+        body = mock_gc.post.call_args[1]["json"]
+        assert body["tile"]["XY"] == 2
+        assert body["tile"]["Time"] == 3
+        # location backfills assignment when no explicit assignment given
+        assert body["assignment"]["XY"] == 2
+        assert body["assignment"]["Time"] == 3
+
+    def test_assignment_alone_still_works(self, mock_gc):
+        """Batch mode: assignment ranges pass through untouched."""
+        mock_gc.post.return_value = [{"_id": "j1", "status": 1}]
+
+        from nimbusimage.annotations import AnnotationAccessor
+
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+        accessor.compute(
+            image="w:latest",
+            assignment={"XY": "1-14", "Time": "1-14"},
+        )
+        body = mock_gc.post.call_args[1]["json"]
+        assert body["assignment"] == {"XY": "1-14", "Time": "1-14"}
 
 
 class TestPropertyCompute:

--- a/nimbusimage/tests/test_retry.py
+++ b/nimbusimage/tests/test_retry.py
@@ -96,6 +96,23 @@ class TestRetryConfiguration:
         assert "POST" not in retry.allowed_methods
         assert "GET" in retry.allowed_methods
 
+    def test_jitter_applied_when_supported(self):
+        gc = create_client(api_url="https://example.test/api/v1", token="x")
+        retry = gc._session.get_adapter("https://example.test/").max_retries
+        assert retry.backoff_jitter == 0.5
+
+    def test_jitter_omitted_when_unsupported(self, monkeypatch):
+        """urllib3 1.26.x has no backoff_jitter kwarg — passing it would
+        crash create_client (Codex P2). The kwarg must be gated."""
+        import nimbusimage._girder as g
+
+        monkeypatch.setattr(g, "_RETRY_SUPPORTS_JITTER", False)
+        gc = g.create_client(api_url="https://example.test/api/v1", token="x")
+        retry = gc._session.get_adapter("https://example.test/").max_retries
+        # Not passed -> urllib3's default (0.0); and it must still build.
+        assert retry.backoff_jitter == 0.0
+        assert retry.total and retry.total > 0
+
 
 class TestRetryBehavior:
     def test_retries_503_then_succeeds(self, flaky_server):

--- a/nimbusimage/tests/test_retry.py
+++ b/nimbusimage/tests/test_retry.py
@@ -1,0 +1,123 @@
+"""Tests for NIM-006: transient-5xx retry-with-backoff in create_client.
+
+The client mounts a urllib3 Retry adapter so transient 502/503/504
+responses are retried with backoff instead of surfacing to the caller,
+removing the need for hand-rolled retry loops.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+import pytest
+from urllib3.util.retry import Retry
+
+from nimbusimage._girder import create_client
+
+
+class _FlakyHandler(BaseHTTPRequestHandler):
+    """Returns a configured sequence of status codes, counting hits.
+
+    Note: the attribute is ``status_codes`` (not ``responses``) because
+    ``BaseHTTPRequestHandler.responses`` is the built-in status->message
+    map used by ``send_response``.
+    """
+
+    status_codes: list[int] = []
+    hits = 0
+
+    def _serve(self):
+        cls = type(self)
+        idx = cls.hits
+        cls.hits += 1
+        status = cls.status_codes[idx] if idx < len(cls.status_codes) \
+            else cls.status_codes[-1]
+        body = json.dumps({"ok": True}).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = _serve
+    do_POST = _serve
+
+    def log_message(self, *args):  # silence stderr noise
+        pass
+
+
+@pytest.fixture
+def flaky_server():
+    """A throwaway HTTP server with a per-test handler subclass."""
+
+    class Handler(_FlakyHandler):
+        status_codes: list[int] = []
+        hits = 0
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield Handler, f"http://127.0.0.1:{port}/api/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# Avoid real backoff sleeps; the retry policy is exercised either way.
+def _no_sleep(self, response=None):
+    return None
+
+
+class TestRetryConfiguration:
+    def test_retry_adapter_mounted_with_5xx_forcelist(self):
+        gc = create_client(api_url="https://example.test/api/v1", token="x")
+        retry = gc._session.get_adapter("https://example.test/").max_retries
+        assert isinstance(retry, Retry)
+        assert {502, 503, 504}.issubset(set(retry.status_forcelist))
+        assert retry.total and retry.total > 0
+        assert retry.backoff_factor and retry.backoff_factor > 0
+        assert retry.respect_retry_after_header is True
+
+    def test_retry_adapter_on_both_schemes(self):
+        gc = create_client(api_url="http://localhost:8080/api/v1", token="x")
+        http_retry = gc._session.get_adapter("http://localhost/").max_retries
+        https_retry = gc._session.get_adapter("https://localhost/").max_retries
+        assert http_retry.total and http_retry.total > 0
+        assert https_retry.total and https_retry.total > 0
+
+    def test_post_not_retried_by_default(self):
+        """Retrying POST could duplicate job submissions (NIM-007), so
+        only idempotent methods are retried."""
+        gc = create_client(api_url="https://example.test/api/v1", token="x")
+        retry = gc._session.get_adapter("https://example.test/").max_retries
+        assert "POST" not in retry.allowed_methods
+        assert "GET" in retry.allowed_methods
+
+
+class TestRetryBehavior:
+    def test_retries_503_then_succeeds(self, flaky_server):
+        Handler, api_url = flaky_server
+        Handler.status_codes = [503, 503, 200]
+        gc = create_client(api_url=api_url, token="x")
+
+        with patch.object(Retry, "sleep", _no_sleep):
+            result = gc.get("anything")
+
+        assert result == {"ok": True}
+        assert Handler.hits == 3
+
+    def test_no_retry_on_4xx(self, flaky_server):
+        from girder_client import HttpError
+
+        Handler, api_url = flaky_server
+        Handler.status_codes = [404]
+        gc = create_client(api_url=api_url, token="x")
+
+        with patch.object(Retry, "sleep", _no_sleep):
+            with pytest.raises(HttpError):
+                gc.get("anything")
+
+        assert Handler.hits == 1


### PR DESCRIPTION
Fixes the four **client-only** issues from #1207 (June 2026 NimbusImage API report, Grant Kinsler / Bhatt Lab). All are independent of any backend change and were implemented test-first.

## Issues addressed

- **NIM-006 — transient 5xx under load.** `create_client` now mounts a `urllib3.Retry` adapter on the `requests.Session` (`status_forcelist=502/503/504`, exponential backoff + jitter, `respect_retry_after_header`). Only idempotent methods are retried — **POST is deliberately excluded** so a retried compute submission can't create duplicate jobs/annotations (NIM-007). `raise_on_status=False` keeps girder_client's usual `HttpError` on final failure.
- **NIM-002 — offset pagination unstable during deletion.** Added `AnnotationAccessor.iter_all()`, a generator that walks the backend's stable `afterId` cursor (plus an `after_id=` kwarg on `list()`). Mutation-safe for delete-as-you-go loops; documents that `offset` is not.
- **NIM-004 — batch mode silently dropped `location`.** `compute()` now raises `ValueError` when both `location=` and `assignment=` are supplied, instead of silently ignoring `location`. Docstring clarified.
- **NIM-005 — confusing 401 from `job.wait()`.** `Job.refresh()`/`wait()` catch the raw 401 from `job/{id}` (which misattributes the missing scope as `jobs.job_<id>`) and re-raise a `PermissionError` naming the real culprit, `core.user_auth`. Required scope set documented in the README.

## Testing

- **235 unit tests pass** (was 218), flake8 clean. New coverage includes a real local-HTTP-server test proving `503,503,200 → success` (and no retry on 4xx), a delete-as-you-go cursor simulation, and an infinite-loop guard.
- **Verified live** against a freshly rebuilt backend (Girder 5.0.11): `iter_all` walks the real `afterId` cursor and left 0 records behind during delete-as-you-go; the NIM-005 401 was reproduced with a real scoped API key and confirmed translated into the clear `core.user_auth` message.
- Added 2 live integration tests for `iter_all` under `tests/integration/`.

## Review notes (from `/branch-review`)
Applied all five findings before committing: declared `requests`/`urllib3` as direct deps, added an infinite-loop guard to `iter_all` (with test), documented the `_id`-ordering assumption, noted `PermissionError` in `wait()`'s docstring, and switched to `collections.abc.Iterator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)