### PR TITLE
fix(annotations): render polygon/line strokes on all Z-slices

### DIFF
--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -87,21 +87,47 @@ export function geojsAnnotationFactory(
 ) {
   const annotationOptions = { ...options };
 
+  // TEMPORARY WORKAROUND for an upstream GeoJS bug:
+  // https://github.com/OpenGeoscience/geojs/issues/1486
+  // Our viewer is a 2D parallel-projection map, but annotation coordinates
+  // carry a `z` equal to the Z-slice index they were drawn on. GeoJS's polygon
+  // *fill* feature zeroes vertex z before building its geometry, but its *line*
+  // feature (which draws the stroke) computes its float-precision `origin` from
+  // the un-zeroed coordinates and only zeroes the per-vertex z afterward
+  // (webgl/lineFeature.js). The origin's z is then re-applied via the modelView
+  // translation, pushing the stroke outside the fixed parallel clipbounds
+  // (near:1 / far:-1, i.e. visible z ~[-1, 3]). The result: polygon/line strokes
+  // silently vanish for annotations on higher Z-slices while the fill still
+  // renders. Flattening z to 0 here keeps strokes inside the clip volume; z is
+  // not used for 2D rendering (the slice is tracked via location/channel).
+  // Remove once GeoJS zeroes the line feature's origin z like the polygon does.
+  //
+  // This runs once per annotation and is a hot path at high annotation counts,
+  // so build the flattened array with an indexed loop and an explicit object
+  // literal rather than map()/spread, which allocate a closure and copy every
+  // property per vertex.
+  const numCoordinates = coordinates.length;
+  const flatCoordinates: IGeoJSPosition[] = new Array(numCoordinates);
+  for (let i = 0; i < numCoordinates; i++) {
+    const coordinate = coordinates[i];
+    flatCoordinates[i] = { x: coordinate.x, y: coordinate.y, z: 0 };
+  }
+
   switch (shape) {
     case AnnotationShape.Point:
-      annotationOptions.position = coordinates[0];
+      annotationOptions.position = flatCoordinates[0];
       return geojs.annotation.pointAnnotation(annotationOptions);
 
     case AnnotationShape.Polygon:
-      annotationOptions.vertices = coordinates;
+      annotationOptions.vertices = flatCoordinates;
       return geojs.annotation.polygonAnnotation(annotationOptions);
 
     case AnnotationShape.Line:
-      annotationOptions.vertices = coordinates;
+      annotationOptions.vertices = flatCoordinates;
       return geojs.annotation.lineAnnotation(annotationOptions);
 
     case AnnotationShape.Rectangle:
-      annotationOptions.corners = coordinates;
+      annotationOptions.corners = flatCoordinates;
       return geojs.annotation.rectangleAnnotation(annotationOptions);
 
     default:


### PR DESCRIPTION
## Problem

Annotation polygon/blob **outlines** (and connection lines) intermittently failed to render — the fill showed but the stroke was missing — making those annotations hard to click/select. Point annotations were unaffected. It looked random but was actually **deterministic on the Z-slice**: strokes vanished for annotations on slices roughly `z >= 4`.

## Root cause (upstream GeoJS bug)

Each annotation is drawn as two WebGL features: a polygon **fill** and a separate **line** for the stroke. Annotation coordinates carry a `z` equal to the Z-slice index they were drawn on.

- The polygon fill feature zeroes vertex `z` *before* computing its geometry/origin → fill always renders.
- The line feature computes its float-precision `origin` from the **un-zeroed** coordinates and only zeroes the per-vertex `z` afterward (`webgl/lineFeature.js`). The origin's `z` is then re-applied via the `modelViewOriginUniform` translation, pushing the whole stroke outside the fixed parallel clipbounds (`near:1` / `far:-1`, i.e. visible z `~[-1, 3]`). At `z=13` the stroke lands at NDC z ≈ -6 and is clipped entirely.

I verified this on the GPU: the line and polygon `modelViewMatrix` were identical except the z-translation (`[14]`) — polygon `0`, line `13` — with the line's program linked, validated, buffers populated, and `drawArrays` issued with no GL errors. Zeroing the line's origin z made every stroke render immediately.

Reported upstream: **https://github.com/OpenGeoscience/geojs/issues/1486** (GeoJS 1.19.1, latest release; also present on `master`).

## Fix

Work around it at the single chokepoint where annotation coordinates become GeoJS vertices — `geojsAnnotationFactory` — by flattening all render coordinates to `z: 0` before handing them to GeoJS. `z` is not used for 2D rendering (the slice is tracked via `annotation.location`/`channel`; the polygon fill already discards it). The change is heavily commented as temporary, to be removed once the upstream line feature zeroes its origin z like the polygon does.

## Testing

- Verified in the running app on a hard reload: strokes render at `z=13` with default styling (GPU `modelViewMatrix[14]` is now `0`).
- `pnpm tsc` and `eslint` pass.
- `geojsAnnotationFactory` is mocked in all unit tests, so the change does not affect existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)