### PR TITLE
feat(tools): add line scan tool with live intensity panel

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -88,6 +88,50 @@ The tool demonstrates how to:
 - Handle mouse interactions directly when appropriate
 - Follow existing patterns while simplifying them for simpler use cases
 
+## Example: Line scan tool
+
+The line scan tool is a *measurement* tool: it never creates stored annotations.
+It plots the raw pixel intensities along a line in a panel at the bottom right
+of the viewer, updating live while the line is being drawn.
+
+### The template
+
+This tool has the type `linescan`. Its submenu is a `select` of id `lineType`
+with two variants:
+- `freehand`: uses the GeoJS `"line"` annotation mode. The interaction layer
+  option `continuousCloseProximity` is set to `true` while this tool is active
+  so that a freehand drag completes as soon as the mouse is released (the GeoJS
+  default requires a double click). Clicking instead of dragging still builds a
+  multi-segment polyline, ended with a double or right click.
+- `segment`: uses the GeoJS `"point"` mode with the same two-click state
+  machine as the click-connect tool: the first click stores the segment start
+  (`lineScanSegmentStart`), mouse moves preview the segment, the second click
+  completes it.
+
+The second interface element (id `layer`) is of type `layerSelect`, a reusable
+interface type that stores an optional layer id (see `OptionalLayerSelect.vue`).
+It lets the user optionally pick a channel when creating the tool; the panel
+then defaults to showing just that channel, with a toggle to show all channels.
+
+### The logic
+
+The tool state is shared through the small `lineScan` store module
+(`src/store/lineScan.ts`): `AnnotationViewer.vue` publishes the line vertices
+(image pixel coordinates) while drawing — a throttled `mousemove` handler reads
+`interactionLayer.currentAnnotation` for the freehand preview — and
+`LineScanPanel.vue` (mounted in `ImageViewer.vue`) watches them, fetches the
+pixel data and renders the graph. Dismissing the panel clears the store, which
+the viewer watches to remove the displayed line.
+
+Intensities are *raw* values, not the styled/contrast-adjusted display: the
+panel fetches the bounding box of the line for each scanned layer's current
+frame through `GirderAPI.getRawRegion` (the large_image
+`/item/{id}/tiles/region` endpoint with `encoding=TIFF&tiffCompression=raw`,
+decoded by `src/utils/tiff.ts`), then bilinearly samples up to 400 points along
+the line (`src/utils/lineScan.ts`). One region request is made per scanned
+layer because every layer displays a different frame. Very large regions are
+downsampled by the server (capped at 2048 px per side).
+
 ## Featured Tools Configuration
 
 The file `public/config/featuredTools.json` configures which tools appear in the "Featured" section at the top of the tool selection dialog.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -92,7 +92,10 @@ The tool demonstrates how to:
 
 The line scan tool is a *measurement* tool: it never creates stored annotations.
 It plots the raw pixel intensities along a line in a panel at the bottom right
-of the viewer, updating live while the line is being drawn.
+of the viewer, updating live while the line is being drawn. The panel also
+shows the line length in pixels and, when the configuration has a physical
+pixel size (anything other than the 1 m placeholder default), in physical
+units.
 
 ### The template
 

--- a/nimbusimage/docs/api/images.md
+++ b/nimbusimage/docs/api/images.md
@@ -1,7 +1,33 @@
 # Images
 
-Image retrieval, stacking, and compositing.
+Image retrieval, stacking, compositing, and line-scan intensity profiles.
+
+## Line scan example
+
+Measure an intensity profile along a line — the same computation as the
+viewer's line scan tool. Works with an anonymous connection on public
+datasets.
+
+```python
+import nimbusimage as ni
+
+client = ni.connect("http://localhost:8080/api/v1", anonymous=True)
+ds = client.dataset("<public-dataset-id>")
+
+# Straight segment (two points) or a freehand path (more points),
+# in image pixel coordinates
+scan = ds.images.line_scan([(120, 512), (520, 512)], channel=0, time=0)
+
+scan.distances   # (N,) distance from start, in pixels
+scan.values      # (N,) intensities; NaN where the line leaves the image
+scan.points      # (N, 2) sampled (x, y) coordinates
+
+# Distances in physical units
+microns = scan.distances * ds.pixel_size.to("um").value
+```
 
 ::: nimbusimage.images.ImageAccessor
+
+::: nimbusimage.images.LineScanResult
 
 ::: nimbusimage.images.ImageWriter

--- a/nimbusimage/docs/getting-started.md
+++ b/nimbusimage/docs/getting-started.md
@@ -25,7 +25,14 @@ client = ni.connect("http://localhost:8080/api/v1", username="admin", password="
 
 # Option 3: Environment variables (NI_API_URL, NI_TOKEN)
 client = ni.connect()
+
+# Option 4: Anonymous — public datasets only, no credentials needed
+client = ni.connect("http://localhost:8080/api/v1", anonymous=True)
 ```
+
+Anonymous connections can read and measure **public** datasets (for
+example, running `ds.images.line_scan(...)` on published data) but cannot
+access private resources.
 
 ## Working with datasets
 

--- a/nimbusimage/nimbusimage/__init__.py
+++ b/nimbusimage/nimbusimage/__init__.py
@@ -13,6 +13,7 @@ from nimbusimage.client import NimbusClient
 from nimbusimage.collections import Collection
 from nimbusimage.coordinates import attach_geometry_methods
 from nimbusimage.dataset import Dataset
+from nimbusimage.images import LineScanResult
 from nimbusimage.jobs import Job
 from nimbusimage.filters import (
     filter_by_tags,
@@ -39,6 +40,7 @@ def connect(
     api_key: str | None = None,
     username: str | None = None,
     password: str | None = None,
+    anonymous: bool = False,
 ) -> NimbusClient:
     """Connect to a NimbusImage server.
 
@@ -50,13 +52,16 @@ def connect(
             session tokens). Recommended for automation.
         username: Username for interactive auth.
         password: Password for interactive auth.
+        anonymous: Connect without credentials. Only public
+            datasets are accessible (e.g., for measurements on
+            published data).
 
     Returns:
         Authenticated NimbusClient.
     """
     return NimbusClient(
         api_url=api_url, token=token, api_key=api_key,
-        username=username, password=password,
+        username=username, password=password, anonymous=anonymous,
     )
 
 
@@ -93,6 +98,7 @@ __all__ = [
     "Dataset",
     "Job",
     "WorkerContext",
+    "LineScanResult",
     # Data models
     "Annotation",
     "Connection",

--- a/nimbusimage/nimbusimage/_girder.py
+++ b/nimbusimage/nimbusimage/_girder.py
@@ -63,15 +63,17 @@ def create_client(
     api_key: str | None = None,
     username: str | None = None,
     password: str | None = None,
+    anonymous: bool = False,
 ) -> girder_client.GirderClient:
     """Create and authenticate a GirderClient.
 
     Connection modes (tried in order):
-    1. Explicit token
-    2. Explicit API key
-    3. Username + password
-    4. NI_API_KEY environment variable
-    5. NI_TOKEN environment variable
+    1. Anonymous (no authentication; public resources only)
+    2. Explicit token
+    3. Explicit API key
+    4. Username + password
+    5. NI_API_KEY environment variable
+    6. NI_TOKEN environment variable
 
     Args:
         api_url: Girder API URL (e.g., 'http://localhost:8080/api/v1').
@@ -79,6 +81,8 @@ def create_client(
         api_key: Girder API key (persistent, doesn't expire).
         username: Username for interactive auth.
         password: Password for interactive auth.
+        anonymous: Connect without credentials. Only public resources
+            are accessible.
 
     Returns:
         Authenticated GirderClient instance.
@@ -100,7 +104,15 @@ def create_client(
     # every request when it is set.
     gc._session = _build_retry_session()
 
-    if token is not None:
+    if anonymous:
+        if any(
+            credential is not None
+            for credential in (token, api_key, username, password)
+        ):
+            raise ValueError(
+                "anonymous=True cannot be combined with credentials"
+            )
+    elif token is not None:
         gc.setToken(token)
     elif api_key is not None:
         gc.authenticate(apiKey=api_key)

--- a/nimbusimage/nimbusimage/client.py
+++ b/nimbusimage/nimbusimage/client.py
@@ -19,6 +19,7 @@ class NimbusClient:
         client = ni.connect(api_url, token=...)
         client = ni.connect(api_url, username=..., password=...)
         client = ni.connect()  # from NI_API_URL + NI_TOKEN env vars
+        client = ni.connect(api_url, anonymous=True)  # public data only
     """
 
     def __init__(
@@ -29,6 +30,7 @@ class NimbusClient:
         username: str | None = None,
         password: str | None = None,
         frontend_url: str = DEFAULT_FRONTEND_URL,
+        anonymous: bool = False,
     ):
         self._gc = create_client(
             api_url=api_url,
@@ -36,6 +38,7 @@ class NimbusClient:
             api_key=api_key,
             username=username,
             password=password,
+            anonymous=anonymous,
         )
         self._api_url = api_url or os.environ.get(
             "NI_API_URL", self._gc.urlBase

--- a/nimbusimage/nimbusimage/images.py
+++ b/nimbusimage/nimbusimage/images.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pickle
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, NamedTuple, Sequence
 
 import numpy as np
 
@@ -11,6 +11,22 @@ from nimbusimage.models import FrameInfo
 
 if TYPE_CHECKING:
     from nimbusimage.dataset import Dataset
+
+
+class LineScanResult(NamedTuple):
+    """Intensity profile along a polyline.
+
+    Attributes:
+        distances: (N,) distances of each sample from the start of the
+            line, in pixels.
+        values: (N,) float64 intensities, bilinearly interpolated.
+            NaN for samples outside the image.
+        points: (N, 2) x, y image coordinates of each sample.
+    """
+
+    distances: np.ndarray
+    values: np.ndarray
+    points: np.ndarray
 
 
 class ImageAccessor:
@@ -211,6 +227,131 @@ class ImageAccessor:
             max_val = np.iinfo(dt).max
             return (composite * max_val).astype(dt)
 
+    def line_scan(
+        self,
+        points: Sequence[tuple[float, float]] | np.ndarray,
+        xy: int = 0,
+        z: int = 0,
+        time: int = 0,
+        channel: int = 0,
+        max_samples: int = 2000,
+        max_region_dim: int = 2048,
+    ) -> LineScanResult:
+        """Measure the intensity profile along a polyline.
+
+        Matches the frontend line scan tool: the polyline is resampled at
+        roughly one sample per pixel of arc length and intensities are
+        bilinearly interpolated from the pixels around each sample.
+
+        Args:
+            points: Polyline vertices as (x, y) pairs in image pixel
+                coordinates. Two points measure a straight segment; more
+                points a freehand path.
+            xy, z, time, channel: Frame coordinates.
+            max_samples: Cap on the number of samples along the line.
+            max_region_dim: Pixel regions larger than this per side are
+                downsampled by the server before sampling. Bounds the
+                transfer size for lines spanning huge images.
+
+        Returns:
+            LineScanResult with distances (px), values (NaN outside the
+            image), and the sampled (x, y) points. Convert distances to
+            physical units with ds.pixel_size.
+
+        Raises:
+            ValueError: For fewer than 2 vertices or a zero-length line.
+        """
+        vertices = np.asarray(points, dtype=np.float64)
+        if vertices.ndim != 2 or vertices.shape[0] < 2 or (
+            vertices.shape[1] != 2
+        ):
+            raise ValueError(
+                "points must be at least 2 (x, y) pairs, "
+                f"got array of shape {vertices.shape}"
+            )
+        segment_lengths = np.hypot(
+            *np.diff(vertices, axis=0).T
+        )
+        cumulative = np.concatenate([[0.0], np.cumsum(segment_lengths)])
+        total_length = cumulative[-1]
+        if total_length <= 0:
+            raise ValueError("line has zero length")
+
+        num_samples = min(
+            max_samples, max(2, int(np.ceil(total_length)) + 1)
+        )
+        distances = np.linspace(0.0, total_length, num_samples)
+        sample_points = np.column_stack([
+            np.interp(distances, cumulative, vertices[:, 0]),
+            np.interp(distances, cumulative, vertices[:, 1]),
+        ])
+
+        region, left, top, scale_x, scale_y = self._get_scaled_region(
+            frame=self._frame_index(channel, time, z, xy),
+            bounds=(
+                np.floor(sample_points.min(axis=0)) - 1,
+                np.ceil(sample_points.max(axis=0)) + 2,
+            ),
+            max_region_dim=max_region_dim,
+        )
+
+        values = _bilinear_sample(
+            region,
+            (sample_points[:, 0] - left) * scale_x - 0.5,
+            (sample_points[:, 1] - top) * scale_y - 0.5,
+        )
+        return LineScanResult(
+            distances=distances, values=values, points=sample_points
+        )
+
+    def _get_scaled_region(
+        self,
+        frame: int,
+        bounds: tuple[np.ndarray, np.ndarray],
+        max_region_dim: int,
+    ) -> tuple[np.ndarray, float, float, float, float]:
+        """Fetch a region clamped to the image, downsampled to fit
+        max_region_dim per side.
+
+        Args:
+            frame: Frame index.
+            bounds: ((min_x, min_y), (max_x, max_y)) region corners in
+                image pixel coordinates; clamped to the image size.
+            max_region_dim: Maximum output size per side.
+
+        Returns:
+            (region, left, top, scale_x, scale_y) where
+            region_x = (image_x - left) * scale_x.
+        """
+        self._dataset._ensure_metadata()
+        left = max(0.0, float(bounds[0][0]))
+        top = max(0.0, float(bounds[0][1]))
+        right = min(float(self._dataset._tiles["sizeX"]), float(bounds[1][0]))
+        bottom = min(
+            float(self._dataset._tiles["sizeY"]), float(bounds[1][1])
+        )
+        if right <= left or bottom <= top:
+            raise ValueError("line is entirely outside the image")
+        kwargs: dict = {
+            "left": left, "top": top, "right": right, "bottom": bottom,
+        }
+        region_width = right - left
+        region_height = bottom - top
+        scale = min(1.0, max_region_dim / max(region_width, region_height))
+        if scale < 1.0:
+            kwargs["width"] = round(region_width * scale)
+            kwargs["height"] = round(region_height * scale)
+        region = self._get_region(frame, **kwargs).squeeze()
+        # The server preserves the aspect ratio, so the effective scale can
+        # differ slightly from the requested one — use the returned size
+        return (
+            region,
+            left,
+            top,
+            region.shape[1] / region_width,
+            region.shape[0] / region_height,
+        )
+
     def iter_frames(self) -> Iterator[tuple[FrameInfo, np.ndarray]]:
         """Iterate over all frames in the dataset.
 
@@ -236,6 +377,46 @@ class ImageAccessor:
                 "Install with: pip install nimbusimage[worker]"
             )
         return ImageWriter(self._dataset, copy_metadata=copy_metadata)
+
+
+def _bilinear_sample(
+    region: np.ndarray, x: np.ndarray, y: np.ndarray
+) -> np.ndarray:
+    """Bilinearly interpolate region values at fractional pixel coordinates.
+
+    Args:
+        region: (H, W) or (H, W, bands) array. Multi-band pixels (e.g. RGB
+            sources) are averaged over the first three bands, ignoring a
+            potential alpha band.
+        x, y: (N,) fractional pixel coordinates into region.
+
+    Returns:
+        (N,) float64 values, NaN where (x, y) is outside the region.
+    """
+    if region.ndim == 3:
+        region = region[:, :, : min(region.shape[2], 3)].mean(axis=2)
+    region = region.astype(np.float64)
+    height, width = region.shape
+
+    inside = (x >= 0) & (y >= 0) & (x <= width - 1) & (y <= height - 1)
+    # Clamp so indexing is valid everywhere; outside samples become NaN below
+    x = np.clip(x, 0, width - 1)
+    y = np.clip(y, 0, height - 1)
+    x0 = np.floor(x).astype(np.intp)
+    y0 = np.floor(y).astype(np.intp)
+    x1 = np.minimum(x0 + 1, width - 1)
+    y1 = np.minimum(y0 + 1, height - 1)
+    fx = x - x0
+    fy = y - y0
+
+    values = (
+        region[y0, x0] * (1 - fx) * (1 - fy)
+        + region[y0, x1] * fx * (1 - fy)
+        + region[y1, x0] * (1 - fx) * fy
+        + region[y1, x1] * fx * fy
+    )
+    values[~inside] = np.nan
+    return values
 
 
 def _parse_color(color: str) -> tuple[float, float, float]:

--- a/nimbusimage/pyproject.toml
+++ b/nimbusimage/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 worker = ["large-image"]
-dev = ["pytest", "pytest-mock"]
+dev = ["pytest", "pytest-mock", "tifffile"]
 docs = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]
 
 [project.urls]

--- a/nimbusimage/tests/integration/test_live_client.py
+++ b/nimbusimage/tests/integration/test_live_client.py
@@ -1,6 +1,11 @@
 """Integration tests for NimbusClient."""
 
+import os
+
+import numpy as np
 import pytest
+
+import nimbusimage as ni
 
 pytestmark = pytest.mark.integration
 
@@ -13,3 +18,101 @@ class TestLiveClient:
     def test_list_projects(self, client):
         projects = client.list_projects()
         assert isinstance(projects, list)
+
+
+class TestLiveAnonymousAccess:
+    """Public-dataset workflow: connect without credentials, read a public
+    dataset, run measurements, but stay blocked from private data."""
+
+    @pytest.fixture(scope="class")
+    def public_dataset(self, client):
+        """Create a dataset with a tiny image, make it public, clean up.
+
+        Skips if the authenticated user can't create public content.
+        """
+        gc = client.girder
+        user = gc.get("user/me")
+        public_folders = gc.get("folder", parameters={
+            "parentType": "user", "parentId": user["_id"], "name": "Public",
+        })
+        if not public_folders:
+            pytest.skip("authenticated user has no Public folder")
+        import json
+        folder = gc.post("folder", parameters={
+            "parentType": "folder", "parentId": public_folders[0]["_id"],
+            "name": "nimbusimage_anon_test", "public": True,
+            "reuseExisting": True,
+            "metadata": json.dumps({"subtype": "contrastDataset"}),
+        })
+
+        # Upload a small deterministic TIFF so images.get / line_scan work.
+        # The server tiles it via large_image; the client only writes a TIFF.
+        try:
+            import tifffile
+        except ImportError:
+            gc.delete(f"folder/{folder['_id']}")
+            pytest.skip("tifffile not installed for test image upload")
+
+        import tempfile
+        arr = np.tile(
+            np.arange(64, dtype=np.uint16)[None, :], (64, 1)
+        )  # value == column index, exact under bilinear
+        path = os.path.join(tempfile.gettempdir(), "anon_test.tiff")
+        tifffile.imwrite(path, arr)
+        item = gc.uploadFileToFolder(folder["_id"], path)
+        os.remove(path)
+        # large_image usually auto-tiles TIFFs on upload; if not, request it.
+        try:
+            gc.post(f"item/{item['itemId']}/tiles")
+        except Exception as exc:
+            if "already has largeImage" not in str(exc):
+                raise
+
+        yield folder["_id"], arr
+        gc.delete(f"folder/{folder['_id']}")
+
+    def test_anonymous_connect_has_no_token(self, api_url):
+        anon = ni.connect(api_url, anonymous=True)
+        assert not anon.girder.token
+
+    def test_anonymous_reads_public_and_line_scans(
+        self, api_url, public_dataset,
+    ):
+        folder_id, arr = public_dataset
+        anon = ni.connect(api_url, anonymous=True)
+        ds = anon.dataset(folder_id)
+        # Row scan: value equals column index in the source image
+        result = ds.images.line_scan(
+            [(5.5, 32.5), (58.5, 32.5)], channel=0, z=0, time=0,
+        )
+        np.testing.assert_allclose(
+            result.values, np.arange(5, 59, dtype=np.float64), atol=1e-6
+        )
+
+    @pytest.fixture
+    def private_folder(self, client):
+        """A folder in the user's Private folder, cleaned up after."""
+        gc = client.girder
+        user = gc.get("user/me")
+        private_folders = gc.get("folder", parameters={
+            "parentType": "user", "parentId": user["_id"], "name": "Private",
+        })
+        if not private_folders:
+            pytest.skip("authenticated user has no Private folder")
+        folder = gc.post("folder", parameters={
+            "parentType": "folder", "parentId": private_folders[0]["_id"],
+            "name": "nimbusimage_private_test", "public": False,
+            "reuseExisting": True,
+        })
+        yield folder["_id"]
+        gc.delete(f"folder/{folder['_id']}")
+
+    def test_anonymous_denied_private_dataset(self, api_url, private_folder):
+        """A private folder must not be readable anonymously."""
+        anon = ni.connect(api_url, anonymous=True)
+        with pytest.raises(Exception) as exc_info:
+            anon.girder.get(f"folder/{private_folder}")
+        status = getattr(exc_info.value, "status", None)
+        assert status in (401, 403), (
+            f"expected auth error, got {exc_info.value!r}"
+        )

--- a/nimbusimage/tests/integration/test_live_config_images.py
+++ b/nimbusimage/tests/integration/test_live_config_images.py
@@ -111,3 +111,48 @@ class TestLiveComposite:
         assert rgb.dtype == np.float64
         assert rgb.min() >= 0.0
         assert rgb.max() <= 1.0
+
+
+class TestLiveLineScan:
+    def test_line_scan_matches_raw_pixels(self, dataset_with_collection):
+        """A horizontal scan sampled at pixel centers must reproduce the
+        raw pixel row exactly — validates the coordinate convention against
+        a real backend, not just a mock."""
+        ds = dataset_with_collection
+        img = ds.images.get(channel=0, z=0, time=0)
+        h, w = img.shape
+        row = h // 2
+        right = min(w - 1, 200)
+        result = ds.images.line_scan(
+            [(10.5, row + 0.5), (right + 0.5, row + 0.5)],
+            channel=0, z=0, time=0,
+        )
+        expected = img[row, 10:right + 1].astype(np.float64)
+        assert len(result.values) == len(expected)
+        np.testing.assert_allclose(result.values, expected, rtol=1e-6)
+
+    def test_line_scan_outside_image_is_nan(self, dataset_with_collection):
+        ds = dataset_with_collection
+        h, _ = ds.images.get(channel=0, z=0, time=0).shape
+        result = ds.images.line_scan(
+            [(-30.0, h // 2), (30.0, h // 2)], channel=0, z=0, time=0,
+        )
+        assert np.isnan(result.values[result.points[:, 0] < 0]).all()
+        assert np.isfinite(
+            result.values[result.points[:, 0] >= 1]
+        ).all()
+
+    def test_line_scan_downsampled_long_line(self, dataset_with_collection):
+        """A line across the whole image forces the server-side downsample
+        path; values must still track a full-resolution scan."""
+        ds = dataset_with_collection
+        h, w = ds.images.get(channel=0, z=0, time=0).shape
+        line = [(0, 0), (w - 1, h - 1)]
+        low = ds.images.line_scan(
+            line, channel=0, z=0, time=0, max_region_dim=256
+        )
+        full = ds.images.line_scan(line, channel=0, z=0, time=0)
+        both = np.isfinite(low.values) & np.isfinite(full.values)
+        assert both.sum() > 0.8 * len(low.values)
+        corr = np.corrcoef(low.values[both], full.values[both])[0, 1]
+        assert corr > 0.8

--- a/nimbusimage/tests/test_client.py
+++ b/nimbusimage/tests/test_client.py
@@ -55,6 +55,41 @@ class TestNimbusClientInit:
             with pytest.raises(ValueError, match="api_url must be provided"):
                 NimbusClient()
 
+    def test_connect_anonymous(self):
+        with patch("nimbusimage._girder.girder_client.GirderClient") as MockGC:
+            mock_gc = MagicMock()
+            MockGC.return_value = mock_gc
+
+            NimbusClient(
+                api_url="http://localhost:8080/api/v1",
+                anonymous=True,
+            )
+            mock_gc.authenticate.assert_not_called()
+            mock_gc.setToken.assert_not_called()
+
+    def test_connect_anonymous_ignores_env_credentials(self):
+        """anonymous=True must not silently authenticate from env vars."""
+        with patch("nimbusimage._girder.girder_client.GirderClient") as MockGC:
+            mock_gc = MagicMock()
+            MockGC.return_value = mock_gc
+
+            with patch.dict(os.environ, {
+                "NI_API_URL": "http://env:8080/api/v1",
+                "NI_API_KEY": "envkey",
+            }):
+                NimbusClient(anonymous=True)
+            mock_gc.authenticate.assert_not_called()
+            mock_gc.setToken.assert_not_called()
+
+    def test_connect_anonymous_with_credentials_raises(self):
+        with patch("nimbusimage._girder.girder_client.GirderClient"):
+            with pytest.raises(ValueError, match="anonymous"):
+                NimbusClient(
+                    api_url="http://localhost:8080/api/v1",
+                    anonymous=True,
+                    token="tok123",
+                )
+
 
 class TestNimbusClientProperties:
     def test_girder_escape_hatch(self, mock_gc):

--- a/nimbusimage/tests/test_images.py
+++ b/nimbusimage/tests/test_images.py
@@ -204,6 +204,172 @@ class TestIterFrames:
         assert frames[0][1].shape == (768, 1024)
 
 
+def _mock_gradient_region_endpoint(mock_gc):
+    """Serve tiles/region requests from a synthetic linear gradient.
+
+    The master image has pixel values master[r, c] = 2*c + 3*r, i.e. the
+    continuous field g(x, y) = 2*(x - 0.5) + 3*(y - 0.5) at pixel centers.
+    Linear fields are reproduced exactly by bilinear interpolation and by
+    center-aligned downsampling, so tests can assert exact values.
+
+    Returns the list of captured request parameter dicts.
+    """
+    captured = []
+
+    def side_effect(path, parameters=None, jsonResp=True):
+        captured.append(parameters)
+        p = parameters
+        left, top = p["left"], p["top"]
+        width = p.get("width", int(round(p["right"] - left)))
+        height = p.get("height", int(round(p["bottom"] - top)))
+        scale_x = width / (p["right"] - left)
+        scale_y = height / (p["bottom"] - top)
+        cols, rows = np.meshgrid(np.arange(width), np.arange(height))
+        x = left + (cols + 0.5) / scale_x
+        y = top + (rows + 0.5) / scale_y
+        arr = 2.0 * (x - 0.5) + 3.0 * (y - 0.5)
+        response = MagicMock()
+        response.content = pickle.dumps(arr)
+        return response
+
+    mock_gc.get.side_effect = side_effect
+    return captured
+
+
+def _gradient(x, y):
+    """The continuous field matching _mock_gradient_region_endpoint."""
+    return 2.0 * (np.asarray(x) - 0.5) + 3.0 * (np.asarray(y) - 0.5)
+
+
+class TestLineScan:
+    def test_straight_line_values_and_distances(
+        self, mock_gc, sample_tiles_metadata,
+    ):
+        ds = _make_dataset(mock_gc, sample_tiles_metadata)
+        _mock_gradient_region_endpoint(mock_gc)
+
+        result = ds.images.line_scan([(5, 10), (15, 10)])
+
+        # ~1 sample per pixel of length: 10 px -> 11 samples
+        assert len(result.distances) == 11
+        np.testing.assert_allclose(result.distances, np.arange(11.0))
+        np.testing.assert_allclose(
+            result.values, _gradient(np.linspace(5, 15, 11), 10)
+        )
+        np.testing.assert_allclose(result.points[:, 1], 10.0)
+
+    def test_polyline_distances_and_corner(
+        self, mock_gc, sample_tiles_metadata,
+    ):
+        ds = _make_dataset(mock_gc, sample_tiles_metadata)
+        _mock_gradient_region_endpoint(mock_gc)
+
+        result = ds.images.line_scan([(10, 10), (20, 10), (20, 20)])
+
+        assert result.distances[-1] == 20.0
+        assert np.all(np.diff(result.distances) > 0)
+        # Sample at distance 10 is the corner vertex (20, 10)
+        corner = np.argmin(np.abs(result.distances - 10.0))
+        np.testing.assert_allclose(result.points[corner], [20.0, 10.0])
+        np.testing.assert_allclose(
+            result.values[corner], _gradient(20.0, 10.0)
+        )
+
+    def test_outside_image_is_nan(self, mock_gc, sample_tiles_metadata):
+        ds = _make_dataset(mock_gc, sample_tiles_metadata)
+        _mock_gradient_region_endpoint(mock_gc)
+
+        result = ds.images.line_scan([(-20, 5), (10, 5)])
+
+        outside = result.points[:, 0] < 0
+        assert outside.any()
+        assert np.isnan(result.values[outside]).all()
+        inside = result.points[:, 0] >= 1
+        assert np.isfinite(result.values[inside]).all()
+        np.testing.assert_allclose(
+            result.values[inside],
+            _gradient(result.points[inside, 0], 5),
+        )
+
+    def test_large_region_downsampled(self, mock_gc):
+        tiles = {
+            "sizeX": 5000, "sizeY": 4000, "dtype": "uint16",
+            "frames": [],
+        }
+        ds = _make_dataset(mock_gc, tiles)
+        captured = _mock_gradient_region_endpoint(mock_gc)
+
+        result = ds.images.line_scan([(0, 0), (4000, 3000)])
+
+        # 5000 px long line, capped at 2000 samples
+        assert len(result.distances) == 2000
+        # The region request must be capped to max_region_dim per side
+        params = captured[0]
+        assert params["width"] == 2048
+        assert max(params["width"], params["height"]) == 2048
+        # Values still map back to image coordinates exactly
+        finite = np.isfinite(result.values)
+        np.testing.assert_allclose(
+            result.values[finite],
+            _gradient(
+                result.points[finite, 0], result.points[finite, 1]
+            ),
+        )
+
+    def test_short_line_sample_count(self, mock_gc, sample_tiles_metadata):
+        ds = _make_dataset(mock_gc, sample_tiles_metadata)
+        _mock_gradient_region_endpoint(mock_gc)
+
+        result = ds.images.line_scan([(10, 10), (14.2, 10)])
+        # ceil(4.2) + 1 = 6 samples
+        assert len(result.distances) == 6
+
+    def test_frame_selection(self, mock_gc, sample_tiles_metadata):
+        ds = _make_dataset(mock_gc, sample_tiles_metadata)
+        captured = _mock_gradient_region_endpoint(mock_gc)
+
+        ds.images.line_scan([(5, 10), (15, 10)], channel=1, z=1)
+
+        # channel=1, z=1 -> frame 3 in sample metadata
+        assert captured[0]["frame"] == 3
+
+    def test_multiband_region_averaged(
+        self, mock_gc, sample_tiles_metadata,
+    ):
+        ds = _make_dataset(mock_gc, sample_tiles_metadata)
+
+        def side_effect(path, parameters=None, jsonResp=True):
+            p = parameters
+            width = int(round(p["right"] - p["left"]))
+            height = int(round(p["bottom"] - p["top"]))
+            cols, rows = np.meshgrid(np.arange(width), np.arange(height))
+            band = _gradient(p["left"] + cols + 0.5, p["top"] + rows + 0.5)
+            # Three bands offset by 0, 3, 6 -> mean is band + 3
+            arr = np.stack([band, band + 3, band + 6], axis=-1)
+            response = MagicMock()
+            response.content = pickle.dumps(arr)
+            return response
+
+        mock_gc.get.side_effect = side_effect
+        result = ds.images.line_scan([(5, 10), (15, 10)])
+        np.testing.assert_allclose(
+            result.values, _gradient(result.points[:, 0], 10) + 3
+        )
+
+    def test_invalid_inputs_raise(self, mock_gc, sample_tiles_metadata):
+        import pytest
+
+        ds = _make_dataset(mock_gc, sample_tiles_metadata)
+        with pytest.raises(ValueError, match="at least 2"):
+            ds.images.line_scan([(5, 10)])
+        with pytest.raises(ValueError, match="zero length"):
+            ds.images.line_scan([(5, 10), (5, 10)])
+        with pytest.raises(ValueError, match="at least 2"):
+            ds.images.line_scan([5, 10])
+        with pytest.raises(ValueError, match="outside the image"):
+            ds.images.line_scan([(-50, -50), (-10, -10)])
+
+
 class TestParseColor:
     def test_white(self):
         assert _parse_color("white") == (1.0, 1.0, 1.0)

--- a/public/config/templates.json
+++ b/public/config/templates.json
@@ -426,6 +426,41 @@
     ]
   },
   {
+    "name": "Line scan tools",
+    "type": "linescan",
+    "shortName": "Linescan",
+    "interface": [
+      {
+        "name": "Line type",
+        "type": "select",
+        "id": "lineType",
+        "isSubmenu": true,
+        "meta": {
+          "items": [
+            {
+              "text": "Freehand line scan",
+              "value": "freehand",
+              "description": "Drag to plot intensity along a freehand line"
+            },
+            {
+              "text": "Segment line scan",
+              "value": "segment",
+              "description": "Click two points to plot intensity along a line"
+            }
+          ]
+        }
+      },
+      {
+        "name": "Channel (optional)",
+        "id": "layer",
+        "type": "layerSelect",
+        "meta": {
+          "label": "Channel"
+        }
+      }
+    ]
+  },
+  {
     "name": "Tagging tools",
     "type": "tagging",
     "shortName": "Tag",

--- a/src/components/AnnotationViewer.test.ts
+++ b/src/components/AnnotationViewer.test.ts
@@ -103,6 +103,7 @@ const mockAnnotationLayer = () => {
     geoOn: vi.fn(),
     geoOff: vi.fn(),
     mode: vi.fn(),
+    options: vi.fn(),
     currentAnnotation: null,
     map: vi.fn(() => ({
       unitsPerPixel: vi.fn().mockReturnValue(1),

--- a/src/components/AnnotationViewer.test.ts
+++ b/src/components/AnnotationViewer.test.ts
@@ -329,6 +329,7 @@ import store from "@/store";
 import annotationStore from "@/store/annotation";
 import propertiesStore from "@/store/properties";
 import filterStore from "@/store/filters";
+import lineScanStore from "@/store/lineScan";
 import {
   pointDistance,
   getAnnotationStyleFromBaseStyle,
@@ -4301,6 +4302,73 @@ describe("AnnotationViewer", () => {
         expect(
           (wrapper.vm as any).interactionLayer.addAnnotation,
         ).toHaveBeenCalled();
+      });
+    });
+
+    describe("linescan auto-restart on next gesture", () => {
+      const armTool = (type: string, lineType?: "freehand" | "segment") => {
+        mockedStore.selectedTool = {
+          configuration: {
+            id: "t1",
+            type,
+            values: lineType ? { lineType: { value: lineType } } : {},
+          },
+          state: {},
+        } as any;
+      };
+      const completedLine = {
+        points: [
+          { x: 0, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        isComplete: true,
+      };
+
+      beforeEach(() => {
+        lineScanStore.clearLine();
+      });
+
+      it("clears a completed freehand scan on mousedown", () => {
+        wrapper = mountComponent();
+        armTool("linescan", "freehand");
+        lineScanStore.setLine(completedLine);
+        expect(lineScanStore.points).not.toBeNull();
+
+        (wrapper.vm as any).handleLineScanMouseDown();
+
+        expect(lineScanStore.points).toBeNull();
+      });
+
+      it("does NOT clear a completed segment scan on mousedown (a segment left-drag pans the map)", () => {
+        wrapper = mountComponent();
+        armTool("linescan", "segment");
+        lineScanStore.setLine(completedLine);
+
+        (wrapper.vm as any).handleLineScanMouseDown();
+
+        // Segment restarts are cleared on the first click, not on mousedown,
+        // so panning never wipes the scan.
+        expect(lineScanStore.points).not.toBeNull();
+      });
+
+      it("leaves an in-progress (incomplete) freehand scan untouched on mousedown", () => {
+        wrapper = mountComponent();
+        armTool("linescan", "freehand");
+        lineScanStore.setLine({ ...completedLine, isComplete: false });
+
+        (wrapper.vm as any).handleLineScanMouseDown();
+
+        expect(lineScanStore.points).not.toBeNull();
+      });
+
+      it("does nothing when a non-linescan tool is active", () => {
+        wrapper = mountComponent();
+        armTool("create");
+        lineScanStore.setLine(completedLine);
+
+        (wrapper.vm as any).handleLineScanMouseDown();
+
+        expect(lineScanStore.points).not.toBeNull();
       });
     });
   });

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -1944,26 +1944,24 @@ function removeLineScanAnnotation() {
 function clearLineScanState() {
   removeLineScanAnnotation();
   lineScanSegmentStart.value = null;
+  lineScanStore.setSegmentStartPlaced(false);
 }
 
 // Display the scanned line on the interaction layer and publish it to the
-// linescan store, where LineScanPanel picks it up to plot the intensities
+// linescan store, where LineScanPanel picks it up to plot the intensities.
+// The display annotation is recreated on every update: addAnnotation converts
+// the image coordinates to map coordinates exactly once per added annotation,
+// so mutating an already-added annotation's coordinates in place would leave
+// them in the wrong coordinate space (drawn mirrored off-image).
 function updateLineScanLine(
   coordinates: IGeoJSPosition[],
   isComplete: boolean,
 ) {
-  if (lineScanAnnotation.value) {
-    lineScanAnnotation.value._coordinates(coordinates);
-    lineScanAnnotation.value.draw();
-  } else {
-    const annotation = geojsAnnotationFactory(
-      AnnotationShape.Line,
-      coordinates,
-      { style: { ...lineScanDisplayStyle } },
-    );
-    if (!annotation) {
-      return;
-    }
+  removeLineScanAnnotation();
+  const annotation = geojsAnnotationFactory(AnnotationShape.Line, coordinates, {
+    style: { ...lineScanDisplayStyle },
+  });
+  if (annotation) {
     annotation.options("specialAnnotation", true);
     lineScanAnnotation.value = markRaw(annotation);
     props.interactionLayer.addAnnotation(annotation);
@@ -1975,31 +1973,39 @@ function updateLineScanLine(
 }
 
 // Live updates while the line is being drawn: segment previews between the
-// two clicks, and freehand lines while the mouse button is held down
-const handleLineScanMouseMove = throttle((evt: IGeoJSMouseState) => {
-  if (selectedToolConfiguration.value?.type !== "linescan" || !evt?.geo) {
-    return;
-  }
-  if (isLineScanSegmentTool.value) {
-    if (lineScanSegmentStart.value) {
-      updateLineScanLine([lineScanSegmentStart.value, evt.geo], false);
-    }
-  } else {
-    const current = props.interactionLayer.currentAnnotation;
-    if (!current) {
+// two clicks, and freehand lines while the mouse button is held down.
+// Bound to both mousemove (segment previews) and actionmove (freehand drags:
+// geojs suppresses mousemove events while a drag action is active).
+const handleLineScanMouseMove = throttle(
+  (evt: { geo?: IGeoJSPosition; mouse?: IGeoJSMouseState }) => {
+    const geo = evt?.geo ?? evt?.mouse?.geo;
+    if (selectedToolConfiguration.value?.type !== "linescan" || !geo) {
       return;
     }
-    // A new line is being drawn: it replaces the previous scan display
-    removeLineScanAnnotation();
-    const coordinates = current.coordinates();
-    if (coordinates.length >= 2) {
+    if (isLineScanSegmentTool.value) {
+      if (lineScanSegmentStart.value) {
+        updateLineScanLine([lineScanSegmentStart.value, geo], false);
+      }
+    } else {
+      // The layer always holds an empty in-create annotation while the tool
+      // is armed; fewer than 2 coordinates means no drag is in progress and
+      // the previously scanned line stays displayed
+      const coordinates =
+        props.interactionLayer.currentAnnotation?.coordinates() ?? [];
+      if (coordinates.length < 2) {
+        return;
+      }
+      // A new line is being drawn: geojs displays it while the drag is in
+      // progress, so only replace the previous scan display and plot data
+      removeLineScanAnnotation();
       lineScanStore.setLine({
         points: coordinates.map(({ x, y }) => ({ x, y })),
         isComplete: false,
       });
     }
-  }
-}, THROTTLE);
+  },
+  THROTTLE,
+);
 
 function handleLineScanAnnotationDone(annotation: IGeoJSAnnotation) {
   const coordinates = annotation.coordinates().map(({ x, y }) => ({ x, y }));
@@ -2009,9 +2015,11 @@ function handleLineScanAnnotationDone(annotation: IGeoJSAnnotation) {
     if (lineScanSegmentStart.value === null) {
       removeLineScanAnnotation();
       lineScanSegmentStart.value = coordinates[0];
+      lineScanStore.setSegmentStartPlaced(true);
     } else {
       updateLineScanLine([lineScanSegmentStart.value, coordinates[0]], true);
       lineScanSegmentStart.value = null;
+      lineScanStore.setSegmentStartPlaced(false);
     }
   } else if (coordinates.length >= 2) {
     removeLineScanAnnotation();
@@ -2156,6 +2164,10 @@ function clearAnnotationMode() {
     cursorAnnotation.value = null;
   }
   props.interactionLayer.geoOff(geojs.event.mousemove, handleLineScanMouseMove);
+  props.interactionLayer.geoOff(
+    geojs.event.actionmove,
+    handleLineScanMouseMove,
+  );
   // Restore the geojs default changed by the freehand linescan mode
   props.interactionLayer.options("continuousCloseProximity", 10);
 }
@@ -2254,6 +2266,10 @@ function setNewAnnotationMode() {
       }
       props.interactionLayer.geoOn(
         geojs.event.mousemove,
+        handleLineScanMouseMove,
+      );
+      props.interactionLayer.geoOn(
+        geojs.event.actionmove,
         handleLineScanMouseMove,
       );
       break;
@@ -2763,6 +2779,7 @@ function unbindInteractionEvents(layer: IGeoJSAnnotationLayer | undefined) {
   // always-detach is safe.
   layer.geoOff(geojs.event.mouseclick, handleTaggingClick);
   layer.geoOff(geojs.event.mousemove, handleLineScanMouseMove);
+  layer.geoOff(geojs.event.actionmove, handleLineScanMouseMove);
 }
 
 function bindTimelapseEvents(
@@ -3212,12 +3229,21 @@ watch(selectedToolConfiguration, () => {
   watchTool();
 });
 
-// Linescan tool selection: publish the configured channel layer and drop any
-// ongoing scan when switching to another tool
+// Linescan tool selection: publish the tool state the panel needs (channel
+// layer, line type) and drop any ongoing scan when switching to another tool
 watch(selectedToolConfiguration, (toolConfiguration) => {
   if (toolConfiguration?.type === "linescan") {
     lineScanStore.setToolLayerId(toolConfiguration.values.layer ?? null);
+    lineScanStore.setToolLineType(
+      toolConfiguration.values.lineType?.value === "segment"
+        ? "segment"
+        : "freehand",
+    );
+    // A segment started with the previously selected tool can't be finished
+    lineScanSegmentStart.value = null;
+    lineScanStore.setSegmentStartPlaced(false);
   } else {
+    lineScanStore.setToolLineType(null);
     lineScanStore.clearLine();
   }
 });
@@ -3342,6 +3368,7 @@ onBeforeUnmount(() => {
   unbindAnnotationEvents(props.annotationLayer);
   unbindInteractionEvents(props.interactionLayer);
   unbindTimelapseEvents(props.timelapseLayer);
+  lineScanStore.setToolLineType(null);
   lineScanStore.clearLine();
   if (spatialIndexRequestId !== null) {
     cancelIdleCallback(spatialIndexRequestId);

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -45,6 +45,7 @@ import store from "@/store";
 import annotationStore from "@/store/annotation";
 import propertiesStore from "@/store/properties";
 import filterStore from "@/store/filters";
+import lineScanStore from "@/store/lineScan";
 
 import geojs from "geojs";
 import { snapCoordinates } from "@/utils/itk";
@@ -219,6 +220,11 @@ const samPromptAnnotations = shallowRef<IGeoJSAnnotation[]>([]);
 const samUnsubmittedAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const samLivePreviewAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const cursorAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+// Line displayed on the interaction layer for the linescan tool (segment
+// preview and completed scans)
+const lineScanAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
+// First click of a segment linescan, waiting for the second click
+const lineScanSegmentStart = ref<IGeoJSPosition | null>(null);
 // Plain coordinate array, fully replaced on each set — shallowRef purely
 // because nothing reads its inner mutations, not because it's heavy.
 const dragOriginalCoordinates = shallowRef<IGeoJSPosition[] | null>(null);
@@ -1913,6 +1919,106 @@ async function addAnnotationFromSnapping(annotation: IGeoJSAnnotation) {
   );
 }
 
+// ---- Linescan tool ----
+
+const isLineScanSegmentTool = computed(
+  () =>
+    selectedToolConfiguration.value?.type === "linescan" &&
+    selectedToolConfiguration.value.values.lineType?.value === "segment",
+);
+
+const lineScanDisplayStyle = {
+  strokeColor: "white",
+  strokeWidth: 2,
+  strokeOpacity: 0.9,
+  fill: false,
+};
+
+function removeLineScanAnnotation() {
+  if (lineScanAnnotation.value) {
+    props.interactionLayer.removeAnnotation(lineScanAnnotation.value);
+    lineScanAnnotation.value = null;
+  }
+}
+
+function clearLineScanState() {
+  removeLineScanAnnotation();
+  lineScanSegmentStart.value = null;
+}
+
+// Display the scanned line on the interaction layer and publish it to the
+// linescan store, where LineScanPanel picks it up to plot the intensities
+function updateLineScanLine(
+  coordinates: IGeoJSPosition[],
+  isComplete: boolean,
+) {
+  if (lineScanAnnotation.value) {
+    lineScanAnnotation.value._coordinates(coordinates);
+    lineScanAnnotation.value.draw();
+  } else {
+    const annotation = geojsAnnotationFactory(
+      AnnotationShape.Line,
+      coordinates,
+      { style: { ...lineScanDisplayStyle } },
+    );
+    if (!annotation) {
+      return;
+    }
+    annotation.options("specialAnnotation", true);
+    lineScanAnnotation.value = markRaw(annotation);
+    props.interactionLayer.addAnnotation(annotation);
+  }
+  lineScanStore.setLine({
+    points: coordinates.map(({ x, y }) => ({ x, y })),
+    isComplete,
+  });
+}
+
+// Live updates while the line is being drawn: segment previews between the
+// two clicks, and freehand lines while the mouse button is held down
+const handleLineScanMouseMove = throttle((evt: IGeoJSMouseState) => {
+  if (selectedToolConfiguration.value?.type !== "linescan" || !evt?.geo) {
+    return;
+  }
+  if (isLineScanSegmentTool.value) {
+    if (lineScanSegmentStart.value) {
+      updateLineScanLine([lineScanSegmentStart.value, evt.geo], false);
+    }
+  } else {
+    const current = props.interactionLayer.currentAnnotation;
+    if (!current) {
+      return;
+    }
+    // A new line is being drawn: it replaces the previous scan display
+    removeLineScanAnnotation();
+    const coordinates = current.coordinates();
+    if (coordinates.length >= 2) {
+      lineScanStore.setLine({
+        points: coordinates.map(({ x, y }) => ({ x, y })),
+        isComplete: false,
+      });
+    }
+  }
+}, THROTTLE);
+
+function handleLineScanAnnotationDone(annotation: IGeoJSAnnotation) {
+  const coordinates = annotation.coordinates().map(({ x, y }) => ({ x, y }));
+  props.interactionLayer.removeAnnotation(annotation);
+  if (isLineScanSegmentTool.value) {
+    // Two-click segment: first click starts the line, second click ends it
+    if (lineScanSegmentStart.value === null) {
+      removeLineScanAnnotation();
+      lineScanSegmentStart.value = coordinates[0];
+    } else {
+      updateLineScanLine([lineScanSegmentStart.value, coordinates[0]], true);
+      lineScanSegmentStart.value = null;
+    }
+  } else if (coordinates.length >= 2) {
+    removeLineScanAnnotation();
+    updateLineScanLine(coordinates, true);
+  }
+}
+
 async function handleAnnotationEdits(selectAnnotation: IGeoJSAnnotation) {
   const selectedAnns = getSelectedAnnotationsFromAnnotation(selectAnnotation);
 
@@ -2049,6 +2155,9 @@ function clearAnnotationMode() {
     props.interactionLayer.geoOff(geojs.event.zoom, updateCursorAnnotation);
     cursorAnnotation.value = null;
   }
+  props.interactionLayer.geoOff(geojs.event.mousemove, handleLineScanMouseMove);
+  // Restore the geojs default changed by the freehand linescan mode
+  props.interactionLayer.options("continuousCloseProximity", 10);
 }
 
 function setupCircleDrawingMode() {
@@ -2133,6 +2242,20 @@ function setNewAnnotationMode() {
       } else {
         props.interactionLayer.mode("line");
       }
+      break;
+    case "linescan":
+      if (isLineScanSegmentTool.value) {
+        props.interactionLayer.mode("point");
+      } else {
+        // Complete freehand lines as soon as the mouse is released instead
+        // of requiring a double click (the geojs default)
+        props.interactionLayer.options("continuousCloseProximity", true);
+        props.interactionLayer.mode("line");
+      }
+      props.interactionLayer.geoOn(
+        geojs.event.mousemove,
+        handleLineScanMouseMove,
+      );
       break;
     case "samAnnotation":
     case null:
@@ -2220,6 +2343,9 @@ function handleInteractionAnnotationChange(evt: any) {
           break;
         case "snap":
           addAnnotationFromSnapping(evt.annotation);
+          break;
+        case "linescan":
+          handleLineScanAnnotationDone(evt.annotation);
           break;
         case "select":
           selectAnnotations(evt.annotation);
@@ -2632,9 +2758,11 @@ function unbindInteractionEvents(layer: IGeoJSAnnotationLayer | undefined) {
     handleInteractionAnnotationChange,
   );
   layer.geoOff(geojs.event.annotation.state, handleInteractionAnnotationChange);
-  // handleTaggingClick is conditionally bound based on tool type; geoOff
-  // is a no-op when nothing matches, so always-detach is safe.
+  // handleTaggingClick and handleLineScanMouseMove are conditionally bound
+  // based on tool type; geoOff is a no-op when nothing matches, so
+  // always-detach is safe.
   layer.geoOff(geojs.event.mouseclick, handleTaggingClick);
+  layer.geoOff(geojs.event.mousemove, handleLineScanMouseMove);
 }
 
 function bindTimelapseEvents(
@@ -3084,6 +3212,27 @@ watch(selectedToolConfiguration, () => {
   watchTool();
 });
 
+// Linescan tool selection: publish the configured channel layer and drop any
+// ongoing scan when switching to another tool
+watch(selectedToolConfiguration, (toolConfiguration) => {
+  if (toolConfiguration?.type === "linescan") {
+    lineScanStore.setToolLayerId(toolConfiguration.values.layer ?? null);
+  } else {
+    lineScanStore.clearLine();
+  }
+});
+
+// Linescan dismissal (panel close button, tool switch): remove the displayed
+// line and reset the segment state
+watch(
+  () => lineScanStore.points,
+  (points) => {
+    if (points === null) {
+      clearLineScanState();
+    }
+  },
+);
+
 // ROI filter
 watch(roiFilter, () => {
   watchFilter();
@@ -3193,6 +3342,7 @@ onBeforeUnmount(() => {
   unbindAnnotationEvents(props.annotationLayer);
   unbindInteractionEvents(props.interactionLayer);
   unbindTimelapseEvents(props.timelapseLayer);
+  lineScanStore.clearLine();
   if (spatialIndexRequestId !== null) {
     cancelIdleCallback(spatialIndexRequestId);
   }
@@ -3311,6 +3461,14 @@ defineExpose({
   addAnnotationFromGeoJsAnnotation,
   addAnnotationFromSnapping,
   handleAnnotationEdits,
+  // Linescan tool
+  lineScanAnnotation,
+  lineScanSegmentStart,
+  isLineScanSegmentTool,
+  updateLineScanLine,
+  handleLineScanMouseMove,
+  handleLineScanAnnotationDone,
+  clearLineScanState,
   editPolygonAnnotation,
   handleNewROIFilter,
   updateCursorAnnotation,

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -225,6 +225,9 @@ const cursorAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 const lineScanAnnotation = shallowRef<IGeoJSAnnotation | null>(null);
 // First click of a segment linescan, waiting for the second click
 const lineScanSegmentStart = ref<IGeoJSPosition | null>(null);
+// Interaction layer option value to restore when the freehand linescan tool
+// releases its continuousCloseProximity override (null = no override active)
+const lineScanSavedCloseProximity = ref<number | boolean | null>(null);
 // Plain coordinate array, fully replaced on each set — shallowRef purely
 // because nothing reads its inner mutations, not because it's heavy.
 const dragOriginalCoordinates = shallowRef<IGeoJSPosition[] | null>(null);
@@ -2168,8 +2171,16 @@ function clearAnnotationMode() {
     geojs.event.actionmove,
     handleLineScanMouseMove,
   );
-  // Restore the geojs default changed by the freehand linescan mode
-  props.interactionLayer.options("continuousCloseProximity", 10);
+  // Restore the layer option overridden by the freehand linescan mode; the
+  // layer is created with its own value (see ImageViewer), so put back what
+  // was there rather than the geojs default
+  if (lineScanSavedCloseProximity.value !== null) {
+    props.interactionLayer.options(
+      "continuousCloseProximity",
+      lineScanSavedCloseProximity.value,
+    );
+    lineScanSavedCloseProximity.value = null;
+  }
 }
 
 function setupCircleDrawingMode() {
@@ -2260,7 +2271,11 @@ function setNewAnnotationMode() {
         props.interactionLayer.mode("point");
       } else {
         // Complete freehand lines as soon as the mouse is released instead
-        // of requiring a double click (the geojs default)
+        // of requiring a double click, whatever the layer is configured with
+        if (lineScanSavedCloseProximity.value === null) {
+          lineScanSavedCloseProximity.value =
+            props.interactionLayer.options("continuousCloseProximity") ?? null;
+        }
         props.interactionLayer.options("continuousCloseProximity", true);
         props.interactionLayer.mode("line");
       }
@@ -3245,6 +3260,10 @@ watch(selectedToolConfiguration, (toolConfiguration) => {
   } else {
     lineScanStore.setToolLineType(null);
     lineScanStore.clearLine();
+    // clearLine doesn't retrigger the points watcher when no line was ever
+    // published (points already null, e.g. a segment start without a
+    // preview), so clear the local state directly as well
+    clearLineScanState();
   }
 });
 

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -2010,6 +2010,23 @@ const handleLineScanMouseMove = throttle(
   THROTTLE,
 );
 
+// Freehand only: pressing to start a new drag clears the previously completed
+// scan the moment the gesture begins, so the next line starts fresh without
+// first pressing Clear. Segment (point) mode is excluded on purpose — there a
+// left-drag pans the map, so clearing on mousedown would wipe the scan every
+// time the user pans. Segment restarts are cleared on the first click instead
+// (see handleLineScanAnnotationDone). Guarded on isComplete so it never fires
+// while a freehand drag is still in progress.
+function handleLineScanMouseDown() {
+  if (
+    selectedToolConfiguration.value?.type === "linescan" &&
+    !isLineScanSegmentTool.value &&
+    lineScanStore.isComplete
+  ) {
+    lineScanStore.clearLine();
+  }
+}
+
 function handleLineScanAnnotationDone(annotation: IGeoJSAnnotation) {
   const coordinates = annotation.coordinates().map(({ x, y }) => ({ x, y }));
   props.interactionLayer.removeAnnotation(annotation);
@@ -2019,6 +2036,11 @@ function handleLineScanAnnotationDone(annotation: IGeoJSAnnotation) {
       removeLineScanAnnotation();
       lineScanSegmentStart.value = coordinates[0];
       lineScanStore.setSegmentStartPlaced(true);
+      // Placing the first point of a new segment clears any previously
+      // completed scan so its graph doesn't linger. Keep a single-point line
+      // (not null) so the points watcher doesn't reset the segment start we
+      // just set.
+      lineScanStore.setLine({ points: [coordinates[0]], isComplete: false });
     } else {
       updateLineScanLine([lineScanSegmentStart.value, coordinates[0]], true);
       lineScanSegmentStart.value = null;
@@ -2171,6 +2193,7 @@ function clearAnnotationMode() {
     geojs.event.actionmove,
     handleLineScanMouseMove,
   );
+  props.interactionLayer.geoOff(geojs.event.mousedown, handleLineScanMouseDown);
   // Restore the layer option overridden by the freehand linescan mode; the
   // layer is created with its own value (see ImageViewer), so put back what
   // was there rather than the geojs default
@@ -2286,6 +2309,10 @@ function setNewAnnotationMode() {
       props.interactionLayer.geoOn(
         geojs.event.actionmove,
         handleLineScanMouseMove,
+      );
+      props.interactionLayer.geoOn(
+        geojs.event.mousedown,
+        handleLineScanMouseDown,
       );
       break;
     case "samAnnotation":
@@ -3513,6 +3540,7 @@ defineExpose({
   isLineScanSegmentTool,
   updateLineScanLine,
   handleLineScanMouseMove,
+  handleLineScanMouseDown,
   handleLineScanAnnotationDone,
   clearLineScanState,
   editPolygonAnnotation,

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -96,6 +96,7 @@
         </div>
       </div>
     </div>
+    <line-scan-panel />
     <div class="bottom-right-container">
       <v-btn
         v-if="submitPendingAnnotation"
@@ -234,6 +235,7 @@ import {
 import setFrameQuad, { ISetQuadStatus } from "@/utils/setFrameQuad";
 
 import AnnotationViewer from "@/components/AnnotationViewer.vue";
+import LineScanPanel from "@/components/LineScanPanel.vue";
 import ImageOverview from "@/components/ImageOverview.vue";
 import ScaleSettings from "@/components/ScaleSettings.vue";
 import ProgressBarGroup from "@/components/ProgressBarGroup.vue";

--- a/src/components/LineScanPanel.vue
+++ b/src/components/LineScanPanel.vue
@@ -1,0 +1,500 @@
+<template>
+  <v-card v-if="isActive" class="line-scan-panel" elevation="8">
+    <div class="panel-header">
+      <v-icon size="16" class="mr-1">mdi-chart-bell-curve</v-icon>
+      <span class="panel-title">Line scan</span>
+      <v-progress-circular
+        v-if="isLoading"
+        indeterminate
+        size="12"
+        width="2"
+        class="ml-2"
+      />
+      <v-spacer />
+      <v-btn
+        variant="text"
+        icon
+        size="x-small"
+        title="Dismiss line scan"
+        @click="dismiss"
+      >
+        <v-icon size="16">mdi-close</v-icon>
+      </v-btn>
+    </div>
+    <div v-if="toolLayer" class="panel-controls">
+      <v-btn-toggle
+        v-model="channelMode"
+        mandatory
+        density="compact"
+        class="channel-toggle"
+      >
+        <v-btn value="all" size="x-small">All channels</v-btn>
+        <v-btn value="selected" size="x-small">{{ toolLayer.name }}</v-btn>
+      </v-btn-toggle>
+    </div>
+    <div v-if="visibleSeries.length" class="panel-legend">
+      <span
+        v-for="serie in visibleSeries"
+        :key="serie.layerId"
+        class="legend-entry"
+      >
+        <span class="legend-dot" :style="{ background: serie.color }" />
+        {{ serie.name }}
+      </span>
+    </div>
+    <svg
+      v-if="visibleSeries.length"
+      class="panel-chart"
+      :viewBox="`0 0 ${chartWidth} ${chartHeight}`"
+      :width="chartWidth"
+      :height="chartHeight"
+      @mousemove="onChartMouseMove"
+      @mouseleave="hoverIndex = null"
+    >
+      <!-- grid and axes -->
+      <g class="chart-grid">
+        <line
+          v-for="tick in yTicks"
+          :key="`y-${tick}`"
+          :x1="margin.left"
+          :x2="chartWidth - margin.right"
+          :y1="yScale(tick)"
+          :y2="yScale(tick)"
+        />
+        <line
+          v-for="tick in xTicks"
+          :key="`x-${tick}`"
+          :x1="xScale(tick)"
+          :x2="xScale(tick)"
+          :y1="margin.top"
+          :y2="chartHeight - margin.bottom"
+        />
+      </g>
+      <g class="chart-tick-labels">
+        <text
+          v-for="tick in yTicks"
+          :key="`yl-${tick}`"
+          :x="margin.left - 4"
+          :y="yScale(tick) + 3"
+          text-anchor="end"
+        >
+          {{ formatValue(tick) }}
+        </text>
+        <text
+          v-for="tick in xTicks"
+          :key="`xl-${tick}`"
+          :x="xScale(tick)"
+          :y="chartHeight - margin.bottom + 12"
+          text-anchor="middle"
+        >
+          {{ formatValue(tick) }}
+        </text>
+        <text
+          class="axis-title"
+          :x="(margin.left + chartWidth - margin.right) / 2"
+          :y="chartHeight - 2"
+          text-anchor="middle"
+        >
+          Distance (px)
+        </text>
+      </g>
+      <!-- intensity profiles -->
+      <g class="chart-series">
+        <path
+          v-for="serie in visibleSeries"
+          :key="serie.layerId"
+          :d="seriePath(serie)"
+          :stroke="serie.color"
+          fill="none"
+          stroke-width="2"
+          stroke-linejoin="round"
+        />
+      </g>
+      <!-- hover crosshair -->
+      <line
+        v-if="hoverIndex !== null"
+        class="chart-crosshair"
+        :x1="xScale(distances[hoverIndex])"
+        :x2="xScale(distances[hoverIndex])"
+        :y1="margin.top"
+        :y2="chartHeight - margin.bottom"
+      />
+    </svg>
+    <div v-else class="panel-hint">
+      {{ hintText }}
+    </div>
+    <div v-if="visibleSeries.length" class="panel-readout">
+      <template v-if="hoverIndex !== null">
+        <span class="readout-entry">
+          {{ formatValue(distances[hoverIndex]) }} px:
+        </span>
+        <span
+          v-for="serie in visibleSeries"
+          :key="serie.layerId"
+          class="readout-entry"
+        >
+          <span class="legend-dot" :style="{ background: serie.color }" />
+          {{
+            serie.values[hoverIndex] === null
+              ? "–"
+              : formatValue(serie.values[hoverIndex]!)
+          }}
+        </span>
+      </template>
+      <template v-else>
+        <span class="readout-entry">
+          Length: {{ formatValue(totalLength) }} px
+        </span>
+      </template>
+    </div>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { debounce } from "lodash";
+import { ticks } from "d3-array";
+import store from "@/store";
+import lineScanStore from "@/store/lineScan";
+import { IDisplayLayer } from "@/store/model";
+import { bilinearSample, resamplePolyline } from "@/utils/lineScan";
+import { logError } from "@/utils/log";
+
+// At most one sample per pixel of line length, capped to keep updates cheap
+const MAX_SAMPLES = 400;
+// Regions larger than this are downsampled by the server before sampling
+const MAX_REGION_DIM = 2048;
+
+const chartWidth = 380;
+const chartHeight = 170;
+const margin = { left: 46, right: 10, top: 10, bottom: 30 };
+
+interface ILineScanSeries {
+  layerId: string;
+  name: string;
+  color: string;
+  values: (number | null)[];
+}
+
+const series = ref<ILineScanSeries[]>([]);
+const distances = ref<number[]>([]);
+const isLoading = ref(false);
+const hoverIndex = ref<number | null>(null);
+const channelMode = ref<"all" | "selected">("all");
+// Ignore responses of superseded scan requests
+let scanRequestId = 0;
+
+const isActive = computed(() => lineScanStore.isActive);
+
+const toolLayer = computed(() =>
+  lineScanStore.toolLayerId
+    ? store.getLayerFromId(lineScanStore.toolLayerId) ?? null
+    : null,
+);
+
+// Layers whose intensities are scanned: either the channel picked in the
+// tool configuration, or all currently visible layers
+const scanLayers = computed((): IDisplayLayer[] => {
+  if (channelMode.value === "selected" && toolLayer.value) {
+    return [toolLayer.value];
+  }
+  return store.layers.filter((layer) => layer.visible);
+});
+
+const visibleSeries = computed(() =>
+  series.value.filter((serie) => serie.values.some((value) => value !== null)),
+);
+
+const hintText = computed(() => {
+  if (isLoading.value) {
+    return "Scanning…";
+  }
+  return scanLayers.value.length
+    ? "Draw a line on the image to scan intensities"
+    : "No visible layers to scan";
+});
+
+const totalLength = computed(() =>
+  distances.value.length ? distances.value[distances.value.length - 1] : 0,
+);
+
+const yDomain = computed((): [number, number] => {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const serie of visibleSeries.value) {
+    for (const value of serie.values) {
+      if (value === null) {
+        continue;
+      }
+      min = Math.min(min, value);
+      max = Math.max(max, value);
+    }
+  }
+  if (min > max) {
+    return [0, 1];
+  }
+  if (min === max) {
+    return [min - 1, max + 1];
+  }
+  // Pad the range so extrema don't sit on the chart border
+  const pad = (max - min) * 0.05;
+  return [min - pad, max + pad];
+});
+
+const xTicks = computed(() =>
+  totalLength.value > 0 ? ticks(0, totalLength.value, 4) : [],
+);
+const yTicks = computed(() => ticks(yDomain.value[0], yDomain.value[1], 4));
+
+function xScale(distance: number) {
+  const [width, length] = [
+    chartWidth - margin.left - margin.right,
+    totalLength.value || 1,
+  ];
+  return margin.left + (distance / length) * width;
+}
+
+function yScale(value: number) {
+  const [min, max] = yDomain.value;
+  const height = chartHeight - margin.top - margin.bottom;
+  return chartHeight - margin.bottom - ((value - min) / (max - min)) * height;
+}
+
+function seriePath(serie: ILineScanSeries) {
+  let path = "";
+  let previousWasNull = true;
+  for (let i = 0; i < serie.values.length; i++) {
+    const value = serie.values[i];
+    if (value === null) {
+      previousWasNull = true;
+      continue;
+    }
+    const x = xScale(distances.value[i]).toFixed(1);
+    const y = yScale(value).toFixed(1);
+    path += `${previousWasNull ? "M" : "L"}${x},${y}`;
+    previousWasNull = false;
+  }
+  return path;
+}
+
+function formatValue(value: number) {
+  if (Math.abs(value) >= 100 || Number.isInteger(value)) {
+    return Math.round(value).toString();
+  }
+  return value.toPrecision(3);
+}
+
+function onChartMouseMove(event: MouseEvent) {
+  if (!distances.value.length) {
+    hoverIndex.value = null;
+    return;
+  }
+  const svg = event.currentTarget as SVGSVGElement;
+  const x =
+    ((event.clientX - svg.getBoundingClientRect().left) /
+      svg.getBoundingClientRect().width) *
+    chartWidth;
+  const distance =
+    ((x - margin.left) / (chartWidth - margin.left - margin.right)) *
+    totalLength.value;
+  const index = Math.round(
+    (distance / (totalLength.value || 1)) * (distances.value.length - 1),
+  );
+  hoverIndex.value = Math.max(0, Math.min(distances.value.length - 1, index));
+}
+
+function dismiss() {
+  lineScanStore.clearLine();
+}
+
+async function updateScans() {
+  const points = lineScanStore.points;
+  const resampled = points && resamplePolyline(points, MAX_SAMPLES);
+  const requestId = ++scanRequestId;
+  if (!resampled) {
+    series.value = [];
+    distances.value = [];
+    return;
+  }
+  const { samplePoints } = resampled;
+  const xs = samplePoints.map(({ x }) => x);
+  const ys = samplePoints.map(({ y }) => y);
+  const bounds = {
+    left: Math.floor(Math.min(...xs)) - 1,
+    top: Math.floor(Math.min(...ys)) - 1,
+    right: Math.ceil(Math.max(...xs)) + 2,
+    bottom: Math.ceil(Math.max(...ys)) + 2,
+  };
+  isLoading.value = true;
+  try {
+    // One region request per layer: each layer displays a different frame,
+    // and the region endpoint serves a single frame per request
+    const results = await Promise.all(
+      scanLayers.value.map(async (layer) => {
+        const image = store.getImagesFromLayer(layer)[0];
+        if (!image) {
+          return null;
+        }
+        const region = await store.api.getRawRegion(
+          image.item._id,
+          image.frameIndex,
+          {
+            left: Math.max(0, bounds.left),
+            top: Math.max(0, bounds.top),
+            right: Math.min(image.sizeX, bounds.right),
+            bottom: Math.min(image.sizeY, bounds.bottom),
+          },
+          MAX_REGION_DIM,
+        );
+        if (!region) {
+          return null;
+        }
+        return {
+          layerId: layer.id,
+          name: layer.name,
+          color: layer.color,
+          values: samplePoints.map((point) =>
+            bilinearSample(
+              region.image,
+              // Convert image coordinates to region pixel centers
+              (point.x - region.left) * region.scaleX - 0.5,
+              (point.y - region.top) * region.scaleY - 0.5,
+            ),
+          ),
+        };
+      }),
+    );
+    if (requestId !== scanRequestId) {
+      // A newer scan superseded this one while it was in flight
+      return;
+    }
+    series.value = results.filter(
+      (result): result is ILineScanSeries => result !== null,
+    );
+    distances.value = resampled.distances;
+    hoverIndex.value = null;
+  } catch (error) {
+    logError("Failed to compute line scan", error);
+  } finally {
+    if (requestId === scanRequestId) {
+      isLoading.value = false;
+    }
+  }
+}
+
+// Live updates while drawing: debounced with maxWait so the graph keeps
+// refreshing during a continuous drag
+const updateScansDebounced = debounce(updateScans, 100, { maxWait: 250 });
+
+watch(
+  [
+    () => lineScanStore.points,
+    scanLayers,
+    () => store.xy,
+    () => store.z,
+    () => store.time,
+  ],
+  () => {
+    updateScansDebounced();
+  },
+);
+
+// Default to the configured channel when one is set
+watch(
+  () => lineScanStore.toolLayerId,
+  (layerId) => {
+    channelMode.value = layerId ? "selected" : "all";
+  },
+  { immediate: true },
+);
+</script>
+
+<style lang="scss" scoped>
+.line-scan-panel {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 200;
+  width: 400px;
+  padding: 8px 10px;
+  background: rgba(var(--v-theme-surface), 0.95);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+}
+
+.panel-title {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.panel-controls {
+  margin: 4px 0;
+}
+
+.channel-toggle {
+  height: 24px;
+}
+
+.panel-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 10px;
+  margin: 2px 0;
+  font-size: 11px;
+  color: rgba(var(--v-theme-on-surface), 0.85);
+}
+
+.legend-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 3px;
+}
+
+.panel-chart {
+  display: block;
+
+  .chart-grid line {
+    stroke: rgba(var(--v-theme-on-surface), 0.12);
+    stroke-width: 1;
+  }
+
+  .chart-tick-labels text {
+    fill: rgba(var(--v-theme-on-surface), 0.65);
+    font-size: 9px;
+  }
+
+  .axis-title {
+    font-size: 10px;
+  }
+
+  .chart-crosshair {
+    stroke: rgba(var(--v-theme-on-surface), 0.5);
+    stroke-width: 1;
+    stroke-dasharray: 3 2;
+  }
+}
+
+.panel-hint {
+  padding: 12px 4px;
+  font-size: 12px;
+  color: rgba(var(--v-theme-on-surface), 0.65);
+}
+
+.panel-readout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 10px;
+  min-height: 18px;
+  font-size: 11px;
+  color: rgba(var(--v-theme-on-surface), 0.85);
+}
+
+.readout-entry {
+  white-space: nowrap;
+}
+</style>

--- a/src/components/LineScanPanel.vue
+++ b/src/components/LineScanPanel.vue
@@ -12,11 +12,21 @@
       />
       <v-spacer />
       <v-btn
+        v-if="lineScanStore.isActive"
+        variant="text"
+        size="x-small"
+        class="clear-btn"
+        title="Clear the line and graph (keep the tool active)"
+        @click="clear"
+      >
+        Clear
+      </v-btn>
+      <v-btn
         variant="text"
         icon
         size="x-small"
-        title="Dismiss line scan"
-        @click="dismiss"
+        title="Close line scan (deactivate the tool)"
+        @click="deactivate"
       >
         <v-icon size="16">mdi-close</v-icon>
       </v-btn>
@@ -335,8 +345,17 @@ function onChartMouseMove(event: MouseEvent) {
   hoverIndex.value = Math.max(0, Math.min(distances.value.length - 1, index));
 }
 
-function dismiss() {
+// Clear the current line and graph but keep the tool armed, ready to draw
+// again (the "Clear" button).
+function clear() {
   lineScanStore.clearLine();
+}
+
+// Deactivate the linescan tool entirely (the "X" button). Deselecting the
+// tool triggers the AnnotationViewer watcher that tears down the line state
+// and hides this panel.
+function deactivate() {
+  store.setSelectedToolId(null);
 }
 
 async function updateScans() {
@@ -460,6 +479,13 @@ watch(
 .panel-title {
   font-size: 13px;
   font-weight: 500;
+}
+
+.clear-btn {
+  min-width: auto;
+  padding: 0 8px;
+  font-size: 11px;
+  letter-spacing: normal;
 }
 
 .panel-controls {

--- a/src/components/LineScanPanel.vue
+++ b/src/components/LineScanPanel.vue
@@ -143,7 +143,9 @@
       </template>
       <template v-else>
         <span class="readout-entry">
-          Length: {{ formatValue(totalLength) }} px
+          Length: {{ formatValue(totalLength) }} px{{
+            physicalLengthText ? ` (${physicalLengthText})` : ""
+          }}
         </span>
       </template>
     </div>
@@ -158,6 +160,7 @@ import store from "@/store";
 import lineScanStore from "@/store/lineScan";
 import { IDisplayLayer } from "@/store/model";
 import { bilinearSample, resamplePolyline } from "@/utils/lineScan";
+import { formatLength } from "@/utils/conversion";
 import { logError } from "@/utils/log";
 
 // At most one sample per pixel of line length, capped to keep updates cheap
@@ -217,6 +220,21 @@ const hintText = computed(() => {
 const totalLength = computed(() =>
   distances.value.length ? distances.value[distances.value.length - 1] : 0,
 );
+
+// Physical length of the line, or null when the pixel size is unknown.
+// A pixel size of exactly 1 m is the placeholder default of configurations
+// whose physical scale was never set.
+const physicalLengthText = computed(() => {
+  const pixelSize = store.scales.pixelSize;
+  if (
+    !pixelSize ||
+    pixelSize.value <= 0 ||
+    (pixelSize.value === 1 && pixelSize.unit === "m")
+  ) {
+    return null;
+  }
+  return formatLength(totalLength.value * pixelSize.value, pixelSize.unit);
+});
 
 const yDomain = computed((): [number, number] => {
   let min = Infinity;

--- a/src/components/LineScanPanel.vue
+++ b/src/components/LineScanPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card v-if="isActive" class="line-scan-panel" elevation="8">
+  <v-card v-if="isVisible" class="line-scan-panel" elevation="8">
     <div class="panel-header">
       <v-icon size="16" class="mr-1">mdi-chart-bell-curve</v-icon>
       <span class="panel-title">Line scan</span>
@@ -187,7 +187,11 @@ const channelMode = ref<"all" | "selected">("all");
 // Ignore responses of superseded scan requests
 let scanRequestId = 0;
 
-const isActive = computed(() => lineScanStore.isActive);
+// Visible while a linescan tool is selected (showing drawing instructions
+// before any line exists) or while a scanned line is displayed
+const isVisible = computed(
+  () => lineScanStore.toolLineType !== null || lineScanStore.isActive,
+);
 
 const toolLayer = computed(() =>
   lineScanStore.toolLayerId
@@ -212,9 +216,19 @@ const hintText = computed(() => {
   if (isLoading.value) {
     return "Scanning…";
   }
-  return scanLayers.value.length
-    ? "Draw a line on the image to scan intensities"
-    : "No visible layers to scan";
+  if (!scanLayers.value.length) {
+    return "No visible layers to scan";
+  }
+  switch (lineScanStore.toolLineType) {
+    case "freehand":
+      return "Click and drag to draw a line";
+    case "segment":
+      return lineScanStore.segmentStartPlaced
+        ? "Click again to finish the segment"
+        : "Click once to start a segment";
+    default:
+      return "Draw a line on the image to scan intensities";
+  }
 });
 
 const totalLength = computed(() =>

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -49,6 +49,7 @@ import { stringify } from "qs";
 import { logError, logWarning } from "@/utils/log";
 import { markRaw } from "vue";
 import { inferZStepFromDimensionLabelsUm } from "@/utils/dimensionLabels";
+import { IRawImageData, parseRawTiff } from "@/utils/tiff";
 
 // Modern browsers limit concurrency to a single domain at 6 requests (though
 // using HTML 2 might improve that slightly).  For a single layer, if we set
@@ -57,6 +58,16 @@ import { inferZStepFromDimensionLabelsUm } from "@/utils/dimensionLabels";
 // fail.  9 is a balance that is somewhat low but was measured as fast as
 // higher values in a limited set of tests.
 const HistogramConcurrency: number = 9;
+
+// A raw pixel region of one frame, with the mapping from image coordinates
+// to region pixels: regionX = (imageX - left) * scaleX
+export interface IRawRegion {
+  image: IRawImageData;
+  left: number;
+  top: number;
+  scaleX: number;
+  scaleY: number;
+}
 
 function toId(item: string | { _id: string }) {
   return typeof item === "string" ? item : item._id;
@@ -404,6 +415,51 @@ export default class GirderAPI {
       params,
     });
     return response.data;
+  }
+
+  /**
+   * Fetch the raw (unstyled) pixel values of a rectangular region of one
+   * frame as a typed array, along with the mapping from image coordinates to
+   * the returned region pixels. The output is capped at maxDim pixels per
+   * side; larger regions are downsampled by the server.
+   */
+  async getRawRegion(
+    itemId: string,
+    frame: number,
+    region: { left: number; top: number; right: number; bottom: number },
+    maxDim: number,
+  ): Promise<IRawRegion | null> {
+    const regionWidth = region.right - region.left;
+    const regionHeight = region.bottom - region.top;
+    if (regionWidth <= 0 || regionHeight <= 0) {
+      return null;
+    }
+    const scale = Math.min(1, maxDim / Math.max(regionWidth, regionHeight));
+    const params: { [key: string]: number | string } = {
+      ...region,
+      units: "base_pixels",
+      frame,
+      encoding: "TIFF",
+      tiffCompression: "raw",
+    };
+    if (scale < 1) {
+      params.width = Math.round(regionWidth * scale);
+      params.height = Math.round(regionHeight * scale);
+    }
+    const response = await this.client.get(`item/${itemId}/tiles/region`, {
+      params,
+      responseType: "arraybuffer",
+    });
+    const image = parseRawTiff(response.data);
+    return {
+      image,
+      left: region.left,
+      top: region.top,
+      // Use the actual returned size: the server preserves the aspect ratio,
+      // so the effective scale can differ slightly from the requested one
+      scaleX: image.width / regionWidth,
+      scaleY: image.height / regionHeight,
+    };
   }
 
   async getItems(folderId: string): Promise<IGirderItem[]> {

--- a/src/store/lineScan.ts
+++ b/src/store/lineScan.ts
@@ -27,6 +27,14 @@ export class LineScan extends VuexModule {
   // Layer id picked in the tool configuration, or null for no preselection
   toolLayerId: string | null = null;
 
+  // Line type of the currently selected linescan tool, or null when no
+  // linescan tool is selected. The panel stays visible while a tool is
+  // selected so it can display drawing instructions.
+  toolLineType: "freehand" | "segment" | null = null;
+
+  // True after the first click of a segment scan, until the second click
+  segmentStartPlaced: boolean = false;
+
   get isActive() {
     return this.points !== null;
   }
@@ -52,6 +60,16 @@ export class LineScan extends VuexModule {
   @Mutation
   setToolLayerId(layerId: string | null) {
     this.toolLayerId = layerId;
+  }
+
+  @Mutation
+  setToolLineType(lineType: "freehand" | "segment" | null) {
+    this.toolLineType = lineType;
+  }
+
+  @Mutation
+  setSegmentStartPlaced(segmentStartPlaced: boolean) {
+    this.segmentStartPlaced = segmentStartPlaced;
   }
 }
 

--- a/src/store/lineScan.ts
+++ b/src/store/lineScan.ts
@@ -1,0 +1,58 @@
+import {
+  getModule,
+  Module,
+  Mutation,
+  VuexModule,
+} from "vuex-module-decorators";
+import store from "./root";
+import { IGeoJSPosition } from "./model";
+
+/**
+ * State shared between the linescan tool (AnnotationViewer) and the
+ * LineScanPanel that displays the intensity profile.
+ *
+ * The tool writes the current line (in image pixel coordinates) as the user
+ * draws it; the panel samples pixel intensities along that line and renders
+ * the graph. Clearing the points dismisses the panel and resets the tool.
+ */
+@Module({ dynamic: true, store, name: "lineScan" })
+export class LineScan extends VuexModule {
+  // Vertices of the scanned line in image pixel coordinates, or null when no
+  // scan is active (panel hidden)
+  points: IGeoJSPosition[] | null = null;
+
+  // False while the line is still being drawn (live preview updates)
+  isComplete: boolean = false;
+
+  // Layer id picked in the tool configuration, or null for no preselection
+  toolLayerId: string | null = null;
+
+  get isActive() {
+    return this.points !== null;
+  }
+
+  @Mutation
+  setLine({
+    points,
+    isComplete,
+  }: {
+    points: IGeoJSPosition[];
+    isComplete: boolean;
+  }) {
+    this.points = points;
+    this.isComplete = isComplete;
+  }
+
+  @Mutation
+  clearLine() {
+    this.points = null;
+    this.isComplete = false;
+  }
+
+  @Mutation
+  setToolLayerId(layerId: string | null) {
+    this.toolLayerId = layerId;
+  }
+}
+
+export default getModule(LineScan);

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -63,7 +63,8 @@ export type TToolType =
   | "edit"
   | "segmentation"
   | "samAnnotation"
-  | "tagging";
+  | "tagging"
+  | "linescan";
 
 export interface IToolTemplateInterface {
   id: string;
@@ -901,6 +902,12 @@ export interface IGeoJSAnnotationLayer extends IGeoJSLayer {
     arg?: string | null,
     editAnnotation?: IGeoJSAnnotation,
   ) => string | null | IGeoJSAnnotationLayer;
+  // The annotation currently being created or edited, if any
+  currentAnnotation: IGeoJSAnnotation | null;
+  options: (() => IObject) &
+    ((key: string) => any) &
+    ((key: string, value: any) => IGeoJSAnnotationLayer) &
+    ((values: IObject) => IGeoJSAnnotationLayer);
 }
 
 // https://opengeoscience.github.io/geojs/apidocs/geo.html#.point2D

--- a/src/tools/ToolIcon.vue
+++ b/src/tools/ToolIcon.vue
@@ -13,6 +13,7 @@ const toolTypeToIcon = {
   edit: "mdi-vector-polygon",
   segmentation: "mdi-shape-polygon-plus",
   connection: "mdi-vector-line",
+  linescan: "mdi-chart-bell-curve",
 } as const;
 
 const createShapeToIcon = {

--- a/src/tools/creation/ToolConfigurationItem.test.ts
+++ b/src/tools/creation/ToolConfigurationItem.test.ts
@@ -73,6 +73,7 @@ describe("ToolConfigurationItem", () => {
       "text",
       "dockerImage",
       "tags",
+      "layerSelect",
     ];
     expect(Object.keys(map)).toEqual(expectedKeys);
     for (const key of expectedKeys) {

--- a/src/tools/creation/ToolConfigurationItem.vue
+++ b/src/tools/creation/ToolConfigurationItem.vue
@@ -44,6 +44,7 @@ import {
 import AnnotationConfiguration from "@/tools/creation/templates/AnnotationConfiguration.vue";
 import TagAndLayerRestriction from "@/tools/creation/templates/TagAndLayerRestriction.vue";
 import DockerImage from "@/tools/creation/templates/DockerImage.vue";
+import OptionalLayerSelect from "@/tools/creation/templates/OptionalLayerSelect.vue";
 import TagPicker from "@/components/TagPicker.vue";
 
 // Used to determine :is="" value from template interface type
@@ -56,6 +57,7 @@ const typeToComponentName: Record<string, any> = {
   text: VTextField,
   dockerImage: DockerImage,
   tags: TagPicker,
+  layerSelect: OptionalLayerSelect,
 };
 
 type TComponentType = keyof typeof typeToComponentName;

--- a/src/tools/creation/ToolTypeSelection.vue
+++ b/src/tools/creation/ToolTypeSelection.vue
@@ -125,6 +125,7 @@ const categoryClassMap: { [key: string]: string } = {
   "Image Processing": "category-processing",
   "Tagging tools": "category-tagging",
   "Annotation Edits": "category-edits",
+  "Line scan tools": "category-measurement",
 };
 
 const hiddenToolTexts = new Set<string>([
@@ -415,6 +416,7 @@ $color-conversion: #fb923c;
 $color-processing: #f472b6;
 $color-tagging: #fbbf24;
 $color-edits: #f87171;
+$color-measurement: #2dd4bf;
 $color-other: #94a3b8;
 $color-featured: #fbbf24; // Gold for featured
 
@@ -600,6 +602,9 @@ $color-featured: #fbbf24; // Gold for featured
 }
 .category-edits {
   @include category-colors($color-edits);
+}
+.category-measurement {
+  @include category-colors($color-measurement);
 }
 .category-other {
   @include category-colors($color-other);

--- a/src/tools/creation/templates/OptionalLayerSelect.vue
+++ b/src/tools/creation/templates/OptionalLayerSelect.vue
@@ -1,0 +1,38 @@
+<template>
+  <layer-select any :label="label" v-model="selectedLayerId" />
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import LayerSelect from "@/components/LayerSelect.vue";
+
+// Tool interface element (type "layerSelect") that stores an optional layer
+// id (null = any layer). Attribute fallthrough is disabled so that the extra
+// attributes ToolConfigurationItem binds on its dynamic component (e.g.
+// return-object) don't reach the inner v-select and change its model type.
+defineOptions({ inheritAttrs: false });
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string | null;
+    label?: string;
+  }>(),
+  {
+    modelValue: null,
+    label: "Layer",
+  },
+);
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string | null): void;
+}>();
+
+const selectedLayerId = computed({
+  get() {
+    return props.modelValue;
+  },
+  set(layerId: string | null) {
+    emit("update:modelValue", layerId);
+  },
+});
+</script>

--- a/src/utils/conversion.test.ts
+++ b/src/utils/conversion.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { convertLength, formatLength } from "./conversion";
+
+describe("convertLength", () => {
+  it("converts between length units", () => {
+    expect(convertLength(1, "m", "mm")).toBe(1000);
+    expect(convertLength(2500, "nm", "µm")).toBe(2.5);
+  });
+});
+
+describe("formatLength", () => {
+  it("keeps values in a readable unit", () => {
+    expect(formatLength(65, "µm")).toBe("65.0 µm");
+    expect(formatLength(0.5, "µm")).toBe("500 nm");
+    expect(formatLength(1234, "µm")).toBe("1.23 mm");
+    expect(formatLength(3, "m")).toBe("3.00 m");
+  });
+
+  it("falls back to the smallest unit for tiny values", () => {
+    expect(formatLength(0.4, "nm")).toBe("0.400 nm");
+  });
+});

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -1,4 +1,4 @@
-import { TUnitLength, TUnitTime } from "@/store/model";
+import { TUnitLength, TUnitTime, unitLengthOptions } from "@/store/model";
 
 const oneUnitToMeterConversion = {
   nm: 1e-9,
@@ -15,6 +15,26 @@ export function convertLength(
   const multiplier =
     oneUnitToMeterConversion[oldUnit] / oneUnitToMeterConversion[newUnit];
   return multiplier * value;
+}
+
+/**
+ * Format a physical length as a human-readable string, picking the unit in
+ * which the value reads best (the largest unit where it is at least 1).
+ */
+export function formatLength(value: number, unit: TUnitLength): string {
+  // unitLengthOptions is ordered from smallest (nm) to largest (m)
+  let bestUnit = unitLengthOptions[0];
+  for (const candidate of unitLengthOptions) {
+    if (convertLength(value, unit, candidate) >= 1) {
+      bestUnit = candidate;
+    }
+  }
+  const bestValue = convertLength(value, unit, bestUnit);
+  const formatted =
+    bestValue >= 100
+      ? Math.round(bestValue).toString()
+      : bestValue.toPrecision(3);
+  return `${formatted} ${bestUnit}`;
 }
 
 const oneUnitToSecondConversion = {

--- a/src/utils/lineScan.test.ts
+++ b/src/utils/lineScan.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { bilinearSample, resamplePolyline } from "./lineScan";
+import { IRawImageData } from "./tiff";
+
+describe("resamplePolyline", () => {
+  it("returns null for degenerate lines", () => {
+    expect(resamplePolyline([], 100)).toBeNull();
+    expect(resamplePolyline([{ x: 1, y: 1 }], 100)).toBeNull();
+    expect(
+      resamplePolyline(
+        [
+          { x: 1, y: 1 },
+          { x: 1, y: 1 },
+        ],
+        100,
+      ),
+    ).toBeNull();
+  });
+
+  it("samples a straight line at regular intervals", () => {
+    const result = resamplePolyline(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      100,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.samplePoints).toHaveLength(11);
+    expect(result!.distances[0]).toBe(0);
+    expect(result!.distances[10]).toBe(10);
+    expect(result!.samplePoints[5]).toEqual({ x: 5, y: 0 });
+  });
+
+  it("caps the number of samples", () => {
+    const result = resamplePolyline(
+      [
+        { x: 0, y: 0 },
+        { x: 1000, y: 0 },
+      ],
+      50,
+    );
+    expect(result!.samplePoints).toHaveLength(50);
+    expect(result!.distances[49]).toBe(1000);
+  });
+
+  it("walks across polyline segments by arc length", () => {
+    // L-shaped line of total length 20
+    const result = resamplePolyline(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+      ],
+      100,
+    );
+    expect(result!.distances[result!.distances.length - 1]).toBe(20);
+    // The sample at distance 15 lies on the second segment
+    const index = result!.distances.findIndex((d) => d === 15);
+    expect(result!.samplePoints[index].x).toBeCloseTo(10);
+    expect(result!.samplePoints[index].y).toBeCloseTo(5);
+  });
+});
+
+describe("bilinearSample", () => {
+  const image: IRawImageData = {
+    width: 3,
+    height: 2,
+    samplesPerPixel: 1,
+    data: new Uint16Array([10, 20, 30, 40, 50, 60]),
+  };
+
+  it("returns exact values at integer coordinates", () => {
+    expect(bilinearSample(image, 0, 0)).toBe(10);
+    expect(bilinearSample(image, 2, 0)).toBe(30);
+    expect(bilinearSample(image, 1, 1)).toBe(50);
+  });
+
+  it("interpolates between pixels", () => {
+    expect(bilinearSample(image, 0.5, 0)).toBeCloseTo(15);
+    expect(bilinearSample(image, 0, 0.5)).toBeCloseTo(25);
+    expect(bilinearSample(image, 0.5, 0.5)).toBeCloseTo(30);
+  });
+
+  it("returns null outside the image", () => {
+    expect(bilinearSample(image, -0.1, 0)).toBeNull();
+    expect(bilinearSample(image, 0, 1.5)).toBeNull();
+    expect(bilinearSample(image, 2.5, 0)).toBeNull();
+  });
+
+  it("averages the color bands of multi-band pixels", () => {
+    const rgb: IRawImageData = {
+      width: 1,
+      height: 1,
+      samplesPerPixel: 3,
+      data: new Uint8Array([10, 20, 60]),
+    };
+    expect(bilinearSample(rgb, 0, 0)).toBeCloseTo(30);
+  });
+});

--- a/src/utils/lineScan.ts
+++ b/src/utils/lineScan.ts
@@ -1,0 +1,114 @@
+import { IGeoJSPosition } from "@/store/model";
+import { IRawImageData } from "@/utils/tiff";
+
+export interface IResampledLine {
+  // Points at regular intervals along the polyline, in the same coordinate
+  // space as the input vertices
+  samplePoints: IGeoJSPosition[];
+  // Distance of each sample point from the start of the line, in input units
+  distances: number[];
+}
+
+/**
+ * Resample a polyline at (at most maxSamples) regularly spaced points along
+ * its arc length. Aims for roughly one sample per unit of length (i.e. one
+ * per pixel when the input is in pixel coordinates).
+ */
+export function resamplePolyline(
+  vertices: IGeoJSPosition[],
+  maxSamples: number,
+): IResampledLine | null {
+  if (vertices.length < 2) {
+    return null;
+  }
+  const cumulative: number[] = [0];
+  for (let i = 1; i < vertices.length; i++) {
+    cumulative.push(
+      cumulative[i - 1] +
+        Math.hypot(
+          vertices[i].x - vertices[i - 1].x,
+          vertices[i].y - vertices[i - 1].y,
+        ),
+    );
+  }
+  const totalLength = cumulative[vertices.length - 1];
+  if (totalLength <= 0) {
+    return null;
+  }
+  const sampleCount = Math.min(
+    maxSamples,
+    Math.max(2, Math.ceil(totalLength) + 1),
+  );
+  const samplePoints: IGeoJSPosition[] = [];
+  const distances: number[] = [];
+  let segment = 0;
+  for (let i = 0; i < sampleCount; i++) {
+    const distance = (totalLength * i) / (sampleCount - 1);
+    while (
+      segment < vertices.length - 2 &&
+      cumulative[segment + 1] < distance
+    ) {
+      segment++;
+    }
+    const segmentLength = cumulative[segment + 1] - cumulative[segment];
+    const t =
+      segmentLength > 0 ? (distance - cumulative[segment]) / segmentLength : 0;
+    samplePoints.push({
+      x:
+        vertices[segment].x +
+        t * (vertices[segment + 1].x - vertices[segment].x),
+      y:
+        vertices[segment].y +
+        t * (vertices[segment + 1].y - vertices[segment].y),
+    });
+    distances.push(distance);
+  }
+  return { samplePoints, distances };
+}
+
+function sampleValueAt(image: IRawImageData, x: number, y: number): number {
+  const { width, samplesPerPixel, data } = image;
+  const base = (y * width + x) * samplesPerPixel;
+  if (samplesPerPixel === 1) {
+    return data[base];
+  }
+  // Multi-band pixels (e.g. RGB sources): average the color bands, ignoring
+  // a potential alpha band
+  const bands = Math.min(samplesPerPixel, 3);
+  let sum = 0;
+  for (let s = 0; s < bands; s++) {
+    sum += data[base + s];
+  }
+  return sum / bands;
+}
+
+/**
+ * Bilinearly interpolate the intensity of a raw image region at fractional
+ * pixel coordinates. Returns null when the position is outside the image.
+ */
+export function bilinearSample(
+  image: IRawImageData,
+  x: number,
+  y: number,
+): number | null {
+  const { width, height } = image;
+  if (x < 0 || y < 0 || x > width - 1 || y > height - 1) {
+    return null;
+  }
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const x1 = Math.min(x0 + 1, width - 1);
+  const y1 = Math.min(y0 + 1, height - 1);
+  const fx = x - x0;
+  const fy = y - y0;
+  const v00 = sampleValueAt(image, x0, y0);
+  const v10 = sampleValueAt(image, x1, y0);
+  const v01 = sampleValueAt(image, x0, y1);
+  const v11 = sampleValueAt(image, x1, y1);
+  return (
+    v00 * (1 - fx) * (1 - fy) +
+    v10 * fx * (1 - fy) +
+    v01 * (1 - fx) * fy +
+    v11 * fx * fy
+  );
+}

--- a/src/utils/tiff.test.ts
+++ b/src/utils/tiff.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { parseRawTiff } from "./tiff";
+
+// Build a minimal uncompressed 3x2 uint16 TIFF with one strip per row,
+// in either byte order
+function buildTiff(littleEndian: boolean): ArrayBuffer {
+  const entries = 9;
+  const ifdOffset = 8;
+  const ifdSize = 2 + entries * 12 + 4;
+  const stripOffsetsOffset = ifdOffset + ifdSize;
+  const stripByteCountsOffset = stripOffsetsOffset + 8;
+  const dataOffset = stripByteCountsOffset + 8;
+  const buffer = new ArrayBuffer(dataOffset + 12);
+  const view = new DataView(buffer);
+
+  view.setUint16(0, littleEndian ? 0x4949 : 0x4d4d, false);
+  view.setUint16(2, 42, littleEndian);
+  view.setUint32(4, ifdOffset, littleEndian);
+
+  let entryOffset = ifdOffset + 2;
+  const writeEntry = (
+    tag: number,
+    type: number,
+    count: number,
+    value: number,
+  ) => {
+    view.setUint16(entryOffset, tag, littleEndian);
+    view.setUint16(entryOffset + 2, type, littleEndian);
+    view.setUint32(entryOffset + 4, count, littleEndian);
+    if (type === 3 && count === 1) {
+      // SHORT values are left-justified in the 4-byte value field
+      view.setUint16(entryOffset + 8, value, littleEndian);
+    } else {
+      view.setUint32(entryOffset + 8, value, littleEndian);
+    }
+    entryOffset += 12;
+  };
+
+  view.setUint16(ifdOffset, entries, littleEndian);
+  writeEntry(256, 3, 1, 3); // ImageWidth
+  writeEntry(257, 3, 1, 2); // ImageLength
+  writeEntry(258, 3, 1, 16); // BitsPerSample
+  writeEntry(259, 3, 1, 1); // Compression: none
+  writeEntry(273, 4, 2, stripOffsetsOffset); // StripOffsets
+  writeEntry(277, 3, 1, 1); // SamplesPerPixel
+  writeEntry(278, 3, 1, 1); // RowsPerStrip
+  writeEntry(279, 4, 2, stripByteCountsOffset); // StripByteCounts
+  writeEntry(339, 3, 1, 1); // SampleFormat: unsigned integer
+  view.setUint32(entryOffset, 0, littleEndian); // no next IFD
+
+  view.setUint32(stripOffsetsOffset, dataOffset, littleEndian);
+  view.setUint32(stripOffsetsOffset + 4, dataOffset + 6, littleEndian);
+  view.setUint32(stripByteCountsOffset, 6, littleEndian);
+  view.setUint32(stripByteCountsOffset + 4, 6, littleEndian);
+
+  const pixels = [10, 20, 30, 40, 50, 60];
+  pixels.forEach((value, i) => {
+    view.setUint16(dataOffset + 2 * i, value, littleEndian);
+  });
+  return buffer;
+}
+
+describe("parseRawTiff", () => {
+  it.each([
+    ["little-endian", true],
+    ["big-endian", false],
+  ])("parses a striped uncompressed uint16 %s TIFF", (_, littleEndian) => {
+    const result = parseRawTiff(buildTiff(littleEndian));
+    expect(result.width).toBe(3);
+    expect(result.height).toBe(2);
+    expect(result.samplesPerPixel).toBe(1);
+    expect(result.data).toBeInstanceOf(Uint16Array);
+    expect(Array.from(result.data)).toEqual([10, 20, 30, 40, 50, 60]);
+  });
+
+  it("rejects non-TIFF data", () => {
+    expect(() => parseRawTiff(new ArrayBuffer(16))).toThrow(/byte order/);
+  });
+
+  it("rejects compressed TIFFs", () => {
+    const buffer = buildTiff(true);
+    const view = new DataView(buffer);
+    // Compression tag is the 4th IFD entry; overwrite its value with LZW (5)
+    view.setUint16(8 + 2 + 3 * 12 + 8, 5, true);
+    expect(() => parseRawTiff(buffer)).toThrow(/compression/i);
+  });
+});

--- a/src/utils/tiff.ts
+++ b/src/utils/tiff.ts
@@ -1,0 +1,223 @@
+// Minimal reader for the uncompressed (compression=1) striped TIFF files that
+// large_image returns from `/item/{id}/tiles/region` when called with
+// `encoding=TIFF&tiffCompression=raw`. This is not a general TIFF reader: it
+// rejects compressed, tiled, planar and BigTIFF files, which large_image never
+// produces for that request.
+
+export type TRawPixels =
+  | Uint8Array
+  | Uint16Array
+  | Uint32Array
+  | Int8Array
+  | Int16Array
+  | Int32Array
+  | Float32Array
+  | Float64Array;
+
+export interface IRawImageData {
+  width: number;
+  height: number;
+  samplesPerPixel: number;
+  // Interleaved samples, row-major: data[(y * width + x) * samplesPerPixel + s]
+  data: TRawPixels;
+}
+
+const enum TiffTag {
+  ImageWidth = 256,
+  ImageLength = 257,
+  BitsPerSample = 258,
+  Compression = 259,
+  StripOffsets = 273,
+  SamplesPerPixel = 277,
+  RowsPerStrip = 278,
+  StripByteCounts = 279,
+  PlanarConfiguration = 284,
+  SampleFormat = 339,
+}
+
+const enum TiffFieldType {
+  Byte = 1,
+  Short = 3,
+  Long = 4,
+}
+
+const fieldTypeSize: { [type: number]: number } = {
+  [TiffFieldType.Byte]: 1,
+  [TiffFieldType.Short]: 2,
+  [TiffFieldType.Long]: 4,
+};
+
+// SampleFormat tag values from the TIFF specification
+const enum TiffSampleFormat {
+  UnsignedInteger = 1,
+  SignedInteger = 2,
+  Float = 3,
+}
+
+function readTagValues(
+  view: DataView,
+  entryOffset: number,
+  littleEndian: boolean,
+): number[] | null {
+  const type = view.getUint16(entryOffset + 2, littleEndian);
+  const count = view.getUint32(entryOffset + 4, littleEndian);
+  const size = fieldTypeSize[type];
+  if (size === undefined) {
+    // Unsupported field type (rational, ascii, ...): callers don't need them
+    return null;
+  }
+  const valuesOffset =
+    size * count <= 4
+      ? entryOffset + 8
+      : view.getUint32(entryOffset + 8, littleEndian);
+  const values: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const offset = valuesOffset + i * size;
+    switch (type) {
+      case TiffFieldType.Byte:
+        values.push(view.getUint8(offset));
+        break;
+      case TiffFieldType.Short:
+        values.push(view.getUint16(offset, littleEndian));
+        break;
+      case TiffFieldType.Long:
+        values.push(view.getUint32(offset, littleEndian));
+        break;
+    }
+  }
+  return values;
+}
+
+function createPixelArray(
+  sampleFormat: number,
+  bitsPerSample: number,
+  count: number,
+): TRawPixels {
+  if (sampleFormat === TiffSampleFormat.Float) {
+    switch (bitsPerSample) {
+      case 32:
+        return new Float32Array(count);
+      case 64:
+        return new Float64Array(count);
+    }
+  } else if (sampleFormat === TiffSampleFormat.SignedInteger) {
+    switch (bitsPerSample) {
+      case 8:
+        return new Int8Array(count);
+      case 16:
+        return new Int16Array(count);
+      case 32:
+        return new Int32Array(count);
+    }
+  } else if (sampleFormat === TiffSampleFormat.UnsignedInteger) {
+    switch (bitsPerSample) {
+      case 8:
+        return new Uint8Array(count);
+      case 16:
+        return new Uint16Array(count);
+      case 32:
+        return new Uint32Array(count);
+    }
+  }
+  throw new Error(
+    `Unsupported TIFF pixel type: sample format ${sampleFormat}, ${bitsPerSample} bits per sample`,
+  );
+}
+
+/**
+ * Parse an uncompressed striped TIFF buffer into a typed array of samples.
+ *
+ * @param buffer The raw TIFF file contents.
+ * @returns Dimensions and interleaved sample values of the image.
+ */
+export function parseRawTiff(buffer: ArrayBuffer): IRawImageData {
+  const view = new DataView(buffer);
+  const byteOrder = view.getUint16(0, false);
+  let littleEndian: boolean;
+  if (byteOrder === 0x4949) {
+    littleEndian = true;
+  } else if (byteOrder === 0x4d4d) {
+    littleEndian = false;
+  } else {
+    throw new Error("Not a TIFF file: bad byte order mark");
+  }
+  if (view.getUint16(2, littleEndian) !== 42) {
+    throw new Error("Not a TIFF file: bad magic number");
+  }
+
+  const ifdOffset = view.getUint32(4, littleEndian);
+  const entryCount = view.getUint16(ifdOffset, littleEndian);
+  const tags: Map<number, number[]> = new Map();
+  for (let i = 0; i < entryCount; i++) {
+    const entryOffset = ifdOffset + 2 + i * 12;
+    const tag = view.getUint16(entryOffset, littleEndian);
+    const values = readTagValues(view, entryOffset, littleEndian);
+    if (values !== null) {
+      tags.set(tag, values);
+    }
+  }
+
+  const width = tags.get(TiffTag.ImageWidth)?.[0];
+  const height = tags.get(TiffTag.ImageLength)?.[0];
+  const stripOffsets = tags.get(TiffTag.StripOffsets);
+  const stripByteCounts = tags.get(TiffTag.StripByteCounts);
+  if (!width || !height || !stripOffsets || !stripByteCounts) {
+    throw new Error("TIFF file is missing required tags");
+  }
+  const compression = tags.get(TiffTag.Compression)?.[0] ?? 1;
+  if (compression !== 1) {
+    throw new Error(`Unsupported TIFF compression: ${compression}`);
+  }
+  const planarConfiguration = tags.get(TiffTag.PlanarConfiguration)?.[0] ?? 1;
+  if (planarConfiguration !== 1) {
+    throw new Error("Unsupported TIFF planar configuration");
+  }
+  const samplesPerPixel = tags.get(TiffTag.SamplesPerPixel)?.[0] ?? 1;
+  const bitsPerSample = tags.get(TiffTag.BitsPerSample)?.[0] ?? 8;
+  const sampleFormat =
+    tags.get(TiffTag.SampleFormat)?.[0] ?? TiffSampleFormat.UnsignedInteger;
+
+  const sampleCount = width * height * samplesPerPixel;
+  const data = createPixelArray(sampleFormat, bitsPerSample, sampleCount);
+  const bytesPerSample = bitsPerSample / 8;
+
+  // Concatenate the strips into a contiguous sample buffer
+  let sampleIndex = 0;
+  for (let strip = 0; strip < stripOffsets.length; strip++) {
+    const stripSamples = Math.min(
+      stripByteCounts[strip] / bytesPerSample,
+      sampleCount - sampleIndex,
+    );
+    let offset = stripOffsets[strip];
+    for (let i = 0; i < stripSamples; i++, offset += bytesPerSample) {
+      let value: number;
+      switch (bytesPerSample) {
+        case 1:
+          value =
+            sampleFormat === TiffSampleFormat.SignedInteger
+              ? view.getInt8(offset)
+              : view.getUint8(offset);
+          break;
+        case 2:
+          value =
+            sampleFormat === TiffSampleFormat.SignedInteger
+              ? view.getInt16(offset, littleEndian)
+              : view.getUint16(offset, littleEndian);
+          break;
+        case 4:
+          value =
+            sampleFormat === TiffSampleFormat.Float
+              ? view.getFloat32(offset, littleEndian)
+              : sampleFormat === TiffSampleFormat.SignedInteger
+                ? view.getInt32(offset, littleEndian)
+                : view.getUint32(offset, littleEndian);
+          break;
+        default:
+          value = view.getFloat64(offset, littleEndian);
+      }
+      data[sampleIndex++] = value;
+    }
+  }
+
+  return { width, height, samplesPerPixel, data };
+}


### PR DESCRIPTION
Add a new "linescan" measurement tool that plots raw pixel intensities
along a line without creating stored annotations:

- Two variants: freehand (drag, completes on mouse release via the
  interaction layer's continuousCloseProximity option) and segment
  (two-click, same pattern as click-connect)
- LineScanPanel at the bottom right of the viewer with an SVG intensity
  profile per layer (colored by layer color), legend, hover readout,
  live updates while drawing, and a close button to dismiss/reset
- Optional channel pick at tool creation via a new reusable
  "layerSelect" interface element (OptionalLayerSelect wrapping
  LayerSelect); the panel toggles between all visible channels and the
  selected one
- Raw (unstyled) intensities come from large_image's tiles/region
  endpoint with encoding=TIFF&tiffCompression=raw, one capped-size
  request per scanned layer, decoded by a minimal striped-TIFF reader
  (utils/tiff.ts, validated against PIL-generated files) and bilinearly
  sampled along the line (utils/lineScan.ts)
- Line state shared through a small lineScan store module; TOOLS.md
  documents the tool as a worked example

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XYzLmoVa6wFcstYuXEtL3r