### PR TITLE
fix(annotation): default find sort to _id, not dead "lowerName"

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -309,7 +309,7 @@ class Annotation(Resource):
         .errorResponse()
     )
     def find(self, params):
-        limit, offset, sort = self.getPagingParameters(params, "lowerName")
+        limit, offset, sort = self.getPagingParameters(params, "_id")
 
         # First, check dataset permissions explicitly
         datasetId = ObjectId(params["datasetId"])

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_annotations.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_annotations.py
@@ -561,3 +561,54 @@ class TestInlinePropertiesField:
             {"annotationId": result["_id"]}
         ))
         assert values == []
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestFindDefaultSort:
+    """The GET /upenn_annotation find route must default its sort to _id.
+
+    The route declares ``pagingParams(defaultSort="_id")`` and hints the
+    ``(datasetId, _id)`` index, so the handler's default must match. If it
+    defaults to a field the hinted index doesn't provide (e.g. ``lowerName``),
+    MongoDB performs a blocking in-memory sort, and the ``afterId`` cursor —
+    which advances on ``_id > afterId`` and uses ``page[-1]._id`` as the next
+    cursor — is only stable by accident (real annotation docs simply lack
+    that field, so the null keys happen to emit in ``_id`` order).
+    """
+
+    def testFindDefaultsToIdSort(self, admin, server):
+        folder = utilities.createFolder(
+            admin, "ds", upenn_utilities.datasetMetadata
+        )
+        datasetId = str(folder["_id"])
+
+        # Create several annotations and record their _ids ascending.
+        ids = [
+            Annotation().create(
+                upenn_utilities.getSampleAnnotation(folder["_id"])
+            )["_id"]
+            for _ in range(5)
+        ]
+        idsAscending = sorted(ids)
+
+        # Give each doc a `lowerName` whose ascending order is the REVERSE of
+        # _id order. Real annotations have no lowerName, so a lowerName-default
+        # sort returns them in _id order by accident; injecting a contradictory
+        # lowerName exposes which field the route actually sorts by.
+        for rank, annotationId in enumerate(idsAscending):
+            Annotation().update(
+                {"_id": annotationId},
+                {"$set": {"lowerName": "%03d" % (len(idsAscending) - rank)}},
+            )
+
+        resp = server.request(
+            path="/upenn_annotation",
+            method="GET",
+            user=admin,
+            params={"datasetId": datasetId},
+        )
+        assertStatusOk(resp)
+
+        returnedIds = [doc["_id"] for doc in resp.json]
+        assert returnedIds == [str(i) for i in idsAscending]


### PR DESCRIPTION
Closes #1210.

## What

Change the `GET /upenn_annotation` (`find`) handler's default-sort fallback from `"lowerName"` to `"_id"` (`annotation.py:312`), aligning it with the route's declared `.pagingParams(defaultSort="_id")` (`:308`) and the `(datasetId,_id)` index hint (`:342`). Adds a regression test.

## Why this is a cleanup, not a runtime perf fix

The investigation for #1210 overturned the issue's premise. On the current Girder 5.x backend the `"lowerName"` fallback is **dead code**: `@autoDescribeRoute`'s `pagingParams(defaultSort="_id")` registers a `sort` param with default `"_id"` and injects it into the request when the client omits `sort` (`girder/api/describe.py:760-761`), so `getPagingParameters` takes its `if 'sort' in params` branch and uses `"_id"` — never reaching `"lowerName"`.

**Proven on the live backend** (Girder 5.0.11, a 26,141-annotation dataset), `GET /upenn_annotation?datasetId=…` with no `sort`:
- `command.sort: {"_id": 1}`
- `planSummary: IXSCAN { datasetId: 1, _id: 1 }` — **no SORT stage**, 5 keys examined, 0 ms.

So there is no blocking in-memory sort, and the `afterId` cursor was already correct *by design* (the injected `_id` default), not "by accident" via all-null `lowerName` keys.

## What the change buys

- Removes dead/misleading code — the `"lowerName"` arg is exactly what made a static read infer a `lowerName` sort.
- Keeps the handler correct if `defaultSort` is ever dropped from the decorator (which would otherwise silently reintroduce a `lowerName` sort + blocking in-memory sort).
- **No observable behavior change** on the current backend.

## Tests

`test_annotations.py::TestFindDefaultSort` injects a `lowerName` on docs in reverse-`_id` order and asserts the route returns `_id` order (it would return reverse order if it sorted by `lowerName`).

Verified **red→green**: with the decorator default temporarily set to `None` (exposing the line-312 fallback), the old `"lowerName"` failed the test and `"_id"` passed; the decorator default was then restored for defense-in-depth. Full plugin suite: **188 passed**, flake8 clean.

## Note on NIM-006 (504s)

The 504s were reproduced on the latest backend, so they are **not** caused by this (nonexistent) blocking sort. Real suspects — unbounded query (no `.maxTimeMS`), pre-stream `cursor.count()` second pass, `coordinates` payload size vs proxy timeout, backend saturation — are being investigated separately and are out of scope here.

## Deploy note

Baked-in backend plugin change — needs `docker compose build girder && docker compose up -d` to take effect on a running container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
