### PR TITLE
Add claude_analysis endpoint: agentic property-value analysis backend

### DIFF
--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/__init__.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/__init__.py
@@ -7,6 +7,8 @@ from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
 
+from .analysis import ClaudeAnalysisResource
+
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -74,3 +76,4 @@ class GirderClaudeChatPlugin(plugin.GirderPlugin):
 
     def load(self, info):
         info['apiRoot'].claude_chat = ClaudeChatResource()
+        info['apiRoot'].claude_analysis = ClaudeAnalysisResource()

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis.py
@@ -5,6 +5,7 @@ import os
 import anthropic
 from anthropic import Anthropic
 from bson import ObjectId
+from pymongo.errors import OperationFailure
 
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
@@ -218,8 +219,14 @@ class ClaudeAnalysisResource(Resource):
                 "tool_use_id": block.id,
                 "content": json.dumps(result),
             }
-        except ValueError as e:
-            errorMessage = str(e)
+        except (ValueError, KeyError, TypeError, OperationFailure) as e:
+            # Tool inputs come from the model and are not schema-guaranteed;
+            # a bad call must become an is_error tool_result the agent can
+            # recover from, not a 500 that discards the whole analysis.
+            if isinstance(e, KeyError):
+                errorMessage = "Missing required tool input field: %s" % e
+            else:
+                errorMessage = str(e)
             toolLog.append({
                 "tool": block.name,
                 "input": block.input,

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis.py
@@ -1,0 +1,233 @@
+import json
+import logging
+import os
+
+import anthropic
+from anthropic import Anthropic
+from bson import ObjectId
+
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import Resource
+from girder.constants import AccessType
+from girder.models.folder import Folder
+
+from .analysis_tools import AnalysisToolkit
+
+logger = logging.getLogger(__name__)
+
+MODEL = "claude-sonnet-5"
+MAX_TOKENS = 8000
+MAX_ITERATIONS = 20
+
+SYSTEM_PROMPT = """You are a data-analysis agent embedded in NimbusImage's \
+AI analysis panel, analyzing computed annotation property values for a \
+microscopy image dataset.
+
+Use the provided tools to inspect the data before drawing conclusions: \
+get statistics, histograms, samples, and tag/shape breakdowns as needed. \
+Then use the plot-creation tools to build the charts most relevant to the \
+user's request (typically 1-4 plots). Plots you create render as \
+interactive Plotly charts in the UI, so favor creating a plot over \
+describing one in prose.
+
+When you reference a plot in your summary, refer to it by its title so \
+the user can find it. Finish with a concise markdown summary of your \
+quantitative findings, referencing the plots you created.
+
+If data for a requested property is missing, entirely non-numeric, or \
+otherwise unsuitable for the request, say so explicitly rather than \
+fabricating results."""
+
+
+def _buildContextMessage(
+    instructions, properties, propertyPaths, annotationCount
+):
+    lines = [
+        instructions,
+        "",
+        "Dataset context:",
+        "- Total annotations: %d" % annotationCount,
+        "- Properties:",
+    ]
+    for prop in properties:
+        lines.append("  - id=%s name=%s" % (
+            prop.get("id"), prop.get("name")
+        ))
+    lines.append("- Plottable property paths (dotted path -> full name):")
+    for propertyPath in propertyPaths:
+        dottedPath = ".".join(propertyPath.get("path", []))
+        lines.append("  - %s -> %s" % (
+            dottedPath, propertyPath.get("fullName")
+        ))
+    return "\n".join(lines)
+
+
+class ClaudeAnalysisResource(Resource):
+    def __init__(self):
+        super().__init__()
+        self.resourceName = "claude_analysis"
+        self.route("POST", (), self.analyze)
+
+        apiKey = os.environ.get("ANTHROPIC_API_KEY")
+        if apiKey:
+            self.client = Anthropic(api_key=apiKey)
+        else:
+            self.client = None
+            logger.error(
+                "Can't create an Anthropic client without an API key, "
+                "the claude_analysis endpoint will not work"
+            )
+
+    @access.user
+    @autoDescribeRoute(
+        Description(
+            "Run an agentic analysis over computed annotation property "
+            "values for a dataset and return a text summary plus "
+            "interactive Plotly chart specs."
+        )
+        .jsonParam("data", "Analysis request", paramType="body", required=True)
+    )
+    def analyze(self, data):
+        return self._analyzeImpl(data)
+
+    def _analyzeImpl(self, data):
+        emptyResponse = {
+            "summary": "",
+            "plots": [],
+            "toolLog": [],
+            "error": None,
+        }
+
+        if self.client is None:
+            emptyResponse["error"] = (
+                "Claude analysis is not configured: missing API key."
+            )
+            return emptyResponse
+
+        datasetIdString = data.get("datasetId")
+        instructions = data.get("instructions")
+        if not datasetIdString or not instructions:
+            emptyResponse["error"] = (
+                "Both datasetId and instructions are required."
+            )
+            return emptyResponse
+
+        properties = data.get("properties", [])
+        propertyPaths = data.get("propertyPaths", [])
+
+        # Convert/validate inputs once at the API boundary.
+        datasetId = ObjectId(datasetIdString)
+        Folder().load(
+            datasetId,
+            user=self.getCurrentUser(),
+            level=AccessType.READ,
+            exc=True,
+        )
+        toolkit = AnalysisToolkit(datasetId)
+
+        annotationCount = toolkit.annotation_count()
+        contextMessage = _buildContextMessage(
+            instructions, properties, propertyPaths, annotationCount
+        )
+
+        messages = [
+            {"role": "user", "content": contextMessage},
+        ]
+        toolLog = []
+
+        try:
+            response = self.client.messages.create(
+                model=MODEL,
+                max_tokens=MAX_TOKENS,
+                system=SYSTEM_PROMPT,
+                tools=toolkit.tool_definitions(),
+                messages=messages,
+            )
+
+            iterations = 0
+            truncated = False
+            while response.stop_reason == "tool_use":
+                iterations += 1
+                if iterations > MAX_ITERATIONS:
+                    truncated = True
+                    break
+
+                messages.append(
+                    {"role": "assistant", "content": response.content}
+                )
+
+                toolResults = []
+                for block in response.content:
+                    if block.type != "tool_use":
+                        continue
+                    toolResults.append(
+                        self._runToolBlock(toolkit, block, toolLog)
+                    )
+
+                messages.append({"role": "user", "content": toolResults})
+
+                response = self.client.messages.create(
+                    model=MODEL,
+                    max_tokens=MAX_TOKENS,
+                    system=SYSTEM_PROMPT,
+                    tools=toolkit.tool_definitions(),
+                    messages=messages,
+                )
+
+            summary = "".join(
+                block.text for block in response.content
+                if block.type == "text"
+            )
+            if truncated:
+                summary += (
+                    "\n\n_Note: analysis stopped early after reaching the "
+                    "maximum number of tool-use iterations._"
+                )
+
+            return {
+                "summary": summary,
+                "plots": toolkit.plots,
+                "toolLog": toolLog,
+                "error": None,
+            }
+        except (anthropic.APIStatusError, anthropic.APIConnectionError) as e:
+            logger.error(
+                "Error in claude_analysis endpoint: %s", str(e),
+                exc_info=True,
+            )
+            return {
+                "summary": "",
+                "plots": toolkit.plots,
+                "toolLog": toolLog,
+                "error": str(e),
+            }
+
+    def _runToolBlock(self, toolkit, block, toolLog):
+        try:
+            result, oneLineSummary = toolkit.run_tool(
+                block.name, block.input
+            )
+            toolLog.append({
+                "tool": block.name,
+                "input": block.input,
+                "summary": oneLineSummary,
+            })
+            return {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": json.dumps(result),
+            }
+        except ValueError as e:
+            errorMessage = str(e)
+            toolLog.append({
+                "tool": block.name,
+                "input": block.input,
+                "summary": "error: %s" % errorMessage,
+            })
+            return {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": errorMessage,
+                "is_error": True,
+            }

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis_tools.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis_tools.py
@@ -112,7 +112,13 @@ class AnalysisToolkit:
         return self._valuesByAnnotationId
 
     def annotation_count(self):
-        return len(self._getAnnotationsById())
+        if self._annotationsById is not None:
+            return len(self._annotationsById)
+        # Indexed count without loading documents; same pattern as the
+        # annotation_property_values count endpoint.
+        return self._annotationModel.collection.count_documents(
+            {"datasetId": self.datasetId}
+        )
 
     def _getAnnotationsById(self):
         if self._annotationsById is None:
@@ -404,21 +410,43 @@ class AnalysisToolkit:
     def _tool_get_histogram(self, toolInput):
         propertyPath = toolInput["property_path"]
         buckets = _clampBuckets(toolInput.get("buckets", 50))
-        rawBuckets = list(self._propertyValuesModel.histogram(
-            propertyPath, self.datasetId, buckets
-        ))
         result = [
             {
-                "min": _roundSignificant(bucket.get("min")),
-                "max": _roundSignificant(bucket.get("max")),
-                "count": bucket.get("count"),
+                "min": _roundSignificant(bucketMin),
+                "max": _roundSignificant(bucketMax),
+                "count": count,
             }
-            for bucket in rawBuckets
+            for bucketMin, bucketMax, count
+            in self._numericHistogramBuckets(propertyPath, buckets)
         ]
         summary = "histogram for %s: %d buckets" % (
             propertyPath, len(result)
         )
         return result, summary
+
+    def _numericHistogramBuckets(self, propertyPath, buckets):
+        """Run the $bucketAuto histogram and keep only buckets with
+        numeric bounds.
+
+        String-valued properties yield non-numeric min/max; raise a
+        recoverable ValueError instead of letting bucket math TypeError.
+        """
+        rawBuckets = list(self._propertyValuesModel.histogram(
+            propertyPath, self.datasetId, buckets
+        ))
+        numericBuckets = []
+        for bucket in rawBuckets:
+            bucketMin = _toNumeric(bucket.get("min"))
+            bucketMax = _toNumeric(bucket.get("max"))
+            if bucketMin is None or bucketMax is None:
+                continue
+            numericBuckets.append((bucketMin, bucketMax, bucket.get("count")))
+        if rawBuckets and not numericBuckets:
+            raise ValueError(
+                "Property path '%s' has no numeric values; it cannot be "
+                "histogrammed." % propertyPath
+            )
+        return numericBuckets
 
     def _tool_get_annotation_summary(self, toolInput):
         annotations = self._getAnnotationsById()
@@ -534,20 +562,15 @@ class AnalysisToolkit:
         buckets = _clampBuckets(toolInput.get("buckets", 50))
         xLabel = toolInput.get("x_label") or propertyPath
 
-        rawBuckets = list(self._propertyValuesModel.histogram(
-            propertyPath, self.datasetId, buckets
-        ))
         xCenters = []
         widths = []
         counts = []
-        for bucket in rawBuckets:
-            bucketMin = bucket.get("min")
-            bucketMax = bucket.get("max")
-            if bucketMin is None or bucketMax is None:
-                continue
+        for bucketMin, bucketMax, count in self._numericHistogramBuckets(
+            propertyPath, buckets
+        ):
             xCenters.append((bucketMin + bucketMax) / 2.0)
             widths.append(bucketMax - bucketMin)
-            counts.append(bucket.get("count"))
+            counts.append(count)
 
         trace = {
             "type": "bar",

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis_tools.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis_tools.py
@@ -11,7 +11,13 @@ logger = logging.getLogger(__name__)
 MAX_SAMPLE_ROWS = 500
 MAX_PLOT_POINTS = 50000
 MAX_BOX_POINTS = 20000
+MAX_HISTOGRAM_BUCKETS = 1000
 SIGNIFICANT_DIGITS = 6
+
+
+def _clampBuckets(buckets):
+    """Clamp a model-supplied bucket count to a range $bucketAuto accepts."""
+    return min(max(int(buckets), 1), MAX_HISTOGRAM_BUCKETS)
 
 
 def _roundSignificant(value, digits=SIGNIFICANT_DIGITS):
@@ -379,18 +385,15 @@ class AnalysisToolkit:
             else:
                 stats["std"] = 0.0
             sortedValues = sorted(values)
-            stats["p25"] = _roundSignificant(
-                statistics.quantiles(
+            if len(sortedValues) > 1:
+                quartiles = statistics.quantiles(
                     sortedValues, n=4, method="inclusive"
-                )[0]
-                if len(sortedValues) > 1 else sortedValues[0]
-            )
-            stats["p75"] = _roundSignificant(
-                statistics.quantiles(
-                    sortedValues, n=4, method="inclusive"
-                )[2]
-                if len(sortedValues) > 1 else sortedValues[0]
-            )
+                )
+                p25, p75 = quartiles[0], quartiles[2]
+            else:
+                p25 = p75 = sortedValues[0]
+            stats["p25"] = _roundSignificant(p25)
+            stats["p75"] = _roundSignificant(p75)
             result[path] = stats
             summaries.append("%s (n=%d)" % (path, len(values)))
         summary = "computed stats for %d path(s): %s" % (
@@ -400,7 +403,7 @@ class AnalysisToolkit:
 
     def _tool_get_histogram(self, toolInput):
         propertyPath = toolInput["property_path"]
-        buckets = int(toolInput.get("buckets", 50))
+        buckets = _clampBuckets(toolInput.get("buckets", 50))
         rawBuckets = list(self._propertyValuesModel.histogram(
             propertyPath, self.datasetId, buckets
         ))
@@ -528,7 +531,7 @@ class AnalysisToolkit:
     def _tool_create_histogram_plot(self, toolInput):
         propertyPath = toolInput["property_path"]
         title = toolInput["title"]
-        buckets = int(toolInput.get("buckets", 50))
+        buckets = _clampBuckets(toolInput.get("buckets", 50))
         xLabel = toolInput.get("x_label") or propertyPath
 
         rawBuckets = list(self._propertyValuesModel.histogram(

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis_tools.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/analysis_tools.py
@@ -1,0 +1,625 @@
+import logging
+import statistics
+from math import floor, log10
+
+from girder.utility.model_importer import ModelImporter
+
+logger = logging.getLogger(__name__)
+
+# Cap on values returned/considered per numeric operation, to keep tool
+# results and token usage bounded.
+MAX_SAMPLE_ROWS = 500
+MAX_PLOT_POINTS = 50000
+MAX_BOX_POINTS = 20000
+SIGNIFICANT_DIGITS = 6
+
+
+def _roundSignificant(value, digits=SIGNIFICANT_DIGITS):
+    """Round a float to a limited number of significant digits.
+
+    Keeps numeric tool results compact to save tokens without losing
+    meaningful precision.
+    """
+    if value is None:
+        return None
+    if value == 0:
+        return 0.0
+    try:
+        exponent = digits - 1 - floor(log10(abs(value)))
+        return round(value, exponent)
+    except (ValueError, OverflowError):
+        return value
+
+
+def _toNumeric(value):
+    """Resolve a leaf value to a float, or None if not numeric.
+
+    Booleans are excluded since bool is a subclass of int in Python and
+    would otherwise silently pass through as 0/1.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def resolvePath(valuesDict, pathParts):
+    """Resolve a dotted property path against a nested values dict.
+
+    :param valuesDict: The "values" sub-document for one annotation.
+    :param pathParts: List of path segments (property id, then subIds).
+    :returns: A float, or None if the path is missing or non-numeric.
+    """
+    current = valuesDict
+    for part in pathParts:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return _toNumeric(current)
+
+
+def _downsample(items, limit):
+    """Deterministically downsample a sequence to at most `limit` items
+    by taking every k-th item, preserving order."""
+    n = len(items)
+    if n <= limit:
+        return items, False
+    step = -(-n // limit)  # ceil division, so result size <= limit
+    return items[::step], True
+
+
+class AnalysisToolkit:
+    """Per-request data access, tool implementations, and plot builders
+    for the Claude analysis panel.
+
+    All tools operate against a single dataset (Folder) ObjectId that is
+    bound server-side at construction time; the model never supplies or
+    chooses the datasetId.
+    """
+
+    def __init__(self, datasetObjectId):
+        self.datasetId = datasetObjectId
+        self._propertyValuesModel = ModelImporter.model(
+            "annotation_property_values", "upenncontrast_annotation"
+        )
+        self._annotationModel = ModelImporter.model(
+            "upenn_annotation", "upenncontrast_annotation"
+        )
+        self._valuesByAnnotationId = None
+        self._annotationsById = None
+        self.plots = []
+        self._nextPlotIndex = 1
+
+    # -- Cached data access -------------------------------------------
+
+    def _getValuesByAnnotationId(self):
+        if self._valuesByAnnotationId is None:
+            cache = {}
+            cursor = self._propertyValuesModel.find(
+                {"datasetId": self.datasetId},
+                fields=["annotationId", "values"],
+            )
+            for doc in cursor:
+                cache[str(doc["annotationId"])] = doc.get("values", {})
+            self._valuesByAnnotationId = cache
+        return self._valuesByAnnotationId
+
+    def annotation_count(self):
+        return len(self._getAnnotationsById())
+
+    def _getAnnotationsById(self):
+        if self._annotationsById is None:
+            cache = {}
+            cursor = self._annotationModel.find(
+                {"datasetId": self.datasetId},
+                fields=["tags", "shape"],
+            )
+            for doc in cursor:
+                cache[str(doc["_id"])] = doc
+            self._annotationsById = cache
+        return self._annotationsById
+
+    def _firstTag(self, annotationId):
+        annotation = self._getAnnotationsById().get(annotationId)
+        if not annotation:
+            return "untagged"
+        tags = annotation.get("tags") or []
+        return tags[0] if tags else "untagged"
+
+    def _collectPathValues(self, path):
+        """Return list of (annotationId, float) for a dotted path,
+        skipping missing/non-numeric values."""
+        pathParts = path.split(".")
+        result = []
+        for annotationId, values in self._getValuesByAnnotationId().items():
+            numeric = resolvePath(values, pathParts)
+            if numeric is not None:
+                result.append((annotationId, numeric))
+        return result
+
+    def _nextPlotId(self):
+        plotId = "plot-%d" % self._nextPlotIndex
+        self._nextPlotIndex += 1
+        return plotId
+
+    # -- Tool schema ----------------------------------------------------
+
+    def tool_definitions(self):
+        return [
+            {
+                "name": "get_property_statistics",
+                "description": (
+                    "Compute summary statistics (count, mean, std, min, "
+                    "max, median, p25, p75) for one or more numeric "
+                    "property paths across all annotations in the "
+                    "dataset. Use this first to understand the scale, "
+                    "spread, and completeness of the data before "
+                    "plotting."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "property_paths": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Dotted property paths, e.g. "
+                                "'propId' or 'propId.subId'."
+                            ),
+                        },
+                    },
+                    "required": ["property_paths"],
+                },
+            },
+            {
+                "name": "get_histogram",
+                "description": (
+                    "Get a binned histogram (min, max, count per bucket) "
+                    "for one numeric property path. Use this to inspect "
+                    "the distribution shape of a property before "
+                    "deciding whether/how to plot it."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "property_path": {
+                            "type": "string",
+                            "description": "Dotted property path.",
+                        },
+                        "buckets": {
+                            "type": "integer",
+                            "description": "Number of buckets (default 50).",
+                        },
+                    },
+                    "required": ["property_path"],
+                },
+            },
+            {
+                "name": "get_annotation_summary",
+                "description": (
+                    "Get the total annotation count and breakdowns by "
+                    "tag and by shape (point/line/polygon/rectangle) for "
+                    "the dataset. Use this to understand what "
+                    "categorical groupings (e.g. for coloring plots by "
+                    "tag) are available."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {},
+                },
+            },
+            {
+                "name": "get_sample_values",
+                "description": (
+                    "Get up to n sample rows (annotation id plus value "
+                    "per requested property path) so you can eyeball raw "
+                    "data before drawing conclusions or plotting."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "property_paths": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Dotted property paths.",
+                        },
+                        "n": {
+                            "type": "integer",
+                            "description": (
+                                "Number of sample rows (default 20)."
+                            ),
+                        },
+                    },
+                    "required": ["property_paths"],
+                },
+            },
+            {
+                "name": "create_scatter_plot",
+                "description": (
+                    "Create an interactive scatter plot of one property "
+                    "against another. Use this to visualize relationships "
+                    "or correlations between two numeric properties. "
+                    "Points with a missing value on either axis are "
+                    "dropped."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "x_path": {
+                            "type": "string",
+                            "description": (
+                                "Dotted property path for the x-axis."
+                            ),
+                        },
+                        "y_path": {
+                            "type": "string",
+                            "description": (
+                                "Dotted property path for the y-axis."
+                            ),
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Plot title.",
+                        },
+                        "x_label": {
+                            "type": "string",
+                            "description": "Optional x-axis label.",
+                        },
+                        "y_label": {
+                            "type": "string",
+                            "description": "Optional y-axis label.",
+                        },
+                        "color_by_tag": {
+                            "type": "boolean",
+                            "description": (
+                                "If true, color points by each "
+                                "annotation's first tag (one trace per "
+                                "tag; untagged annotations grouped "
+                                "together)."
+                            ),
+                        },
+                    },
+                    "required": ["x_path", "y_path", "title"],
+                },
+            },
+            {
+                "name": "create_histogram_plot",
+                "description": (
+                    "Create an interactive histogram (bar chart of "
+                    "binned counts) for one numeric property path. Use "
+                    "this to visualize the distribution of a single "
+                    "property."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "property_path": {
+                            "type": "string",
+                            "description": "Dotted property path.",
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Plot title.",
+                        },
+                        "buckets": {
+                            "type": "integer",
+                            "description": "Number of buckets (default 50).",
+                        },
+                        "x_label": {
+                            "type": "string",
+                            "description": "Optional x-axis label.",
+                        },
+                    },
+                    "required": ["property_path", "title"],
+                },
+            },
+            {
+                "name": "create_box_plot",
+                "description": (
+                    "Create an interactive box plot for one or more "
+                    "numeric property paths, or for one property path "
+                    "grouped by tag. Use this to compare distributions "
+                    "across properties or across categories."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "property_paths": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Dotted property paths.",
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Plot title.",
+                        },
+                        "group_by_tag": {
+                            "type": "boolean",
+                            "description": (
+                                "If true and exactly one property path is "
+                                "given, create one box per tag instead of "
+                                "one box per property path."
+                            ),
+                        },
+                    },
+                    "required": ["property_paths", "title"],
+                },
+            },
+        ]
+
+    # -- Tool dispatch ----------------------------------------------------
+
+    def run_tool(self, name, toolInput):
+        handler = getattr(self, "_tool_" + name, None)
+        if handler is None:
+            raise ValueError("Unknown tool: %s" % name)
+        return handler(toolInput)
+
+    # -- Tool implementations ---------------------------------------------
+
+    def _tool_get_property_statistics(self, toolInput):
+        propertyPaths = toolInput["property_paths"]
+        result = {}
+        summaries = []
+        for path in propertyPaths:
+            values = [v for _, v in self._collectPathValues(path)]
+            if not values:
+                result[path] = {"count": 0}
+                continue
+            stats = {
+                "count": len(values),
+                "mean": _roundSignificant(statistics.fmean(values)),
+                "min": _roundSignificant(min(values)),
+                "max": _roundSignificant(max(values)),
+                "median": _roundSignificant(statistics.median(values)),
+            }
+            if len(values) > 1:
+                stats["std"] = _roundSignificant(statistics.stdev(values))
+            else:
+                stats["std"] = 0.0
+            sortedValues = sorted(values)
+            stats["p25"] = _roundSignificant(
+                statistics.quantiles(
+                    sortedValues, n=4, method="inclusive"
+                )[0]
+                if len(sortedValues) > 1 else sortedValues[0]
+            )
+            stats["p75"] = _roundSignificant(
+                statistics.quantiles(
+                    sortedValues, n=4, method="inclusive"
+                )[2]
+                if len(sortedValues) > 1 else sortedValues[0]
+            )
+            result[path] = stats
+            summaries.append("%s (n=%d)" % (path, len(values)))
+        summary = "computed stats for %d path(s): %s" % (
+            len(propertyPaths), ", ".join(summaries) or "none with data"
+        )
+        return result, summary
+
+    def _tool_get_histogram(self, toolInput):
+        propertyPath = toolInput["property_path"]
+        buckets = int(toolInput.get("buckets", 50))
+        rawBuckets = list(self._propertyValuesModel.histogram(
+            propertyPath, self.datasetId, buckets
+        ))
+        result = [
+            {
+                "min": _roundSignificant(bucket.get("min")),
+                "max": _roundSignificant(bucket.get("max")),
+                "count": bucket.get("count"),
+            }
+            for bucket in rawBuckets
+        ]
+        summary = "histogram for %s: %d buckets" % (
+            propertyPath, len(result)
+        )
+        return result, summary
+
+    def _tool_get_annotation_summary(self, toolInput):
+        annotations = self._getAnnotationsById()
+        tagCounts = {}
+        shapeCounts = {}
+        for annotation in annotations.values():
+            shape = annotation.get("shape", "unknown")
+            shapeCounts[shape] = shapeCounts.get(shape, 0) + 1
+            tags = annotation.get("tags") or []
+            if not tags:
+                tagCounts["untagged"] = tagCounts.get("untagged", 0) + 1
+            for tag in tags:
+                tagCounts[tag] = tagCounts.get(tag, 0) + 1
+        result = {
+            "totalCount": len(annotations),
+            "byTag": tagCounts,
+            "byShape": shapeCounts,
+        }
+        summary = "%d annotations, %d distinct tags, %d shapes" % (
+            len(annotations), len(tagCounts), len(shapeCounts)
+        )
+        return result, summary
+
+    def _tool_get_sample_values(self, toolInput):
+        propertyPaths = toolInput["property_paths"]
+        n = min(int(toolInput.get("n", 20)), MAX_SAMPLE_ROWS)
+        valuesByAnnotationId = self._getValuesByAnnotationId()
+        rows = []
+        for annotationId in list(valuesByAnnotationId.keys())[:n]:
+            values = valuesByAnnotationId[annotationId]
+            row = {"annotationId": annotationId}
+            for path in propertyPaths:
+                numeric = resolvePath(values, path.split("."))
+                row[path] = _roundSignificant(numeric)
+            rows.append(row)
+        summary = "%d sample rows across %d path(s)" % (
+            len(rows), len(propertyPaths)
+        )
+        return rows, summary
+
+    def _tool_create_scatter_plot(self, toolInput):
+        xPath = toolInput["x_path"]
+        yPath = toolInput["y_path"]
+        title = toolInput["title"]
+        xLabel = toolInput.get("x_label") or xPath
+        yLabel = toolInput.get("y_label") or yPath
+        colorByTag = bool(toolInput.get("color_by_tag", False))
+
+        xValues = dict(self._collectPathValues(xPath))
+        yValues = dict(self._collectPathValues(yPath))
+        annotationIds = [
+            annotationId for annotationId in xValues
+            if annotationId in yValues
+        ]
+
+        downsampled = False
+        if len(annotationIds) > MAX_PLOT_POINTS:
+            annotationIds, downsampled = _downsample(
+                annotationIds, MAX_PLOT_POINTS
+            )
+
+        if colorByTag:
+            groups = {}
+            for annotationId in annotationIds:
+                tag = self._firstTag(annotationId)
+                groups.setdefault(tag, []).append(annotationId)
+            traces = []
+            for tag, ids in groups.items():
+                traces.append({
+                    "type": "scattergl",
+                    "mode": "markers",
+                    "name": tag,
+                    "x": [xValues[i] for i in ids],
+                    "y": [yValues[i] for i in ids],
+                    "marker": {"size": 5, "opacity": 0.7},
+                })
+        else:
+            traces = [{
+                "type": "scattergl",
+                "mode": "markers",
+                "name": title,
+                "x": [xValues[i] for i in annotationIds],
+                "y": [yValues[i] for i in annotationIds],
+                "marker": {"size": 5, "opacity": 0.7},
+            }]
+
+        plotTitle = title + (" (downsampled)" if downsampled else "")
+        plot = {
+            "id": self._nextPlotId(),
+            "title": plotTitle,
+            "data": traces,
+            "layout": {
+                "title": plotTitle,
+                "xaxis": {"title": xLabel},
+                "yaxis": {"title": yLabel},
+                "hovermode": "closest",
+            },
+        }
+        self.plots.append(plot)
+        result = {
+            "status": "created",
+            "points": len(annotationIds),
+            "plotId": plot["id"],
+        }
+        summary = "scatter plot '%s' with %d points" % (
+            plotTitle, len(annotationIds)
+        )
+        return result, summary
+
+    def _tool_create_histogram_plot(self, toolInput):
+        propertyPath = toolInput["property_path"]
+        title = toolInput["title"]
+        buckets = int(toolInput.get("buckets", 50))
+        xLabel = toolInput.get("x_label") or propertyPath
+
+        rawBuckets = list(self._propertyValuesModel.histogram(
+            propertyPath, self.datasetId, buckets
+        ))
+        xCenters = []
+        widths = []
+        counts = []
+        for bucket in rawBuckets:
+            bucketMin = bucket.get("min")
+            bucketMax = bucket.get("max")
+            if bucketMin is None or bucketMax is None:
+                continue
+            xCenters.append((bucketMin + bucketMax) / 2.0)
+            widths.append(bucketMax - bucketMin)
+            counts.append(bucket.get("count"))
+
+        trace = {
+            "type": "bar",
+            "name": title,
+            "x": xCenters,
+            "y": counts,
+            "width": widths,
+        }
+        plot = {
+            "id": self._nextPlotId(),
+            "title": title,
+            "data": [trace],
+            "layout": {
+                "title": title,
+                "xaxis": {"title": xLabel},
+                "yaxis": {"title": "count"},
+                "hovermode": "closest",
+                "bargap": 0,
+            },
+        }
+        self.plots.append(plot)
+        result = {
+            "status": "created",
+            "points": len(counts),
+            "plotId": plot["id"],
+        }
+        summary = "histogram plot '%s' with %d buckets" % (
+            title, len(counts)
+        )
+        return result, summary
+
+    def _tool_create_box_plot(self, toolInput):
+        propertyPaths = toolInput["property_paths"]
+        title = toolInput["title"]
+        groupByTag = bool(toolInput.get("group_by_tag", False))
+
+        traces = []
+        if groupByTag and len(propertyPaths) == 1:
+            path = propertyPaths[0]
+            pathValues = dict(self._collectPathValues(path))
+            groups = {}
+            for annotationId, value in pathValues.items():
+                tag = self._firstTag(annotationId)
+                groups.setdefault(tag, []).append(value)
+            for tag, values in groups.items():
+                sampled, _ = _downsample(values, MAX_BOX_POINTS)
+                traces.append({
+                    "type": "box",
+                    "name": tag,
+                    "y": sampled,
+                })
+        else:
+            for path in propertyPaths:
+                values = [v for _, v in self._collectPathValues(path)]
+                sampled, _ = _downsample(values, MAX_BOX_POINTS)
+                traces.append({
+                    "type": "box",
+                    "name": path,
+                    "y": sampled,
+                })
+
+        plot = {
+            "id": self._nextPlotId(),
+            "title": title,
+            "data": traces,
+            "layout": {
+                "title": title,
+                "hovermode": "closest",
+            },
+        }
+        self.plots.append(plot)
+        result = {
+            "status": "created",
+            "traces": len(traces),
+            "plotId": plot["id"],
+        }
+        summary = "box plot '%s' with %d trace(s)" % (title, len(traces))
+        return result, summary

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "p-limit": "^7.1.1",
     "p-retry": "^7.0.0",
     "papaparse": "^5.4.1",
+    "plotly.js-dist-min": "^3.6.0",
     "polygon-clipping": "^0.15.7",
     "qs": "^6.15.2",
     "rbush": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "d3-zoom": "^3.0.0",
     "dataframe-js": "^1.4.4",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.4.11",
     "driver.js": "^1.4.0",
     "earcut": "^3.0.2",
     "fflate": "^0.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dompurify:
+        specifier: ^3.4.11
+        version: 3.4.11
       driver.js:
         specifier: ^1.4.0
         version: 1.4.0
@@ -1670,6 +1673,9 @@ packages:
   '@types/sortablejs@1.15.7':
     resolution: {integrity: sha512-PvgWCx1Lbgm88FdQ6S7OGvLIjWS66mudKPlfdrWil0TjsO5zmoZmzoKiiwRShs1dwPgrlkr0N4ewuy0/+QUXYQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
@@ -2610,6 +2616,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -6354,6 +6363,9 @@ snapshots:
 
   '@types/sortablejs@1.15.7': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/uuid@8.3.4': {}
 
   '@types/web-bluetooth@0.0.21': {}
@@ -7472,6 +7484,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       papaparse:
         specifier: ^5.4.1
         version: 5.4.1
+      plotly.js-dist-min:
+        specifier: ^3.6.0
+        version: 3.6.0
       polygon-clipping:
         specifier: ^0.15.7
         version: 0.15.7
@@ -3755,6 +3758,9 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  plotly.js-dist-min@3.6.0:
+    resolution: {integrity: sha512-VR9jO2YdcEwbzVwtRyPE0eAieXFv1x5q6M9nnIgUS8FggahPrjiID6kzpnTYABwLX0gZkgEc0zxS6gQgVmgHzw==}
 
   polygon-clipping@0.15.7:
     resolution: {integrity: sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==}
@@ -8662,6 +8668,8 @@ snapshots:
   pinkie@2.0.4: {}
 
   platform@1.3.6: {}
+
+  plotly.js-dist-min@3.6.0: {}
 
   polygon-clipping@0.15.7:
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -362,10 +362,27 @@
             </v-btn>
           </template>
         </v-tooltip>
+        <v-tooltip text="AI analysis of property values">
+          <template v-slot:activator="{ props: activatorProps }">
+            <v-btn
+              v-bind="activatorProps"
+              variant="text"
+              icon
+              size="small"
+              @click="analysisPanelOpen = !analysisPanelOpen"
+            >
+              <v-icon>mdi-chart-scatter-plot</v-icon>
+            </v-btn>
+          </template>
+        </v-tooltip>
       </div>
     </v-app-bar>
 
     <chat-component v-if="chatbotOpen" @close="chatbotOpen = false" />
+    <analysis-panel
+      v-if="analysisPanelOpen"
+      @close="analysisPanelOpen = false"
+    />
 
     <v-main>
       <router-view />
@@ -482,6 +499,7 @@ import volumeViewStore from "@/store/volumeView";
 import { logError } from "@/utils/log";
 import { IHotkey } from "@/utils/v-mousetrap";
 import ChatComponent from "@/components/ChatComponent.vue";
+import AnalysisPanel from "@/components/AnalysisPanel.vue";
 import FloatingPalette from "@/components/FloatingPalette.vue";
 import { IGirderFolder } from "@/girder";
 import { ITourMetadata } from "./store/model";
@@ -504,6 +522,7 @@ void Toolset;
 void HelpPanel;
 void BreadCrumbs;
 void ChatComponent;
+void AnalysisPanel;
 
 const route = useRoute();
 const router = useRouter();
@@ -519,6 +538,7 @@ const settingsPanel = ref(false);
 const filtersPanel = ref(false);
 const analyzePanel = ref(false);
 const chatbotOpen = ref(false);
+const analysisPanelOpen = ref(false);
 
 // Left-zone palettes (dissolved left sidebar). Open by default.
 const navigatorPanel = ref(true);
@@ -976,6 +996,7 @@ defineExpose({
   layersPanel,
   analyzePanel,
   chatbotOpen,
+  analysisPanelOpen,
   isUploadLoading,
   helpPanelIsOpen,
   appHotkeys,

--- a/src/components/AnalysisPanel.vue
+++ b/src/components/AnalysisPanel.vue
@@ -1,0 +1,401 @@
+<template>
+  <div ref="rootEl">
+    <v-card class="analysis-panel">
+      <div class="analysis-header">
+        <v-icon size="18" class="mr-2">mdi-chart-scatter-plot</v-icon>
+        <span class="analysis-title">AI Analysis</span>
+        <div class="analysis-header-actions">
+          <v-btn icon variant="text" size="small" @click="emit('close')">
+            <v-icon size="small">mdi-close</v-icon>
+          </v-btn>
+        </div>
+      </div>
+      <v-card-text>
+        <v-alert
+          v-if="propertyStore.computedPropertyPaths.length === 0"
+          type="warning"
+          density="compact"
+          variant="tonal"
+          class="analysis-alert"
+        >
+          No computed property values found for this dataset — compute
+          properties first.
+        </v-alert>
+        <div v-if="runs.length === 0" class="analysis-hint">
+          Describe an analysis of the computed property values, e.g. "Plot
+          intensity vs area colored by tag and summarize the correlation."
+        </div>
+        <div class="analysis-results">
+          <div
+            v-for="run in [...runs].reverse()"
+            :key="run.id"
+            class="analysis-run"
+          >
+            <div class="user">{{ run.instructions }}</div>
+            <template v-if="run.status === 'pending'">
+              <div class="analysis-progress">
+                <v-progress-circular
+                  indeterminate
+                  size="20"
+                  width="2"
+                  color="primary"
+                />
+                <span>Analyzing… the agent is querying property values</span>
+              </div>
+            </template>
+            <template v-else-if="run.status === 'error'">
+              <div class="error">{{ run.error }}</div>
+            </template>
+            <template v-else-if="run.result">
+              <div class="assistant" v-html="marked(run.result.summary)"></div>
+              <analysis-plot
+                v-for="plot in run.result.plots"
+                :key="plot.id"
+                :plot="plot"
+              />
+              <v-expansion-panels
+                v-if="run.result.toolLog.length > 0"
+                variant="accordion"
+                class="analysis-tool-log"
+              >
+                <v-expansion-panel>
+                  <v-expansion-panel-title>
+                    Agent steps ({{ run.result.toolLog.length }})
+                  </v-expansion-panel-title>
+                  <v-expansion-panel-text>
+                    <div
+                      v-for="(entry, index) in run.result.toolLog"
+                      :key="index"
+                      class="tool-log-entry"
+                    >
+                      <strong>{{ entry.tool }}</strong>
+                      <div>{{ entry.summary }}</div>
+                    </div>
+                  </v-expansion-panel-text>
+                </v-expansion-panel>
+              </v-expansion-panels>
+            </template>
+          </div>
+        </div>
+      </v-card-text>
+      <v-card-actions>
+        <div class="bottom-inputs">
+          <v-textarea
+            v-model="instructions"
+            class="analysis-input"
+            placeholder="What should the agent analyze?"
+            rows="2"
+            auto-grow
+            max-rows="5"
+            density="compact"
+            variant="outlined"
+            hide-details
+            :disabled="isRunning"
+            @keydown="handleKeydown"
+          />
+          <v-btn
+            variant="flat"
+            color="primary"
+            size="small"
+            :loading="isRunning"
+            :disabled="isRunning || !instructions.trim()"
+            @click="runAnalysis"
+          >
+            Run analysis
+          </v-btn>
+        </div>
+      </v-card-actions>
+    </v-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { marked } from "marked";
+import { logError } from "@/utils/log";
+import store from "@/store";
+import propertyStore from "@/store/properties";
+import { IAnalysisResult } from "@/store/AnalysisAPI";
+import AnalysisPlot from "@/components/AnalysisPlot.vue";
+
+interface IAnalysisRun {
+  id: string;
+  instructions: string;
+  status: "pending" | "done" | "error";
+  result?: IAnalysisResult;
+  error?: string;
+}
+
+const emit = defineEmits<{
+  (e: "close"): void;
+}>();
+
+const rootEl = ref<HTMLElement>();
+const instructions = ref("");
+const isRunning = ref(false);
+const runs = ref<IAnalysisRun[]>([]);
+
+let nextRunId = 0;
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+    event.preventDefault();
+    runAnalysis();
+  }
+}
+
+async function runAnalysis() {
+  const trimmedInstructions = instructions.value.trim();
+  if (isRunning.value || !trimmedInstructions) {
+    return;
+  }
+
+  const run: IAnalysisRun = {
+    id: `run-${nextRunId++}`,
+    instructions: trimmedInstructions,
+    status: "pending",
+  };
+  runs.value.push(run);
+  instructions.value = "";
+  isRunning.value = true;
+
+  try {
+    if (!store.dataset) {
+      throw new Error("No dataset is open.");
+    }
+    const request = {
+      datasetId: store.dataset.id,
+      instructions: trimmedInstructions,
+      properties: propertyStore.properties.map((property) => ({
+        id: property.id,
+        name: property.name,
+      })),
+      propertyPaths: propertyStore.computedPropertyPaths.map((path) => ({
+        path,
+        fullName: propertyStore.getFullNameFromPath(path),
+      })),
+    };
+    run.result = await store.analysisAPI.runAnalysis(request);
+    run.status = "done";
+  } catch (error) {
+    logError("Analysis run failed", error);
+    run.error = error instanceof Error ? error.message : String(error);
+    run.status = "error";
+  } finally {
+    isRunning.value = false;
+  }
+}
+
+defineExpose({
+  instructions,
+  isRunning,
+  runs,
+  runAnalysis,
+});
+</script>
+
+<style scoped>
+/* === Card container === */
+.analysis-panel {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 640px;
+  height: 720px;
+  max-height: 720px;
+  z-index: 2000;
+  background-color: rgba(var(--v-theme-surface-bright), 0.88);
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  border: 1px solid var(--nimbus-border-strong);
+  border-radius: var(--nimbus-radius-lg);
+}
+
+/* === Header === */
+.analysis-header {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  flex-shrink: 0;
+}
+
+.analysis-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  opacity: 0.9;
+}
+
+.analysis-header-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+}
+
+/* === Body === */
+:deep(.v-card-text) {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 8px;
+}
+
+.analysis-alert {
+  flex-shrink: 0;
+  margin-bottom: 8px;
+}
+
+.analysis-hint {
+  flex-shrink: 0;
+  font-size: 0.82rem;
+  opacity: 0.7;
+  padding: 8px 4px;
+}
+
+.analysis-results {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  gap: 12px;
+  padding: 4px;
+}
+
+.analysis-run {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* === Message bubbles (shared look with chat) === */
+.user {
+  align-self: flex-end;
+  color: #ffffff;
+  background-color: rgba(33, 150, 243, 0.25);
+  border: 1px solid rgba(33, 150, 243, 0.3);
+  padding: 8px 12px;
+  border-radius: 12px 12px 2px 12px;
+  max-width: 80%;
+  width: fit-content;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.assistant {
+  align-self: flex-start;
+  color: rgba(255, 255, 255, 0.92);
+  background-color: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 10px 14px;
+  border-radius: 12px 12px 12px 2px;
+  max-width: 100%;
+  width: 100%;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.analysis-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.82rem;
+  opacity: 0.8;
+  padding: 4px 2px;
+}
+
+.system,
+.error {
+  text-align: center;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+  background-color: rgba(255, 80, 80, 0.15);
+  border: 1px solid rgba(255, 80, 80, 0.2);
+  border-radius: 8px;
+  padding: 6px 12px;
+  margin: 2px 0;
+}
+
+/* === Markdown (v-html needs :deep) === */
+.assistant :deep(h1),
+.assistant :deep(h2),
+.assistant :deep(h3),
+.assistant :deep(h4) {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin: 0.6em 0 0.2em;
+}
+
+.assistant :deep(p) {
+  margin: 0.25em 0;
+}
+
+.assistant :deep(ul),
+.assistant :deep(ol) {
+  padding-left: 1.4em;
+  margin: 0.25em 0;
+}
+
+.assistant :deep(li) {
+  margin: 0.1em 0;
+}
+
+.assistant :deep(code) {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  font-size: 0.82rem;
+}
+
+.assistant :deep(pre) {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.5em;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 0.4em 0;
+}
+
+.assistant :deep(pre code) {
+  background: none;
+  padding: 0;
+}
+
+/* === Tool log === */
+.analysis-tool-log {
+  font-size: 0.8rem;
+}
+
+.tool-log-entry {
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.tool-log-entry:last-child {
+  border-bottom: none;
+}
+
+/* === Input area === */
+:deep(.v-card-actions) {
+  flex-direction: column;
+  align-items: stretch;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.bottom-inputs {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 8px 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.analysis-input {
+  flex: 1;
+}
+</style>

--- a/src/components/AnalysisPanel.vue
+++ b/src/components/AnalysisPanel.vue
@@ -26,11 +26,7 @@
           intensity vs area colored by tag and summarize the correlation."
         </div>
         <div class="analysis-results">
-          <div
-            v-for="run in [...runs].reverse()"
-            :key="run.id"
-            class="analysis-run"
-          >
+          <div v-for="run in reversedRuns" :key="run.id" class="analysis-run">
             <div class="user">{{ run.instructions }}</div>
             <template v-if="run.status === 'pending'">
               <div class="analysis-progress">
@@ -47,7 +43,10 @@
               <div class="error">{{ run.error }}</div>
             </template>
             <template v-else-if="run.result">
-              <div class="assistant" v-html="marked(run.result.summary)"></div>
+              <div
+                class="assistant"
+                v-html="renderMarkdown(run.result.summary)"
+              ></div>
               <analysis-plot
                 v-for="plot in run.result.plots"
                 :key="plot.id"
@@ -110,8 +109,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { marked } from "marked";
+import DOMPurify from "dompurify";
 import { logError } from "@/utils/log";
 import store from "@/store";
 import propertyStore from "@/store/properties";
@@ -134,8 +134,16 @@ const rootEl = ref<HTMLElement>();
 const instructions = ref("");
 const isRunning = ref(false);
 const runs = ref<IAnalysisRun[]>([]);
+// Newest run first in the results list.
+const reversedRuns = computed(() => [...runs.value].reverse());
 
 let nextRunId = 0;
+
+function renderMarkdown(text: string): string {
+  // The summary is model-generated; sanitize so HTML smuggled through the
+  // agent (e.g. via a crafted property name) can't run in our origin.
+  return DOMPurify.sanitize(marked(text) as string);
+}
 
 function handleKeydown(event: KeyboardEvent) {
   if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {

--- a/src/components/AnalysisPlot.vue
+++ b/src/components/AnalysisPlot.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="analysis-plot">
+    <div ref="plotEl" class="analysis-plot-el"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useTheme } from "vuetify";
+import { logError } from "@/utils/log";
+import { IAnalysisPlot } from "@/store/AnalysisAPI";
+
+const props = defineProps<{
+  plot: IAnalysisPlot;
+}>();
+
+const theme = useTheme();
+const plotEl = ref<HTMLElement>();
+
+// Loaded lazily so plotly.js-dist-min never lands in the main bundle.
+let PlotlyModule: any = null;
+
+function buildLayout(): Record<string, unknown> {
+  const fontColor = theme.current.value.colors["on-surface"];
+  return {
+    autosize: true,
+    height: 380,
+    margin: { l: 56, r: 24, t: 40, b: 48 },
+    paper_bgcolor: "transparent",
+    plot_bgcolor: "transparent",
+    font: { color: fontColor },
+    ...props.plot.layout,
+  };
+}
+
+async function renderPlot() {
+  const el = plotEl.value;
+  if (!el) {
+    return;
+  }
+  try {
+    if (!PlotlyModule) {
+      const module = await import("plotly.js-dist-min");
+      // plotly.js-dist-min is a CJS bundle; depending on interop the API
+      // is either the namespace itself or its default export.
+      PlotlyModule = module.default ?? module;
+    }
+    await PlotlyModule.newPlot(el, props.plot.data, buildLayout(), {
+      responsive: true,
+      displaylogo: false,
+    });
+  } catch (error) {
+    logError("Failed to render analysis plot", error);
+  }
+}
+
+watch(
+  () => props.plot,
+  () => {
+    renderPlot();
+  },
+  { deep: true },
+);
+
+onMounted(() => {
+  renderPlot();
+});
+
+onBeforeUnmount(() => {
+  if (PlotlyModule && plotEl.value) {
+    PlotlyModule.purge(plotEl.value);
+  }
+});
+</script>
+
+<style scoped>
+.analysis-plot {
+  width: 100%;
+}
+
+.analysis-plot-el {
+  width: 100%;
+  height: 380px;
+}
+</style>

--- a/src/components/ChatComponent.vue
+++ b/src/components/ChatComponent.vue
@@ -39,7 +39,7 @@
             </div>
             <div
               v-if="message.type === 'assistant'"
-              v-html="marked(message.content)"
+              v-html="renderMarkdown(message.content)"
             ></div>
             <div v-else>{{ message.content }}</div>
           </div>
@@ -122,6 +122,7 @@ import store from "@/store";
 import chatStore from "@/store/chat";
 import { IChatImage, IChatMessage, IGeoJSMap } from "@/store/model";
 import { marked } from "marked";
+import DOMPurify from "dompurify";
 import html2canvas from "html2canvas";
 
 const emit = defineEmits<{
@@ -149,6 +150,12 @@ const firstMap = computed<IGeoJSMap | undefined>(() =>
 const visibleImagesInput = computed(() =>
   filterVisibleImages(imagesInput.value),
 );
+
+function renderMarkdown(text: string): string {
+  // Assistant messages are model-generated; sanitize so HTML smuggled
+  // through the model can't run in our origin.
+  return DOMPurify.sanitize(marked(text) as string);
+}
 
 function clearInputs() {
   textInput.value = "";

--- a/src/plotly-dist-min.d.ts
+++ b/src/plotly-dist-min.d.ts
@@ -1,0 +1,1 @@
+declare module "plotly.js-dist-min";

--- a/src/store/AnalysisAPI.ts
+++ b/src/store/AnalysisAPI.ts
@@ -1,0 +1,57 @@
+import { RestClientInstance } from "@/girder";
+
+export interface IAnalysisPropertyRef {
+  id: string;
+  name: string;
+}
+
+export interface IAnalysisPropertyPathRef {
+  path: string[];
+  fullName: string | null;
+}
+
+export interface IAnalysisRequest {
+  datasetId: string;
+  instructions: string;
+  properties: IAnalysisPropertyRef[];
+  propertyPaths: IAnalysisPropertyPathRef[];
+}
+
+export interface IAnalysisPlot {
+  id: string;
+  title: string;
+  data: unknown[];
+  layout: Record<string, unknown>;
+}
+
+export interface IAnalysisToolLogEntry {
+  tool: string;
+  input: Record<string, unknown>;
+  summary: string;
+}
+
+export interface IAnalysisResult {
+  summary: string;
+  plots: IAnalysisPlot[];
+  toolLog: IAnalysisToolLogEntry[];
+  error: string | null;
+}
+
+export default class AnalysisAPI {
+  private readonly client: RestClientInstance;
+
+  constructor(client: RestClientInstance) {
+    this.client = client;
+  }
+
+  async runAnalysis(request: IAnalysisRequest): Promise<IAnalysisResult> {
+    const response = await this.client.post("claude_analysis", {
+      ...request,
+    });
+    const { data } = response;
+    if (data?.error) {
+      throw new Error(data.error);
+    }
+    return data as IAnalysisResult;
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,6 +25,7 @@ import { v4 as uuidv4 } from "uuid";
 import AnnotationsAPI from "./AnnotationsAPI";
 import PropertiesAPI from "./PropertiesAPI";
 import ChatAPI from "./ChatAPI";
+import AnalysisAPI from "./AnalysisAPI";
 import GirderAPI from "./GirderAPI";
 import ExportAPI from "./ExportAPI";
 import ProjectsAPI from "./ProjectsAPI";
@@ -236,6 +237,7 @@ export class Main extends VuexModule {
   annotationsAPI = new AnnotationsAPI(this.girderRestProxy);
   propertiesAPI = new PropertiesAPI(this.girderRestProxy);
   chatAPI = new ChatAPI(this.girderRestProxy);
+  analysisAPI = new AnalysisAPI(this.girderRestProxy);
   exportAPI = new ExportAPI(this.girderRestProxy);
   projectsAPI = new ProjectsAPI(this.girderRestProxy);
   zenodoAPI = new ZenodoAPI(this.girderRestProxy);


### PR DESCRIPTION
New POST /api/v1/claude_analysis endpoint in the girder-claude-chat plugin
runs a Claude (claude-sonnet-5) agent loop with dataset-bound tools over
computed annotation property values: statistics, histograms, samples,
tag/shape summaries, and Plotly plot builders (scatter, histogram, box).
Dataset READ access is checked once at the API boundary; tools never
receive a caller-chosen datasetId. Plot data arrays are assembled
server-side from MongoDB so raw values stay out of the model context.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HrBgREFZ2T7zYzMZbHjh1p