### PR TITLE
3D annotation rendering: shaded lofted surfaces, point spheres, adjustable opacity

### DIFF
--- a/src/components/VolumeViewer.test.ts
+++ b/src/components/VolumeViewer.test.ts
@@ -29,14 +29,27 @@ const h = vi.hoisted(() => {
     setEnabled: vi.fn(),
     delete: vi.fn(),
   };
-  const property = () => ({
-    setRGBTransferFunction: vi.fn(),
-    setScalarOpacity: vi.fn(),
-    setInterpolationTypeToLinear: vi.fn(),
-    setShade: vi.fn(),
-    setOpacity: vi.fn(),
-    setBackfaceCulling: vi.fn(),
-  });
+  // Every property created by an actor mock is recorded so tests can assert
+  // on e.g. opacity changes across all segmentation actors.
+  const properties: any[] = [];
+  const property = () => {
+    const instance = {
+      setRGBTransferFunction: vi.fn(),
+      setScalarOpacity: vi.fn(),
+      setInterpolationTypeToLinear: vi.fn(),
+      setInterpolationToPhong: vi.fn(),
+      setShade: vi.fn(),
+      setOpacity: vi.fn(),
+      setBackfaceCulling: vi.fn(),
+      setAmbient: vi.fn(),
+      setDiffuse: vi.fn(),
+      setSpecular: vi.fn(),
+      setSpecularPower: vi.fn(),
+    };
+    properties.push(instance);
+    return instance;
+  };
+  const sphereMappers: any[] = [];
   return {
     buildVolume: vi.fn(),
     annotationsTo3D: vi.fn(),
@@ -44,6 +57,8 @@ const h = vi.hoisted(() => {
     orientationWidget,
     cubeAxes,
     property,
+    properties,
+    sphereMappers,
   };
 });
 
@@ -83,14 +98,45 @@ vi.mock("@kitware/vtk.js/Rendering/Core/VolumeMapper", () => ({
     })),
   },
 }));
+vi.mock("@kitware/vtk.js/Rendering/Profiles/Molecule", () => ({}));
 vi.mock("@kitware/vtk.js/Rendering/Core/Actor", () => ({
   default: {
+    newInstance: vi.fn(() => {
+      // One stable property per actor, like the real vtkActor.
+      const property = h.property();
+      return {
+        setMapper: vi.fn(),
+        setVisibility: vi.fn(),
+        getProperty: vi.fn(() => property),
+        delete: vi.fn(),
+      };
+    }),
+  },
+}));
+vi.mock("@kitware/vtk.js/Filters/Core/PolyDataNormals", () => ({
+  default: {
     newInstance: vi.fn(() => ({
-      setMapper: vi.fn(),
-      setVisibility: vi.fn(),
-      getProperty: vi.fn(() => h.property()),
+      setInputData: vi.fn(),
+      getOutputData: vi.fn(() => ({})),
       delete: vi.fn(),
     })),
+  },
+}));
+vi.mock("@kitware/vtk.js/Rendering/Core/SphereMapper", () => ({
+  default: {
+    newInstance: vi.fn(() => {
+      const instance = {
+        setInputData: vi.fn(),
+        setRadius: vi.fn(),
+        setScalarModeToUsePointData: vi.fn(),
+        setColorModeToMapScalars: vi.fn(),
+        setLookupTable: vi.fn(),
+        setScalarRange: vi.fn(),
+        delete: vi.fn(),
+      };
+      h.sphereMappers.push(instance);
+      return instance;
+    }),
   },
 }));
 vi.mock("@kitware/vtk.js/Rendering/Core/Mapper", () => ({
@@ -168,6 +214,7 @@ vi.mock("@/store/volumeView", () => {
     showBoundingBox: false,
     segmentationColorMode: "tag",
     segmentationPropertyPath: [] as string[],
+    segmentationOpacity: 0.55,
     timeStepUmOverride: null as number | null,
     setViewMode: (v: string) => (state.viewMode = v),
     setAxis: (v: string) => (state.axis = v),
@@ -179,6 +226,7 @@ vi.mock("@/store/volumeView", () => {
     setSegmentationColorMode: (v: string) => (state.segmentationColorMode = v),
     setSegmentationPropertyPath: (v: string[]) =>
       (state.segmentationPropertyPath = v),
+    setSegmentationOpacity: (v: number) => (state.segmentationOpacity = v),
     setTimeStepUmOverride: (v: number | null) => (state.timeStepUmOverride = v),
   });
   return { default: state };
@@ -217,10 +265,12 @@ const fakeVolume = {
 
 function segResult() {
   return {
-    polyData: { getNumberOfCells: () => 1 },
+    surfacePolyData: { getNumberOfCells: () => 1 },
+    pointsPolyData: { getNumberOfPoints: () => 1 },
+    pointRadius: 2,
     lookupTable: {},
     scalarRange: [0, 1],
-    usedCount: 1,
+    usedCount: 2,
     skippedByShape: {},
   };
 }
@@ -256,6 +306,9 @@ beforeEach(() => {
   volumeViewStore.setShowBoundingBox(false);
   volumeViewStore.setShowSegmentations(true);
   volumeViewStore.setSegmentationColorMode("tag");
+  volumeViewStore.setSegmentationOpacity(0.55);
+  h.properties.length = 0;
+  h.sphereMappers.length = 0;
   h.cubeAxes.setVisibility.mockClear();
   h.buildVolume.mockReset().mockResolvedValue([fakeVolume]);
   h.annotationsTo3D.mockReset().mockImplementation(segResult);
@@ -343,5 +396,27 @@ describe("VolumeViewer", () => {
     expect((wrapper.vm as any).blendMode).toBe("composite");
     (wrapper.vm as any).blendMode = "mip";
     expect(volumeViewStore.blendMode).toBe("mip");
+  });
+
+  it("renders point annotations with a sphere mapper at the suggested radius", async () => {
+    await mountReady();
+    expect(h.sphereMappers).toHaveLength(1);
+    expect(h.sphereMappers[0].setRadius).toHaveBeenCalledWith(2);
+  });
+
+  it("applies opacity changes to actors without rebuilding anything", async () => {
+    await mountReady();
+    h.annotationsTo3D.mockClear();
+    h.buildVolume.mockClear();
+
+    volumeViewStore.setSegmentationOpacity(0.8);
+    await nextTick();
+
+    const opacityCalls = h.properties.flatMap((property) =>
+      property.setOpacity.mock.calls.map((call: number[]) => call[0]),
+    );
+    expect(opacityCalls).toContain(0.8);
+    expect(h.annotationsTo3D).not.toHaveBeenCalled();
+    expect(h.buildVolume).not.toHaveBeenCalled();
   });
 });

--- a/src/components/VolumeViewer.test.ts
+++ b/src/components/VolumeViewer.test.ts
@@ -252,6 +252,7 @@ vi.mock("@/utils/log", () => ({ logError: vi.fn(), logWarning: vi.fn() }));
 
 import volumeViewStore from "@/store/volumeView";
 import propertyStore from "@/store/properties";
+import filterStore from "@/store/filters";
 import VolumeViewer from "./VolumeViewer.vue";
 
 const fakeVolume = {
@@ -421,6 +422,26 @@ describe("VolumeViewer", () => {
       loftOverlapFraction: 0.5,
     });
     expect(h.buildVolume).not.toHaveBeenCalled();
+  });
+
+  it("discards a segmentation build that finishes after segmentations were hidden", async () => {
+    await mountReady();
+    // Make the next build hang until we resolve it, like a slow worker job.
+    let resolveBuild!: (value: ReturnType<typeof segResult>) => void;
+    h.annotationsTo3D.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveBuild = resolve)),
+    );
+    (filterStore as any).filteredAnnotations = [{ id: "new" }];
+    await nextTick();
+
+    volumeViewStore.setShowSegmentations(false);
+    await nextTick();
+    h.renderer.addActor.mockClear();
+
+    resolveBuild(segResult());
+    await flushPromises();
+
+    expect(h.renderer.addActor).not.toHaveBeenCalled();
   });
 
   it("renders point annotations with a sphere mapper at the suggested radius", async () => {

--- a/src/components/VolumeViewer.test.ts
+++ b/src/components/VolumeViewer.test.ts
@@ -215,6 +215,8 @@ vi.mock("@/store/volumeView", () => {
     segmentationColorMode: "tag",
     segmentationPropertyPath: [] as string[],
     segmentationOpacity: 0.55,
+    loftSurfaces: true,
+    loftOverlapPercent: 0,
     timeStepUmOverride: null as number | null,
     setViewMode: (v: string) => (state.viewMode = v),
     setAxis: (v: string) => (state.axis = v),
@@ -227,6 +229,8 @@ vi.mock("@/store/volumeView", () => {
     setSegmentationPropertyPath: (v: string[]) =>
       (state.segmentationPropertyPath = v),
     setSegmentationOpacity: (v: number) => (state.segmentationOpacity = v),
+    setLoftSurfaces: (v: boolean) => (state.loftSurfaces = v),
+    setLoftOverlapPercent: (v: number) => (state.loftOverlapPercent = v),
     setTimeStepUmOverride: (v: number | null) => (state.timeStepUmOverride = v),
   });
   return { default: state };
@@ -307,6 +311,8 @@ beforeEach(() => {
   volumeViewStore.setShowSegmentations(true);
   volumeViewStore.setSegmentationColorMode("tag");
   volumeViewStore.setSegmentationOpacity(0.55);
+  volumeViewStore.setLoftSurfaces(true);
+  volumeViewStore.setLoftOverlapPercent(0);
   h.properties.length = 0;
   h.sphereMappers.length = 0;
   h.cubeAxes.setVisibility.mockClear();
@@ -396,6 +402,25 @@ describe("VolumeViewer", () => {
     expect((wrapper.vm as any).blendMode).toBe("composite");
     (wrapper.vm as any).blendMode = "mip";
     expect(volumeViewStore.blendMode).toBe("mip");
+  });
+
+  it("passes loft settings through and rebuilds segmentations on change", async () => {
+    await mountReady();
+    expect(h.annotationsTo3D.mock.calls[0][0]).toMatchObject({
+      loftSurfaces: true,
+      loftOverlapFraction: 0,
+    });
+    h.annotationsTo3D.mockClear();
+    h.buildVolume.mockClear();
+
+    volumeViewStore.setLoftOverlapPercent(50);
+    await nextTick();
+
+    expect(h.annotationsTo3D).toHaveBeenCalledTimes(1);
+    expect(h.annotationsTo3D.mock.calls[0][0]).toMatchObject({
+      loftOverlapFraction: 0.5,
+    });
+    expect(h.buildVolume).not.toHaveBeenCalled();
   });
 
   it("renders point annotations with a sphere mapper at the suggested radius", async () => {

--- a/src/components/VolumeViewer.vue
+++ b/src/components/VolumeViewer.vue
@@ -185,16 +185,17 @@
         <v-card-title>Loft overlap threshold</v-card-title>
         <v-card-text>
           <v-slider
-            v-model="loftOverlapPercent"
+            v-model="loftThresholdDraft"
             :min="0"
             :max="95"
             :step="5"
             density="comfortable"
             hide-details
+            @end="loftOverlapPercent = $event"
           >
             <template v-slot:append>
               <span class="loft-threshold-value">
-                {{ loftOverlapPercent }}%
+                {{ loftThresholdDraft }}%
               </span>
             </template>
           </v-slider>
@@ -308,7 +309,10 @@ import {
   VolumeGeometry,
   defaultTimeStepUm as computeDefaultTimeStepUm,
 } from "@/store/VolumeAPI";
-import { annotationsTo3D } from "@/utils/annotationsTo3D";
+import {
+  IAnnotationsTo3DResult,
+  annotationsTo3D,
+} from "@/utils/annotationsTo3D";
 import { convertLength } from "@/utils/conversion";
 import { layerToVolumeTransferFunction } from "@/utils/layerToVolumeTransferFunction";
 import { logError } from "@/utils/log";
@@ -416,6 +420,15 @@ const loftOverlapPercent = computed({
 });
 
 const loftDialog = ref(false);
+// Shown while dragging the threshold slider; committed to the store (which
+// queues a chain-matching job in the worker) only on release, so a drag
+// doesn't pile up one job per step.
+const loftThresholdDraft = ref(0);
+watch(loftDialog, (open) => {
+  if (open) {
+    loftThresholdDraft.value = loftOverlapPercent.value;
+  }
+});
 
 function propertyKey(path: string[]) {
   return path.join("\u0000");
@@ -729,20 +742,27 @@ async function updateSegmentationActors() {
   }
 
   // Async: the loft chain matching runs in a web worker. The previous actors
-  // stay on screen until the replacement is ready.
-  const result = await annotationsTo3D({
-    annotations: filterStore.filteredAnnotations,
-    geometry: activeGeometry,
-    currentXY: store.xy,
-    currentTime: store.time,
-    currentZ: store.z,
-    axis: axisMode.value,
-    colorMode: segmentationColorMode.value,
-    propertyPath: volumeViewStore.segmentationPropertyPath,
-    propertyValues: propertyStore.propertyValues,
-    loftSurfaces: loftSurfaces.value,
-    loftOverlapFraction: loftOverlapPercent.value / 100,
-  });
+  // stay on screen until the replacement is ready. Callers don't await this
+  // function, so failures are logged here instead of rejecting.
+  let result: IAnnotationsTo3DResult;
+  try {
+    result = await annotationsTo3D({
+      annotations: filterStore.filteredAnnotations,
+      geometry: activeGeometry,
+      currentXY: store.xy,
+      currentTime: store.time,
+      currentZ: store.z,
+      axis: axisMode.value,
+      colorMode: segmentationColorMode.value,
+      propertyPath: volumeViewStore.segmentationPropertyPath,
+      propertyValues: propertyStore.propertyValues,
+      loftSurfaces: loftSurfaces.value,
+      loftOverlapFraction: loftOverlapPercent.value / 100,
+    });
+  } catch (error) {
+    logError(error);
+    return;
+  }
   if (serial !== segmentationSerial || !renderer() || !activeGeometry) {
     return;
   }

--- a/src/components/VolumeViewer.vue
+++ b/src/components/VolumeViewer.vue
@@ -73,6 +73,21 @@
       >
         <v-icon size="20">mdi-vector-polygon</v-icon>
       </v-btn>
+      <div
+        v-if="showSegmentations"
+        class="segmentation-opacity"
+        title="Segmentation opacity"
+      >
+        <v-icon size="16">mdi-opacity</v-icon>
+        <v-slider
+          v-model="segmentationOpacity"
+          :min="0.05"
+          :max="1"
+          :step="0.05"
+          density="compact"
+          hide-details
+        />
+      </div>
       <v-btn
         variant="text"
         size="small"
@@ -189,9 +204,15 @@
 <script setup lang="ts">
 import "@kitware/vtk.js/Rendering/Profiles/Geometry";
 import "@kitware/vtk.js/Rendering/Profiles/Volume";
+// Registers the OpenGL implementation of vtkSphereMapper (point spheres).
+import "@kitware/vtk.js/Rendering/Profiles/Molecule";
+import vtkPolyDataNormals from "@kitware/vtk.js/Filters/Core/PolyDataNormals";
 import vtkActor, {
   vtkActor as VtkActor,
 } from "@kitware/vtk.js/Rendering/Core/Actor";
+import vtkSphereMapper, {
+  vtkSphereMapper as VtkSphereMapper,
+} from "@kitware/vtk.js/Rendering/Core/SphereMapper";
 import vtkAxesActor from "@kitware/vtk.js/Rendering/Core/AxesActor";
 import vtkCubeAxesActor from "@kitware/vtk.js/Rendering/Core/CubeAxesActor";
 import vtkOrientationMarkerWidget, {
@@ -259,15 +280,19 @@ const volumeSource = new TileFrameVolumeSource(store.girderRestProxy, {
   getLayerHistogram: (images) => store.api.getLayerHistogram(images),
 });
 
-const SEGMENTATION_OPACITY = 0.55;
+interface ISegmentationPipeline {
+  actor: VtkActor;
+  mapper: VtkMapper | VtkSphereMapper;
+}
 
 let genericRenderWindow: VtkGenericRenderWindow | null = null;
 let orientationWidget: VtkOrientationMarkerWidget | null = null;
 let axesActor: ReturnType<typeof vtkAxesActor.newInstance> | null = null;
 let cubeAxesActor: VtkCubeAxesActor | null = null;
 let volumePipelines: IVolumePipeline[] = [];
-let segmentationActor: VtkActor | null = null;
-let segmentationMapper: VtkMapper | null = null;
+// Annotation rendering: one actor for extruded surfaces, one for point
+// spheres (only the ones with geometry are created).
+let segmentationPipelines: ISegmentationPipeline[] = [];
 let activeGeometry: VolumeGeometry | null = null;
 let activeAbortController: AbortController | null = null;
 let buildSerial = 0;
@@ -319,6 +344,11 @@ const showBoundingBox = computed({
 const segmentationColorMode = computed<TVolumeSegmentationColorMode>({
   get: () => volumeViewStore.segmentationColorMode,
   set: (value) => volumeViewStore.setSegmentationColorMode(value),
+});
+
+const segmentationOpacity = computed({
+  get: () => volumeViewStore.segmentationOpacity,
+  set: (value: number) => volumeViewStore.setSegmentationOpacity(value),
 });
 
 function propertyKey(path: string[]) {
@@ -449,15 +479,14 @@ function applyTransferFunction(pipeline: IVolumePipeline) {
   property.setShade(false);
 }
 
-function clearSegmentationActor() {
+function clearSegmentationActors() {
   const currentRenderer = renderer();
-  if (currentRenderer && segmentationActor) {
-    currentRenderer.removeActor(segmentationActor);
+  for (const pipeline of segmentationPipelines) {
+    currentRenderer?.removeActor(pipeline.actor);
+    pipeline.actor.delete();
+    pipeline.mapper.delete();
   }
-  segmentationActor?.delete();
-  segmentationMapper?.delete();
-  segmentationActor = null;
-  segmentationMapper = null;
+  segmentationPipelines = [];
 }
 
 function clearVolumeActors() {
@@ -546,7 +575,7 @@ async function rebuildVolume() {
   const serial = ++buildSerial;
   loading.value = true;
   statusText.value = "Building 3D";
-  clearSegmentationActor();
+  clearSegmentationActors();
   clearVolumeActors();
 
   if (visibleLayerStackImages.value.length === 0) {
@@ -574,7 +603,7 @@ async function rebuildVolume() {
     }
     volumes.forEach(addChannelVolume);
     activeGeometry = volumes[0]?.geometry ?? null;
-    updateSegmentationActor();
+    updateSegmentationActors();
     updateBoundingBox();
     // Reframe only when the volume geometry fundamentally changes (dataset or
     // depth axis); contrast / channel-visibility rebuilds keep the camera.
@@ -599,16 +628,32 @@ async function rebuildVolume() {
   }
 }
 
-function updateSegmentationActor() {
+function addSegmentationActor(mapper: VtkMapper | VtkSphereMapper) {
   const currentRenderer = renderer();
-  if (!currentRenderer || !activeGeometry) {
-    clearSegmentationActor();
-    render();
+  if (!currentRenderer) {
     return;
   }
+  const actor = vtkActor.newInstance();
+  actor.setMapper(mapper);
+  const property = actor.getProperty();
+  property.setOpacity(segmentationOpacity.value);
+  // Backface culling off: earcut cap triangulation has arbitrary winding, and
+  // the translucent prisms/ribbons should render both faces.
+  property.setBackfaceCulling(false);
+  // Lit, slightly specular shading so annotations read as surfaces.
+  property.setInterpolationToPhong();
+  property.setAmbient(0.3);
+  property.setDiffuse(0.7);
+  property.setSpecular(0.15);
+  property.setSpecularPower(16);
+  segmentationPipelines.push(markRaw({ actor, mapper }));
+  currentRenderer.addActor(actor);
+}
 
-  clearSegmentationActor();
-  if (!showSegmentations.value) {
+function updateSegmentationActors() {
+  const currentRenderer = renderer();
+  clearSegmentationActors();
+  if (!currentRenderer || !activeGeometry || !showSegmentations.value) {
     render();
     return;
   }
@@ -624,25 +669,39 @@ function updateSegmentationActor() {
     propertyPath: volumeViewStore.segmentationPropertyPath,
     propertyValues: propertyStore.propertyValues,
   });
-  if (result.polyData.getNumberOfCells() === 0) {
-    render();
-    return;
+
+  if (result.surfacePolyData.getNumberOfCells() > 0) {
+    // Smooth point normals make the extruded prisms shade like rounded
+    // surfaces instead of flat unlit slabs.
+    const normalsFilter = vtkPolyDataNormals.newInstance();
+    normalsFilter.setInputData(result.surfacePolyData);
+    const mapper = vtkMapper.newInstance({ scalarVisibility: true });
+    mapper.setInputData(normalsFilter.getOutputData());
+    mapper.setScalarModeToUseCellData();
+    mapper.setColorModeToMapScalars();
+    mapper.setLookupTable(result.lookupTable);
+    mapper.setScalarRange(result.scalarRange);
+    addSegmentationActor(mapper);
   }
 
-  segmentationMapper = vtkMapper.newInstance({ scalarVisibility: true });
-  segmentationMapper.setInputData(result.polyData);
-  segmentationMapper.setScalarModeToUseCellData();
-  segmentationMapper.setColorModeToMapScalars();
-  segmentationMapper.setLookupTable(result.lookupTable);
-  segmentationMapper.setScalarRange(result.scalarRange);
+  if (result.pointsPolyData.getNumberOfPoints() > 0) {
+    // Point annotations render as small shaded spheres.
+    const mapper = vtkSphereMapper.newInstance();
+    mapper.setInputData(result.pointsPolyData);
+    mapper.setRadius(result.pointRadius);
+    mapper.setScalarModeToUsePointData();
+    mapper.setColorModeToMapScalars();
+    mapper.setLookupTable(result.lookupTable);
+    mapper.setScalarRange(result.scalarRange);
+    addSegmentationActor(mapper);
+  }
+  render();
+}
 
-  segmentationActor = vtkActor.newInstance();
-  segmentationActor.setMapper(segmentationMapper);
-  segmentationActor.getProperty().setOpacity(SEGMENTATION_OPACITY);
-  // Backface culling off: earcut cap triangulation has arbitrary winding, and
-  // the translucent prisms should render both faces.
-  segmentationActor.getProperty().setBackfaceCulling(false);
-  currentRenderer.addActor(segmentationActor);
+function applySegmentationOpacity() {
+  segmentationPipelines.forEach((pipeline) =>
+    pipeline.actor.getProperty().setOpacity(segmentationOpacity.value),
+  );
   render();
 }
 
@@ -650,11 +709,11 @@ function applyVisibility() {
   volumePipelines.forEach((pipeline) =>
     pipeline.actor.setVisibility(showVolume.value),
   );
-  if (segmentationActor) {
-    segmentationActor.setVisibility(showSegmentations.value);
-  }
-  if (showSegmentations.value && !segmentationActor) {
-    updateSegmentationActor();
+  segmentationPipelines.forEach((pipeline) =>
+    pipeline.actor.setVisibility(showSegmentations.value),
+  );
+  if (showSegmentations.value && segmentationPipelines.length === 0) {
+    updateSegmentationActors();
   }
   render();
 }
@@ -722,7 +781,7 @@ onBeforeUnmount(() => {
   activeAbortController?.abort();
   resizeObserver?.disconnect();
   resizeObserver = null;
-  clearSegmentationActor();
+  clearSegmentationActors();
   clearVolumeActors();
   orientationWidget?.setEnabled(false);
   orientationWidget?.delete();
@@ -755,6 +814,8 @@ watch(showAxes, (value) => {
 });
 watch(showBoundingBox, updateBoundingBox);
 watch(colorKey, applyLayerColors);
+// Opacity only touches actor properties; the geometry is left alone.
+watch(segmentationOpacity, applySegmentationOpacity);
 // Segmentation-only inputs (these don't change the volume, so they don't go
 // through rebuildVolume). Navigation / axis changes update segmentations via
 // the rebuild instead.
@@ -766,7 +827,7 @@ watch(
     () => propertyStore.propertyValues,
   ],
   () => {
-    updateSegmentationActor();
+    updateSegmentationActors();
   },
 );
 
@@ -778,11 +839,12 @@ defineExpose({
   showVolume,
   showSegmentations,
   segmentationColorMode,
+  segmentationOpacity,
   selectedPropertyKey,
   propertyItems,
   rebuildVolume,
   resetCamera,
-  updateSegmentationActor,
+  updateSegmentationActors,
   get genericRenderWindow() {
     return genericRenderWindow;
   },
@@ -829,6 +891,19 @@ $gizmo-clearance: 130px;
 
 .property-select {
   width: min(260px, 35vw);
+}
+
+.segmentation-opacity {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 110px;
+  padding: 0 4px;
+
+  .v-slider {
+    flex: 1;
+    margin-inline: 0;
+  }
 }
 
 .time-spacing-hint {

--- a/src/components/VolumeViewer.vue
+++ b/src/components/VolumeViewer.vue
@@ -763,7 +763,14 @@ async function updateSegmentationActors() {
     logError(error);
     return;
   }
-  if (serial !== segmentationSerial || !renderer() || !activeGeometry) {
+  // Superseded, torn down, or hidden while the build was in flight
+  // (applyVisibility only toggles actors that already exist).
+  if (
+    serial !== segmentationSerial ||
+    !renderer() ||
+    !activeGeometry ||
+    !showSegmentations.value
+  ) {
     return;
   }
   clearSegmentationActors();

--- a/src/components/VolumeViewer.vue
+++ b/src/components/VolumeViewer.vue
@@ -716,15 +716,21 @@ function addSegmentationActor(mapper: VtkMapper | VtkSphereMapper) {
   currentRenderer.addActor(actor);
 }
 
-function updateSegmentationActors() {
-  const currentRenderer = renderer();
-  clearSegmentationActors();
-  if (!currentRenderer || !activeGeometry || !showSegmentations.value) {
+// Bumped on every segmentation update; results of superseded async builds
+// are discarded instead of being applied out of order.
+let segmentationSerial = 0;
+
+async function updateSegmentationActors() {
+  const serial = ++segmentationSerial;
+  if (!renderer() || !activeGeometry || !showSegmentations.value) {
+    clearSegmentationActors();
     render();
     return;
   }
 
-  const result = annotationsTo3D({
+  // Async: the loft chain matching runs in a web worker. The previous actors
+  // stay on screen until the replacement is ready.
+  const result = await annotationsTo3D({
     annotations: filterStore.filteredAnnotations,
     geometry: activeGeometry,
     currentXY: store.xy,
@@ -737,6 +743,10 @@ function updateSegmentationActors() {
     loftSurfaces: loftSurfaces.value,
     loftOverlapFraction: loftOverlapPercent.value / 100,
   });
+  if (serial !== segmentationSerial || !renderer() || !activeGeometry) {
+    return;
+  }
+  clearSegmentationActors();
 
   if (result.surfacePolyData.getNumberOfCells() > 0) {
     // Smooth point normals make the extruded prisms shade like rounded

--- a/src/components/VolumeViewer.vue
+++ b/src/components/VolumeViewer.vue
@@ -89,6 +89,27 @@
         />
       </div>
       <v-btn
+        v-if="showSegmentations"
+        variant="text"
+        size="small"
+        icon
+        :color="loftSurfaces ? 'primary' : undefined"
+        title="Loft stacked annotations into smooth surfaces"
+        @click="loftSurfaces = !loftSurfaces"
+      >
+        <v-icon size="20">mdi-vector-curve</v-icon>
+      </v-btn>
+      <v-btn
+        v-if="showSegmentations && loftSurfaces"
+        variant="text"
+        size="small"
+        icon
+        title="Loft overlap threshold"
+        @click="loftDialog = true"
+      >
+        <v-icon size="20">mdi-tune-variant</v-icon>
+      </v-btn>
+      <v-btn
         variant="text"
         size="small"
         icon
@@ -158,6 +179,39 @@
       />
       <span>{{ statusText }}</span>
     </div>
+
+    <v-dialog v-model="loftDialog" max-width="420px">
+      <v-card>
+        <v-card-title>Loft overlap threshold</v-card-title>
+        <v-card-text>
+          <v-slider
+            v-model="loftOverlapPercent"
+            :min="0"
+            :max="95"
+            :step="5"
+            density="comfortable"
+            hide-details
+          >
+            <template v-slot:append>
+              <span class="loft-threshold-value">
+                {{ loftOverlapPercent }}%
+              </span>
+            </template>
+          </v-slider>
+          <div class="loft-hint">
+            Annotations with the same tag on adjacent slices are joined into one
+            surface when their xy overlap is at least this fraction of the
+            smaller annotation. 0% joins on any overlap.
+          </div>
+        </v-card-text>
+        <v-card-actions class="button-bar">
+          <v-spacer />
+          <v-btn variant="text" size="small" @click="loftDialog = false">
+            Close
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
 
     <v-dialog v-model="timeSpacingDialog" max-width="360px">
       <v-card>
@@ -350,6 +404,18 @@ const segmentationOpacity = computed({
   get: () => volumeViewStore.segmentationOpacity,
   set: (value: number) => volumeViewStore.setSegmentationOpacity(value),
 });
+
+const loftSurfaces = computed({
+  get: () => volumeViewStore.loftSurfaces,
+  set: (value: boolean) => volumeViewStore.setLoftSurfaces(value),
+});
+
+const loftOverlapPercent = computed({
+  get: () => volumeViewStore.loftOverlapPercent,
+  set: (value: number) => volumeViewStore.setLoftOverlapPercent(value),
+});
+
+const loftDialog = ref(false);
 
 function propertyKey(path: string[]) {
   return path.join("\u0000");
@@ -668,6 +734,8 @@ function updateSegmentationActors() {
     colorMode: segmentationColorMode.value,
     propertyPath: volumeViewStore.segmentationPropertyPath,
     propertyValues: propertyStore.propertyValues,
+    loftSurfaces: loftSurfaces.value,
+    loftOverlapFraction: loftOverlapPercent.value / 100,
   });
 
   if (result.surfacePolyData.getNumberOfCells() > 0) {
@@ -825,6 +893,8 @@ watch(
     segmentationColorMode,
     selectedPropertyKey,
     () => propertyStore.propertyValues,
+    loftSurfaces,
+    loftOverlapPercent,
   ],
   () => {
     updateSegmentationActors();
@@ -840,6 +910,8 @@ defineExpose({
   showSegmentations,
   segmentationColorMode,
   segmentationOpacity,
+  loftSurfaces,
+  loftOverlapPercent,
   selectedPropertyKey,
   propertyItems,
   rebuildVolume,
@@ -906,10 +978,17 @@ $gizmo-clearance: 130px;
   }
 }
 
-.time-spacing-hint {
+.time-spacing-hint,
+.loft-hint {
   margin-top: 8px;
   font-size: 12px;
   opacity: 0.7;
+}
+
+.loft-threshold-value {
+  min-width: 40px;
+  text-align: right;
+  font-size: 13px;
 }
 
 .volume-status {

--- a/src/shims-vtk-polydatanormals.d.ts
+++ b/src/shims-vtk-polydatanormals.d.ts
@@ -1,0 +1,17 @@
+// vtk.js ships PolyDataNormals without type declarations. Only the members
+// used by VolumeViewer.vue are typed here.
+declare module "@kitware/vtk.js/Filters/Core/PolyDataNormals" {
+  import { vtkPolyData } from "@kitware/vtk.js/Common/DataModel/PolyData";
+
+  export interface vtkPolyDataNormals {
+    setInputData(polyData: vtkPolyData): void;
+    getOutputData(): vtkPolyData;
+    setComputePointNormals(value: boolean): boolean;
+    setComputeCellNormals(value: boolean): boolean;
+    delete(): void;
+  }
+  const vtkPolyDataNormalsFactory: {
+    newInstance(initialValues?: Record<string, unknown>): vtkPolyDataNormals;
+  };
+  export default vtkPolyDataNormalsFactory;
+}

--- a/src/store/volumeView.ts
+++ b/src/store/volumeView.ts
@@ -29,6 +29,12 @@ export class VolumeView extends VuexModule {
   segmentationPropertyPath: string[] = [];
   // Opacity of 3D annotation surfaces and point spheres, in (0, 1].
   segmentationOpacity: number = 0.55;
+  // Loft same-tag annotations that overlap across adjacent slices into
+  // continuous 3D surfaces (instead of per-slice prisms).
+  loftSurfaces: boolean = true;
+  // Minimum xy overlap (% of the smaller annotation) required to treat
+  // annotations on adjacent slices as the same object. 0 = any overlap.
+  loftOverlapPercent: number = 0;
   // Depth spacing (µm) to use when time is the depth axis. null → auto default
   // (5× the xy pixel size), computed at build time.
   timeStepUmOverride: number | null = null;
@@ -81,6 +87,16 @@ export class VolumeView extends VuexModule {
   @Mutation
   setSegmentationOpacity(value: number) {
     this.segmentationOpacity = Math.min(1, Math.max(0.05, value));
+  }
+
+  @Mutation
+  setLoftSurfaces(value: boolean) {
+    this.loftSurfaces = value;
+  }
+
+  @Mutation
+  setLoftOverlapPercent(value: number) {
+    this.loftOverlapPercent = Math.min(95, Math.max(0, value));
   }
 
   @Mutation

--- a/src/store/volumeView.ts
+++ b/src/store/volumeView.ts
@@ -27,6 +27,8 @@ export class VolumeView extends VuexModule {
   showBoundingBox: boolean = false;
   segmentationColorMode: TVolumeSegmentationColorMode = "tag";
   segmentationPropertyPath: string[] = [];
+  // Opacity of 3D annotation surfaces and point spheres, in (0, 1].
+  segmentationOpacity: number = 0.55;
   // Depth spacing (µm) to use when time is the depth axis. null → auto default
   // (5× the xy pixel size), computed at build time.
   timeStepUmOverride: number | null = null;
@@ -74,6 +76,11 @@ export class VolumeView extends VuexModule {
   @Mutation
   setSegmentationPropertyPath(value: string[]) {
     this.segmentationPropertyPath = [...value];
+  }
+
+  @Mutation
+  setSegmentationOpacity(value: number) {
+    this.segmentationOpacity = Math.min(1, Math.max(0.05, value));
   }
 
   @Mutation

--- a/src/utils/annotationsTo3D.test.ts
+++ b/src/utils/annotationsTo3D.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { annotationsTo3D } from "@/utils/annotationsTo3D";
+import {
+  IAnnotationsTo3DOptions,
+  annotationsTo3D,
+} from "@/utils/annotationsTo3D";
 import { AnnotationShape, IAnnotation } from "@/store/model";
 import type { VolumeGeometry } from "@/store/VolumeAPI";
 
@@ -35,7 +38,10 @@ function annotation(delta: Partial<IAnnotation>): IAnnotation {
   };
 }
 
-function convert(annotations: IAnnotation[], delta = {}) {
+function convert(
+  annotations: IAnnotation[],
+  delta: Partial<IAnnotationsTo3DOptions> = {},
+) {
   return annotationsTo3D({
     annotations,
     geometry,

--- a/src/utils/annotationsTo3D.test.ts
+++ b/src/utils/annotationsTo3D.test.ts
@@ -35,28 +35,33 @@ function annotation(delta: Partial<IAnnotation>): IAnnotation {
   };
 }
 
+function convert(annotations: IAnnotation[], delta = {}) {
+  return annotationsTo3D({
+    annotations,
+    geometry,
+    currentXY: 0,
+    currentTime: 0,
+    colorMode: "tag",
+    propertyPath: [],
+    propertyValues: {},
+    ...delta,
+  });
+}
+
 describe("annotationsTo3D", () => {
   it("extrudes current XY/time polygons into micrometer prism geometry", () => {
-    const result = annotationsTo3D({
-      annotations: [
-        annotation({ id: "included" }),
-        annotation({ id: "other-xy", location: { XY: 1, Z: 1, Time: 0 } }),
-        annotation({ id: "spot", shape: AnnotationShape.Point }),
-      ],
-      geometry,
-      currentXY: 0,
-      currentTime: 0,
-      colorMode: "tag",
-      propertyPath: [],
-      propertyValues: {},
-    });
+    const result = convert([
+      annotation({ id: "included" }),
+      annotation({ id: "other-xy", location: { XY: 1, Z: 1, Time: 0 } }),
+      annotation({ id: "unsupported", shape: AnnotationShape.Circle }),
+    ]);
 
     expect(result.usedCount).toBe(1);
-    expect(result.skippedByShape.point).toBe(1);
-    expect(result.polyData.getNumberOfPoints()).toBe(8);
-    expect(result.polyData.getNumberOfCells()).toBe(12);
+    expect(result.skippedByShape.circle).toBe(1);
+    expect(result.surfacePolyData.getNumberOfPoints()).toBe(8);
+    expect(result.surfacePolyData.getNumberOfCells()).toBe(12);
 
-    const points = Array.from(result.polyData.getPoints().getData());
+    const points = Array.from(result.surfacePolyData.getPoints().getData());
     expect(points.slice(0, 12)).toEqual([
       0, 0, 2.5, 2, 0, 2.5, 2, 4, 2.5, 0, 4, 2.5,
     ]);
@@ -64,16 +69,84 @@ describe("annotationsTo3D", () => {
       0, 0, 7.5, 2, 0, 7.5, 2, 4, 7.5, 0, 4, 7.5,
     ]);
 
-    const scalars = result.polyData.getCellData().getScalars();
+    const scalars = result.surfacePolyData.getCellData().getScalars();
     expect(Array.from(scalars.getData())).toEqual(Array(12).fill(0));
   });
 
+  it("extrudes rectangles like polygons", () => {
+    const result = convert([annotation({ shape: AnnotationShape.Rectangle })]);
+
+    expect(result.usedCount).toBe(1);
+    expect(result.surfacePolyData.getNumberOfCells()).toBe(12);
+    expect(result.skippedByShape).toEqual({});
+  });
+
+  it("turns point annotations into sphere centers at the slice depth", () => {
+    const result = convert([
+      annotation({
+        shape: AnnotationShape.Point,
+        coordinates: [{ x: 2, y: 1 }],
+      }),
+    ]);
+
+    expect(result.usedCount).toBe(1);
+    expect(result.surfacePolyData.getNumberOfCells()).toBe(0);
+    expect(result.pointsPolyData.getNumberOfPoints()).toBe(1);
+    // Source pixel (2, 1) maps to (2 µm, 2 µm); z index 1 maps to 5 µm.
+    expect(Array.from(result.pointsPolyData.getPoints().getData())).toEqual([
+      2, 2, 5,
+    ]);
+    expect(
+      Array.from(result.pointsPolyData.getPointData().getScalars().getData()),
+    ).toEqual([0]);
+    // 3 × in-plane source spacing and 0.6 × slice thickness both exceed the
+    // volume-diagonal cap for this tiny volume, so the cap wins.
+    expect(result.pointRadius).toBeCloseTo(Math.hypot(16, 16, 15) / 50, 6);
+  });
+
+  it("extrudes line annotations into ribbons through the slice", () => {
+    const result = convert([
+      annotation({
+        shape: AnnotationShape.Line,
+        coordinates: [
+          { x: 0, y: 0 },
+          { x: 2, y: 0 },
+          { x: 4, y: 0 },
+        ],
+      }),
+    ]);
+
+    expect(result.usedCount).toBe(1);
+    expect(result.surfacePolyData.getNumberOfPoints()).toBe(6);
+    // Two triangles per segment.
+    expect(result.surfacePolyData.getNumberOfCells()).toBe(4);
+
+    const points = Array.from(result.surfacePolyData.getPoints().getData());
+    expect(points.slice(0, 9)).toEqual([0, 0, 2.5, 2, 0, 2.5, 4, 0, 2.5]);
+    expect(points.slice(9, 18)).toEqual([0, 0, 7.5, 2, 0, 7.5, 4, 0, 7.5]);
+  });
+
+  it("assigns consistent tag scalars across shapes", () => {
+    const result = convert([
+      annotation({ id: "blob", tags: ["nucleus"] }),
+      annotation({
+        id: "spot",
+        tags: ["spot"],
+        shape: AnnotationShape.Point,
+        coordinates: [{ x: 1, y: 1 }],
+      }),
+    ]);
+
+    expect(result.usedCount).toBe(2);
+    expect(result.scalarRange).toEqual([0, 1]);
+    // The polygon got tag scalar 0, so the differently-tagged point gets 1.
+    expect(
+      Array.from(result.pointsPolyData.getPointData().getScalars().getData()),
+    ).toEqual([1]);
+  });
+
   it("uses numeric property values as per-cell scalars", () => {
-    const result = annotationsTo3D({
-      annotations: [annotation({ id: "ann-a" })],
-      geometry,
-      currentXY: 0,
-      currentTime: 0,
+    const result = convert([annotation({ id: "ann-a" })], {
       colorMode: "property",
       propertyPath: ["area"],
       propertyValues: { "ann-a": { area: 42 } },
@@ -81,24 +154,34 @@ describe("annotationsTo3D", () => {
 
     expect(result.scalarRange).toEqual([42, 43]);
     expect(
-      Array.from(result.polyData.getCellData().getScalars().getData()),
+      Array.from(result.surfacePolyData.getCellData().getScalars().getData()),
     ).toEqual(Array(12).fill(42));
   });
 
   it("falls back to neutral scalars when property values are missing", () => {
-    const result = annotationsTo3D({
-      annotations: [annotation({ id: "ann-a", tags: ["tag-a"] })],
-      geometry,
-      currentXY: 0,
-      currentTime: 0,
-      colorMode: "property",
-      propertyPath: ["area"],
-      propertyValues: {},
-    });
+    const result = convert(
+      [
+        annotation({ id: "ann-a", tags: ["tag-a"] }),
+        annotation({
+          id: "spot",
+          shape: AnnotationShape.Point,
+          coordinates: [{ x: 1, y: 1 }],
+        }),
+      ],
+      {
+        colorMode: "property",
+        propertyPath: ["area"],
+        propertyValues: { "ann-a": { area: 42 } },
+      },
+    );
 
+    // The point has no property value, so all shapes drop to neutral scalars.
     expect(result.scalarRange).toEqual([0, 1]);
     expect(
-      Array.from(result.polyData.getCellData().getScalars().getData()),
+      Array.from(result.surfacePolyData.getCellData().getScalars().getData()),
     ).toEqual(Array(12).fill(0));
+    expect(
+      Array.from(result.pointsPolyData.getPointData().getScalars().getData()),
+    ).toEqual([0]);
   });
 });

--- a/src/utils/annotationsTo3D.test.ts
+++ b/src/utils/annotationsTo3D.test.ts
@@ -145,6 +145,86 @@ describe("annotationsTo3D", () => {
     ).toEqual([1]);
   });
 
+  it("lofts overlapping same-tag polygons on adjacent slices", () => {
+    const result = convert(
+      [
+        annotation({ id: "slice-0", location: { XY: 0, Z: 0, Time: 0 } }),
+        annotation({ id: "slice-1", location: { XY: 0, Z: 1, Time: 0 } }),
+      ],
+      { loftSurfaces: true },
+    );
+
+    expect(result.usedCount).toBe(2);
+    // Four rings (bottom skirt, two slice centers, top skirt) of 24 points.
+    expect(result.surfacePolyData.getNumberOfPoints()).toBe(96);
+    // Three bands of 2×24 triangles plus two end caps.
+    expect(result.surfacePolyData.getNumberOfCells()).toBeGreaterThan(144);
+
+    const points = Array.from(result.surfacePolyData.getPoints().getData());
+    // The bottom skirt ring extends half a slice below the first center.
+    expect(points[2]).toBe(-2.5);
+    // The last pushed ring is the top skirt, half a slice above z index 1.
+    expect(points[points.length - 1]).toBe(7.5);
+  });
+
+  it("keeps separate prisms when overlap is below the loft threshold", () => {
+    const annotations = [
+      annotation({ id: "slice-0", location: { XY: 0, Z: 0, Time: 0 } }),
+      annotation({
+        id: "slice-1",
+        location: { XY: 0, Z: 1, Time: 0 },
+        // Shifted by half the width: 50% overlap of the smaller polygon.
+        coordinates: [
+          { x: 1, y: 0 },
+          { x: 3, y: 0 },
+          { x: 3, y: 2 },
+          { x: 1, y: 2 },
+        ],
+      }),
+    ];
+
+    const lofted = convert(annotations, {
+      loftSurfaces: true,
+      loftOverlapFraction: 0.25,
+    });
+    expect(lofted.surfacePolyData.getNumberOfPoints()).toBe(96);
+
+    const separate = convert(annotations, {
+      loftSurfaces: true,
+      loftOverlapFraction: 0.75,
+    });
+    expect(separate.surfacePolyData.getNumberOfPoints()).toBe(16);
+    expect(separate.surfacePolyData.getNumberOfCells()).toBe(24);
+  });
+
+  it("does not loft across z gaps or across different tags", () => {
+    const gapped = convert(
+      [
+        annotation({ id: "slice-0", location: { XY: 0, Z: 0, Time: 0 } }),
+        annotation({ id: "slice-2", location: { XY: 0, Z: 2, Time: 0 } }),
+      ],
+      { loftSurfaces: true },
+    );
+    expect(gapped.surfacePolyData.getNumberOfCells()).toBe(24);
+
+    const mixedTags = convert(
+      [
+        annotation({
+          id: "slice-0",
+          tags: ["nucleus"],
+          location: { XY: 0, Z: 0, Time: 0 },
+        }),
+        annotation({
+          id: "slice-1",
+          tags: ["cell"],
+          location: { XY: 0, Z: 1, Time: 0 },
+        }),
+      ],
+      { loftSurfaces: true },
+    );
+    expect(mixedTags.surfacePolyData.getNumberOfCells()).toBe(24);
+  });
+
   it("uses numeric property values as per-cell scalars", () => {
     const result = convert([annotation({ id: "ann-a" })], {
       colorMode: "property",

--- a/src/utils/annotationsTo3D.test.ts
+++ b/src/utils/annotationsTo3D.test.ts
@@ -49,8 +49,8 @@ function convert(annotations: IAnnotation[], delta = {}) {
 }
 
 describe("annotationsTo3D", () => {
-  it("extrudes current XY/time polygons into micrometer prism geometry", () => {
-    const result = convert([
+  it("extrudes current XY/time polygons into micrometer prism geometry", async () => {
+    const result = await convert([
       annotation({ id: "included" }),
       annotation({ id: "other-xy", location: { XY: 1, Z: 1, Time: 0 } }),
       annotation({ id: "unsupported", shape: AnnotationShape.Circle }),
@@ -73,16 +73,18 @@ describe("annotationsTo3D", () => {
     expect(Array.from(scalars.getData())).toEqual(Array(12).fill(0));
   });
 
-  it("extrudes rectangles like polygons", () => {
-    const result = convert([annotation({ shape: AnnotationShape.Rectangle })]);
+  it("extrudes rectangles like polygons", async () => {
+    const result = await convert([
+      annotation({ shape: AnnotationShape.Rectangle }),
+    ]);
 
     expect(result.usedCount).toBe(1);
     expect(result.surfacePolyData.getNumberOfCells()).toBe(12);
     expect(result.skippedByShape).toEqual({});
   });
 
-  it("turns point annotations into sphere centers at the slice depth", () => {
-    const result = convert([
+  it("turns point annotations into sphere centers at the slice depth", async () => {
+    const result = await convert([
       annotation({
         shape: AnnotationShape.Point,
         coordinates: [{ x: 2, y: 1 }],
@@ -104,8 +106,8 @@ describe("annotationsTo3D", () => {
     expect(result.pointRadius).toBeCloseTo(Math.hypot(16, 16, 15) / 50, 6);
   });
 
-  it("extrudes line annotations into ribbons through the slice", () => {
-    const result = convert([
+  it("extrudes line annotations into ribbons through the slice", async () => {
+    const result = await convert([
       annotation({
         shape: AnnotationShape.Line,
         coordinates: [
@@ -126,8 +128,8 @@ describe("annotationsTo3D", () => {
     expect(points.slice(9, 18)).toEqual([0, 0, 7.5, 2, 0, 7.5, 4, 0, 7.5]);
   });
 
-  it("assigns consistent tag scalars across shapes", () => {
-    const result = convert([
+  it("assigns consistent tag scalars across shapes", async () => {
+    const result = await convert([
       annotation({ id: "blob", tags: ["nucleus"] }),
       annotation({
         id: "spot",
@@ -145,8 +147,8 @@ describe("annotationsTo3D", () => {
     ).toEqual([1]);
   });
 
-  it("lofts overlapping same-tag polygons on adjacent slices", () => {
-    const result = convert(
+  it("lofts overlapping same-tag polygons on adjacent slices", async () => {
+    const result = await convert(
       [
         annotation({ id: "slice-0", location: { XY: 0, Z: 0, Time: 0 } }),
         annotation({ id: "slice-1", location: { XY: 0, Z: 1, Time: 0 } }),
@@ -167,7 +169,7 @@ describe("annotationsTo3D", () => {
     expect(points[points.length - 1]).toBe(7.5);
   });
 
-  it("keeps separate prisms when overlap is below the loft threshold", () => {
+  it("keeps separate prisms when overlap is below the loft threshold", async () => {
     const annotations = [
       annotation({ id: "slice-0", location: { XY: 0, Z: 0, Time: 0 } }),
       annotation({
@@ -183,13 +185,13 @@ describe("annotationsTo3D", () => {
       }),
     ];
 
-    const lofted = convert(annotations, {
+    const lofted = await convert(annotations, {
       loftSurfaces: true,
       loftOverlapFraction: 0.25,
     });
     expect(lofted.surfacePolyData.getNumberOfPoints()).toBe(96);
 
-    const separate = convert(annotations, {
+    const separate = await convert(annotations, {
       loftSurfaces: true,
       loftOverlapFraction: 0.75,
     });
@@ -197,8 +199,8 @@ describe("annotationsTo3D", () => {
     expect(separate.surfacePolyData.getNumberOfCells()).toBe(24);
   });
 
-  it("does not loft across z gaps or across different tags", () => {
-    const gapped = convert(
+  it("does not loft across z gaps or across different tags", async () => {
+    const gapped = await convert(
       [
         annotation({ id: "slice-0", location: { XY: 0, Z: 0, Time: 0 } }),
         annotation({ id: "slice-2", location: { XY: 0, Z: 2, Time: 0 } }),
@@ -207,7 +209,7 @@ describe("annotationsTo3D", () => {
     );
     expect(gapped.surfacePolyData.getNumberOfCells()).toBe(24);
 
-    const mixedTags = convert(
+    const mixedTags = await convert(
       [
         annotation({
           id: "slice-0",
@@ -225,8 +227,8 @@ describe("annotationsTo3D", () => {
     expect(mixedTags.surfacePolyData.getNumberOfCells()).toBe(24);
   });
 
-  it("uses numeric property values as per-cell scalars", () => {
-    const result = convert([annotation({ id: "ann-a" })], {
+  it("uses numeric property values as per-cell scalars", async () => {
+    const result = await convert([annotation({ id: "ann-a" })], {
       colorMode: "property",
       propertyPath: ["area"],
       propertyValues: { "ann-a": { area: 42 } },
@@ -238,8 +240,8 @@ describe("annotationsTo3D", () => {
     ).toEqual(Array(12).fill(42));
   });
 
-  it("falls back to neutral scalars when property values are missing", () => {
-    const result = convert(
+  it("falls back to neutral scalars when property values are missing", async () => {
+    const result = await convert(
       [
         annotation({ id: "ann-a", tags: ["tag-a"] }),
         annotation({

--- a/src/utils/annotationsTo3D.ts
+++ b/src/utils/annotationsTo3D.ts
@@ -20,9 +20,9 @@ import { logWarning } from "@/utils/log";
 import {
   IPlanarPoint,
   alignRingToReference,
-  overlapFraction,
   resampleClosedContour,
 } from "@/utils/contourLoft";
+import { computeLoftChains } from "@/utils/loftChainsWorkerClient";
 import type { VolumeGeometry } from "@/store/VolumeAPI";
 
 export interface IAnnotationsTo3DOptions {
@@ -267,94 +267,6 @@ interface IPrismEntry {
   tag: string;
 }
 
-// Pairs each polygon with at most one polygon on the next slice — greedy
-// best-overlap matching, like frame-to-frame tracking — and returns the
-// resulting chains. Only same-tag polygons on consecutive original slices
-// whose xy overlap reaches `minOverlapFraction` are linked; a chain of
-// length 1 falls back to a plain prism.
-function buildLoftChains(
-  entries: IPrismEntry[],
-  minOverlapFraction: number,
-): IPrismEntry[][] {
-  const bounds = new Map<IPrismEntry, [number, number, number, number]>();
-  for (const entry of entries) {
-    const xs = entry.polygon.map((point) => point.x);
-    const ys = entry.polygon.map((point) => point.y);
-    bounds.set(entry, [
-      Math.min(...xs),
-      Math.min(...ys),
-      Math.max(...xs),
-      Math.max(...ys),
-    ]);
-  }
-  const boundsIntersect = (a: IPrismEntry, b: IPrismEntry) => {
-    const [aMinX, aMinY, aMaxX, aMaxY] = bounds.get(a)!;
-    const [bMinX, bMinY, bMaxX, bMaxY] = bounds.get(b)!;
-    return aMinX <= bMaxX && bMinX <= aMaxX && aMinY <= bMaxY && bMinY <= aMaxY;
-  };
-
-  const byTagAndDepth = new Map<string, Map<number, IPrismEntry[]>>();
-  for (const entry of entries) {
-    const byDepth = byTagAndDepth.get(entry.tag) ?? new Map();
-    byTagAndDepth.set(entry.tag, byDepth);
-    byDepth.set(entry.originalDepth, [
-      ...(byDepth.get(entry.originalDepth) ?? []),
-      entry,
-    ]);
-  }
-
-  const nextOf = new Map<IPrismEntry, IPrismEntry>();
-  const hasPrevious = new Set<IPrismEntry>();
-  for (const byDepth of byTagAndDepth.values()) {
-    for (const [depth, sliceEntries] of byDepth) {
-      const nextSliceEntries = byDepth.get(depth + 1);
-      if (!nextSliceEntries) {
-        continue;
-      }
-      const candidates: {
-        lower: IPrismEntry;
-        upper: IPrismEntry;
-        overlap: number;
-      }[] = [];
-      for (const lower of sliceEntries) {
-        for (const upper of nextSliceEntries) {
-          if (!boundsIntersect(lower, upper)) {
-            continue;
-          }
-          const overlap = overlapFraction(lower.polygon, upper.polygon);
-          if (overlap > 0 && overlap >= minOverlapFraction) {
-            candidates.push({ lower, upper, overlap });
-          }
-        }
-      }
-      candidates.sort((a, b) => b.overlap - a.overlap);
-      for (const { lower, upper } of candidates) {
-        if (!nextOf.has(lower) && !hasPrevious.has(upper)) {
-          nextOf.set(lower, upper);
-          hasPrevious.add(upper);
-        }
-      }
-    }
-  }
-
-  const chains: IPrismEntry[][] = [];
-  for (const entry of entries) {
-    if (hasPrevious.has(entry)) {
-      continue;
-    }
-    const chain: IPrismEntry[] = [];
-    for (
-      let link: IPrismEntry | undefined = entry;
-      link !== undefined;
-      link = nextOf.get(link)
-    ) {
-      chain.push(link);
-    }
-    chains.push(chain);
-  }
-  return chains;
-}
-
 // Resampled ring sizes for lofted surfaces: enough points to keep blob
 // detail, bounded so huge SAM polygons don't explode the mesh.
 const LOFT_MIN_RING_SIZE = 24;
@@ -546,9 +458,9 @@ function buildPointsPolyData(
   return polyData;
 }
 
-export function annotationsTo3D(
+export async function annotationsTo3D(
   options: IAnnotationsTo3DOptions,
-): IAnnotationsTo3DResult {
+): Promise<IAnnotationsTo3DResult> {
   const axis = options.axis ?? "z";
   const currentZ = options.currentZ ?? 0;
   // Keep annotations in the current field of view; the depth axis spans all of
@@ -656,8 +568,19 @@ export function annotationsTo3D(
     usedAnnotationCount += 1;
   });
 
+  // Chain matching is the expensive part (pairwise polygon intersections);
+  // it runs in a web worker where available (see loftChainsWorkerClient.ts).
   const chains = options.loftSurfaces
-    ? buildLoftChains(prismEntries, options.loftOverlapFraction ?? 0)
+    ? (
+        await computeLoftChains(
+          prismEntries.map((entry) => ({
+            polygon: entry.polygon,
+            depth: entry.originalDepth,
+            group: entry.tag,
+          })),
+          options.loftOverlapFraction ?? 0,
+        )
+      ).map((indices) => indices.map((index) => prismEntries[index]))
     : prismEntries.map((entry) => [entry]);
   // Half the world-z distance between consecutive original slices, so lofted
   // surfaces span the full thickness of their first and last slices.

--- a/src/utils/annotationsTo3D.ts
+++ b/src/utils/annotationsTo3D.ts
@@ -35,7 +35,14 @@ export interface IAnnotationsTo3DOptions {
 }
 
 export interface IAnnotationsTo3DResult {
-  polyData: VtkPolyData;
+  // Extruded polygon/rectangle prisms and line ribbons, one scalar per cell.
+  // Rendered as a shaded, translucent surface.
+  surfacePolyData: VtkPolyData;
+  // One point per point annotation, one scalar per point. Rendered as spheres
+  // of radius `pointRadius`.
+  pointsPolyData: VtkPolyData;
+  // Sphere radius (µm) for point annotations, derived from the volume size.
+  pointRadius: number;
   lookupTable: VtkLookupTable;
   scalarRange: [number, number];
   usedCount: number;
@@ -67,7 +74,7 @@ function makeLookupTable(
     table[offset] = Math.round(red * 255);
     table[offset + 1] = Math.round(green * 255);
     table[offset + 2] = Math.round(blue * 255);
-    table[offset + 3] = 190;
+    table[offset + 3] = 255;
   });
   lookupTable.setTable(
     vtkDataArray.newInstance({
@@ -82,10 +89,14 @@ function neutralLookupTable(): VtkLookupTable {
   return makeLookupTable([[0.74, 0.74, 0.7]], [0, 1]);
 }
 
-function normalizedPolygon(points: IAnnotation["coordinates"]) {
-  const result = points
+function finitePoints(points: IAnnotation["coordinates"]) {
+  return points
     .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y))
     .map((point) => ({ x: point.x, y: point.y }));
+}
+
+function normalizedPolygon(points: IAnnotation["coordinates"]) {
+  const result = finitePoints(points);
   const first = result[0];
   const last = result.at(-1);
   if (first && last && first.x === last.x && first.y === last.y) {
@@ -94,39 +105,76 @@ function normalizedPolygon(points: IAnnotation["coordinates"]) {
   return result;
 }
 
-function addPrism(
-  sourcePoints: { x: number; y: number }[],
-  depthIndex: number,
-  scalar: number,
-  geometry: VolumeGeometry,
-  points: number[],
-  triangles: number[],
-  cellScalars: number[],
-) {
+// Converts source-image pixel coordinates and depth indices to world µm.
+interface IWorldTransform {
+  toX(x: number): number;
+  toY(y: number): number;
+  zCenter(depthIndex: number): number;
+  spacingZ: number;
+}
+
+function makeWorldTransform(geometry: VolumeGeometry): IWorldTransform {
   const [spacingX, spacingY, spacingZ] = geometry.spacing;
   const [originX, originY, originZ] = geometry.origin;
   const [fetchedWidth, fetchedHeight] = geometry.dimensions;
   const [sourceWidth, sourceHeight] = geometry.sourceSize;
   const sourceSpacingX = spacingX * (fetchedWidth / sourceWidth);
   const sourceSpacingY = spacingY * (fetchedHeight / sourceHeight);
-  const z0 = originZ + depthIndex * spacingZ - spacingZ / 2;
-  const z1 = z0 + spacingZ;
-  const baseIndex = points.length / 3;
+  return {
+    toX: (x) => originX + x * sourceSpacingX,
+    toY: (y) => originY + y * sourceSpacingY,
+    zCenter: (depthIndex) => originZ + depthIndex * spacingZ,
+    spacingZ,
+  };
+}
+
+// Sphere radius for point annotations: a few source pixels across and at
+// least most of a slice thickness, but never a large fraction of the volume.
+function suggestedPointRadius(geometry: VolumeGeometry): number {
+  const [spacingX, spacingY, spacingZ] = geometry.spacing;
+  const [dimX, dimY, dimZ] = geometry.dimensions;
+  const [sourceWidth, sourceHeight] = geometry.sourceSize;
+  const sourceSpacingX = spacingX * (dimX / sourceWidth);
+  const sourceSpacingY = spacingY * (dimY / sourceHeight);
+  const diagonal = Math.hypot(
+    dimX * spacingX,
+    dimY * spacingY,
+    dimZ * spacingZ,
+  );
+  const radius = Math.min(
+    Math.max(3 * Math.max(sourceSpacingX, sourceSpacingY), 0.6 * spacingZ),
+    diagonal / 50,
+  );
+  return Number.isFinite(radius) && radius > 0 ? radius : 1;
+}
+
+interface ISurfaceMesh {
+  points: number[];
+  triangles: number[];
+  cellScalars: number[];
+}
+
+function addPrism(
+  sourcePoints: { x: number; y: number }[],
+  depthIndex: number,
+  scalar: number,
+  world: IWorldTransform,
+  mesh: ISurfaceMesh,
+) {
+  const z0 = world.zCenter(depthIndex) - world.spacingZ / 2;
+  const z1 = z0 + world.spacingZ;
+  const baseIndex = mesh.points.length / 3;
 
   for (const point of sourcePoints) {
-    points.push(originX + point.x * sourceSpacingX);
-    points.push(originY + point.y * sourceSpacingY);
-    points.push(z0);
+    mesh.points.push(world.toX(point.x), world.toY(point.y), z0);
   }
   for (const point of sourcePoints) {
-    points.push(originX + point.x * sourceSpacingX);
-    points.push(originY + point.y * sourceSpacingY);
-    points.push(z1);
+    mesh.points.push(world.toX(point.x), world.toY(point.y), z1);
   }
 
   const addTriangle = (a: number, b: number, c: number) => {
-    triangles.push(3, a, b, c);
-    cellScalars.push(scalar);
+    mesh.triangles.push(3, a, b, c);
+    mesh.cellScalars.push(scalar);
   };
 
   // Triangulate the (possibly concave) polygon caps via earcut. Backface
@@ -156,19 +204,136 @@ function addPrism(
   }
 }
 
-function buildEmptyResult(): IAnnotationsTo3DResult {
+// Extrudes a polyline through the slice thickness, producing a vertical
+// ribbon (two triangles per segment) that matches the prism walls visually.
+function addRibbon(
+  sourcePoints: { x: number; y: number }[],
+  depthIndex: number,
+  scalar: number,
+  world: IWorldTransform,
+  mesh: ISurfaceMesh,
+) {
+  const z0 = world.zCenter(depthIndex) - world.spacingZ / 2;
+  const z1 = z0 + world.spacingZ;
+  const baseIndex = mesh.points.length / 3;
+
+  for (const point of sourcePoints) {
+    mesh.points.push(world.toX(point.x), world.toY(point.y), z0);
+  }
+  for (const point of sourcePoints) {
+    mesh.points.push(world.toX(point.x), world.toY(point.y), z1);
+  }
+
+  const topBase = baseIndex + sourcePoints.length;
+  for (let index = 0; index < sourcePoints.length - 1; index += 1) {
+    mesh.triangles.push(
+      3,
+      baseIndex + index,
+      baseIndex + index + 1,
+      topBase + index + 1,
+    );
+    mesh.cellScalars.push(scalar);
+    mesh.triangles.push(
+      3,
+      baseIndex + index,
+      topBase + index + 1,
+      topBase + index,
+    );
+    mesh.cellScalars.push(scalar);
+  }
+}
+
+type TSegmentationKind = "prism" | "ribbon" | "sphere";
+
+interface ISegmentationItem {
+  annotation: IAnnotation;
+  kind: TSegmentationKind;
+  // Source-pixel coordinates: polygon vertices (prism), polyline vertices
+  // (ribbon), or a single center (sphere).
+  planarPoints: { x: number; y: number }[];
+}
+
+function classifyAnnotation(
+  annotation: IAnnotation,
+  skippedByShape: Record<string, number>,
+): ISegmentationItem | null {
+  switch (annotation.shape) {
+    case AnnotationShape.Polygon:
+    case AnnotationShape.Rectangle: {
+      const polygon = normalizedPolygon(annotation.coordinates);
+      if (polygon.length >= 3) {
+        return { annotation, kind: "prism", planarPoints: polygon };
+      }
+      break;
+    }
+    case AnnotationShape.Line: {
+      const line = finitePoints(annotation.coordinates);
+      if (line.length >= 2) {
+        return { annotation, kind: "ribbon", planarPoints: line };
+      }
+      break;
+    }
+    case AnnotationShape.Point: {
+      const center = finitePoints(annotation.coordinates);
+      if (center.length >= 1) {
+        return { annotation, kind: "sphere", planarPoints: [center[0]] };
+      }
+      break;
+    }
+    default:
+      skippedByShape[annotation.shape] =
+        (skippedByShape[annotation.shape] ?? 0) + 1;
+      return null;
+  }
+  skippedByShape.empty = (skippedByShape.empty ?? 0) + 1;
+  return null;
+}
+
+function buildSurfacePolyData(mesh: ISurfaceMesh): VtkPolyData {
   const polyData = vtkPolyData.newInstance();
   const points = vtkPoints.newInstance({ empty: true });
-  points.setData(new Float32Array(), 3);
+  points.setData(new Float32Array(mesh.points), 3);
   polyData.setPoints(points);
-  polyData.setPolys(vtkCellArray.newInstance({ values: new Uint32Array() }));
-  return {
-    polyData,
-    lookupTable: neutralLookupTable(),
-    scalarRange: [0, 1],
-    usedCount: 0,
-    skippedByShape: {},
-  };
+  polyData.setPolys(
+    vtkCellArray.newInstance({ values: new Uint32Array(mesh.triangles) }),
+  );
+  if (mesh.cellScalars.length > 0) {
+    polyData.getCellData().setScalars(
+      vtkDataArray.newInstance({
+        name: "annotationScalar",
+        numberOfComponents: 1,
+        values: new Float32Array(mesh.cellScalars),
+      }),
+    );
+  }
+  return polyData;
+}
+
+function buildPointsPolyData(
+  coordinates: number[],
+  scalars: number[],
+): VtkPolyData {
+  const polyData = vtkPolyData.newInstance();
+  const points = vtkPoints.newInstance({ empty: true });
+  points.setData(new Float32Array(coordinates), 3);
+  polyData.setPoints(points);
+  const numberOfPoints = scalars.length;
+  const verts = new Uint32Array(numberOfPoints * 2);
+  for (let index = 0; index < numberOfPoints; index += 1) {
+    verts[index * 2] = 1;
+    verts[index * 2 + 1] = index;
+  }
+  polyData.setVerts(vtkCellArray.newInstance({ values: verts }));
+  if (numberOfPoints > 0) {
+    polyData.getPointData().setScalars(
+      vtkDataArray.newInstance({
+        name: "annotationScalar",
+        numberOfComponents: 1,
+        values: new Float32Array(scalars),
+      }),
+    );
+  }
+  return polyData;
 }
 
 export function annotationsTo3D(
@@ -185,34 +350,19 @@ export function annotationsTo3D(
         ? annotation.location.Time === options.currentTime
         : annotation.location.Z === currentZ),
   );
-  if (relevantAnnotations.length === 0) {
-    return buildEmptyResult();
-  }
 
+  const pointRadius = suggestedPointRadius(options.geometry);
   const skippedByShape: Record<string, number> = {};
-  const polygons = relevantAnnotations.flatMap((annotation) => {
-    if (annotation.shape !== AnnotationShape.Polygon) {
-      skippedByShape[annotation.shape] =
-        (skippedByShape[annotation.shape] ?? 0) + 1;
-      return [];
-    }
-    const polygon = normalizedPolygon(annotation.coordinates);
-    if (polygon.length < 3) {
-      skippedByShape.empty = (skippedByShape.empty ?? 0) + 1;
-      return [];
-    }
-    return [{ annotation, polygon }];
+  const items = relevantAnnotations.flatMap((annotation) => {
+    const item = classifyAnnotation(annotation, skippedByShape);
+    return item ? [item] : [];
   });
 
   if (Object.keys(skippedByShape).length > 0) {
     logWarning("Skipped unsupported 3D annotation shapes", skippedByShape);
   }
 
-  if (polygons.length === 0) {
-    return { ...buildEmptyResult(), skippedByShape };
-  }
-
-  const propertyScalars = polygons.map(({ annotation }) => {
+  const propertyScalars = items.map(({ annotation }) => {
     const value = getValueFromObjectAndPath(
       options.propertyValues[annotation.id] ?? {},
       options.propertyPath,
@@ -222,25 +372,31 @@ export function annotationsTo3D(
   const canUsePropertyScalars =
     options.colorMode === "property" &&
     options.propertyPath.length > 0 &&
+    propertyScalars.length > 0 &&
     propertyScalars.every((value) => value !== null);
   const neutralPropertyScalars =
     options.colorMode === "property" && !canUsePropertyScalars;
 
   const tagToScalar = new Map<string, number>();
-  const points: number[] = [];
-  const triangles: number[] = [];
-  const cellScalars: number[] = [];
+  const world = makeWorldTransform(options.geometry);
+  const surfaceMesh: ISurfaceMesh = {
+    points: [],
+    triangles: [],
+    cellScalars: [],
+  };
+  const spherePoints: number[] = [];
+  const sphereScalars: number[] = [];
   let usedAnnotationCount = 0;
   let minScalar = Number.POSITIVE_INFINITY;
   let maxScalar = Number.NEGATIVE_INFINITY;
 
   // When the volume depth was subsampled, original depth index d maps to the
-  // (possibly fractional) voxel position d / depthStride, keeping the prism at
-  // its true physical depth.
+  // (possibly fractional) voxel position d / depthStride, keeping the
+  // annotation at its true physical depth.
   const depthStride = options.geometry.depthStride ?? 1;
-  polygons.forEach(({ annotation, polygon }, index) => {
+  items.forEach((item, index) => {
     const originalDepth =
-      axis === "z" ? annotation.location.Z : annotation.location.Time;
+      axis === "z" ? item.annotation.location.Z : item.annotation.location.Time;
     const depthIndex = originalDepth / depthStride;
     if (depthIndex < 0 || depthIndex >= options.geometry.dimensions[2]) {
       skippedByShape.outOfBoundsDepth =
@@ -252,7 +408,7 @@ export function annotationsTo3D(
     if (canUsePropertyScalars) {
       scalar = propertyScalars[index] ?? 0;
     } else if (!neutralPropertyScalars) {
-      const tag = annotation.tags[0] ?? "untagged";
+      const tag = item.annotation.tags[0] ?? "untagged";
       if (!tagToScalar.has(tag)) {
         tagToScalar.set(tag, tagToScalar.size);
       }
@@ -260,36 +416,42 @@ export function annotationsTo3D(
     }
     minScalar = Math.min(minScalar, scalar);
     maxScalar = Math.max(maxScalar, scalar);
-    addPrism(
-      polygon,
-      depthIndex,
-      scalar,
-      options.geometry,
-      points,
-      triangles,
-      cellScalars,
-    );
+
+    switch (item.kind) {
+      case "prism":
+        addPrism(item.planarPoints, depthIndex, scalar, world, surfaceMesh);
+        break;
+      case "ribbon":
+        addRibbon(item.planarPoints, depthIndex, scalar, world, surfaceMesh);
+        break;
+      case "sphere": {
+        const center = item.planarPoints[0];
+        spherePoints.push(
+          world.toX(center.x),
+          world.toY(center.y),
+          world.zCenter(depthIndex),
+        );
+        sphereScalars.push(scalar);
+        break;
+      }
+    }
     usedAnnotationCount += 1;
   });
 
-  if (cellScalars.length === 0) {
-    return { ...buildEmptyResult(), skippedByShape };
-  }
+  const surfacePolyData = buildSurfacePolyData(surfaceMesh);
+  const pointsPolyData = buildPointsPolyData(spherePoints, sphereScalars);
 
-  const polyData = vtkPolyData.newInstance();
-  const vtkPointArray = vtkPoints.newInstance({ empty: true });
-  vtkPointArray.setData(new Float32Array(points), 3);
-  polyData.setPoints(vtkPointArray);
-  polyData.setPolys(
-    vtkCellArray.newInstance({ values: new Uint32Array(triangles) }),
-  );
-  polyData.getCellData().setScalars(
-    vtkDataArray.newInstance({
-      name: "annotationScalar",
-      numberOfComponents: 1,
-      values: new Float32Array(cellScalars),
-    }),
-  );
+  if (usedAnnotationCount === 0) {
+    return {
+      surfacePolyData,
+      pointsPolyData,
+      pointRadius,
+      lookupTable: neutralLookupTable(),
+      scalarRange: [0, 1],
+      usedCount: 0,
+      skippedByShape,
+    };
+  }
 
   const scalarRange: [number, number] =
     minScalar === maxScalar
@@ -315,7 +477,9 @@ export function annotationsTo3D(
         ]);
 
   return {
-    polyData,
+    surfacePolyData,
+    pointsPolyData,
+    pointRadius,
     lookupTable,
     scalarRange,
     usedCount: usedAnnotationCount,

--- a/src/utils/annotationsTo3D.ts
+++ b/src/utils/annotationsTo3D.ts
@@ -118,26 +118,32 @@ function normalizedPolygon(points: IAnnotation["coordinates"]) {
   return result;
 }
 
+// World µm per source-image pixel in x and y.
+function sourcePixelSpacing(geometry: VolumeGeometry): [number, number] {
+  const [spacingX, spacingY] = geometry.spacing;
+  const [fetchedWidth, fetchedHeight] = geometry.dimensions;
+  const [sourceWidth, sourceHeight] = geometry.sourceSize;
+  return [
+    spacingX * (fetchedWidth / sourceWidth),
+    spacingY * (fetchedHeight / sourceHeight),
+  ];
+}
+
 // Converts source-image pixel coordinates and depth indices to world µm.
 interface IWorldTransform {
   toX(x: number): number;
   toY(y: number): number;
   zCenter(depthIndex: number): number;
-  spacingZ: number;
 }
 
 function makeWorldTransform(geometry: VolumeGeometry): IWorldTransform {
-  const [spacingX, spacingY, spacingZ] = geometry.spacing;
+  const spacingZ = geometry.spacing[2];
   const [originX, originY, originZ] = geometry.origin;
-  const [fetchedWidth, fetchedHeight] = geometry.dimensions;
-  const [sourceWidth, sourceHeight] = geometry.sourceSize;
-  const sourceSpacingX = spacingX * (fetchedWidth / sourceWidth);
-  const sourceSpacingY = spacingY * (fetchedHeight / sourceHeight);
+  const [sourceSpacingX, sourceSpacingY] = sourcePixelSpacing(geometry);
   return {
     toX: (x) => originX + x * sourceSpacingX,
     toY: (y) => originY + y * sourceSpacingY,
     zCenter: (depthIndex) => originZ + depthIndex * spacingZ,
-    spacingZ,
   };
 }
 
@@ -146,9 +152,7 @@ function makeWorldTransform(geometry: VolumeGeometry): IWorldTransform {
 function suggestedPointRadius(geometry: VolumeGeometry): number {
   const [spacingX, spacingY, spacingZ] = geometry.spacing;
   const [dimX, dimY, dimZ] = geometry.dimensions;
-  const [sourceWidth, sourceHeight] = geometry.sourceSize;
-  const sourceSpacingX = spacingX * (dimX / sourceWidth);
-  const sourceSpacingY = spacingY * (dimY / sourceHeight);
+  const [sourceSpacingX, sourceSpacingY] = sourcePixelSpacing(geometry);
   const diagonal = Math.hypot(
     dimX * spacingX,
     dimY * spacingY,
@@ -168,14 +172,15 @@ interface ISurfaceMesh {
 }
 
 function addPrism(
-  sourcePoints: { x: number; y: number }[],
+  sourcePoints: IPlanarPoint[],
   depthIndex: number,
   scalar: number,
+  halfThickness: number,
   world: IWorldTransform,
   mesh: ISurfaceMesh,
 ) {
-  const z0 = world.zCenter(depthIndex) - world.spacingZ / 2;
-  const z1 = z0 + world.spacingZ;
+  const z0 = world.zCenter(depthIndex) - halfThickness;
+  const z1 = world.zCenter(depthIndex) + halfThickness;
   const baseIndex = mesh.points.length / 3;
 
   for (const point of sourcePoints) {
@@ -220,14 +225,15 @@ function addPrism(
 // Extrudes a polyline through the slice thickness, producing a vertical
 // ribbon (two triangles per segment) that matches the prism walls visually.
 function addRibbon(
-  sourcePoints: { x: number; y: number }[],
+  sourcePoints: IPlanarPoint[],
   depthIndex: number,
   scalar: number,
+  halfThickness: number,
   world: IWorldTransform,
   mesh: ISurfaceMesh,
 ) {
-  const z0 = world.zCenter(depthIndex) - world.spacingZ / 2;
-  const z1 = z0 + world.spacingZ;
+  const z0 = world.zCenter(depthIndex) - halfThickness;
+  const z1 = world.zCenter(depthIndex) + halfThickness;
   const baseIndex = mesh.points.length / 3;
 
   for (const point of sourcePoints) {
@@ -372,7 +378,7 @@ interface ISegmentationItem {
   kind: TSegmentationKind;
   // Source-pixel coordinates: polygon vertices (prism), polyline vertices
   // (ribbon), or a single center (sphere).
-  planarPoints: { x: number; y: number }[];
+  planarPoints: IPlanarPoint[];
 }
 
 function classifyAnnotation(
@@ -515,8 +521,10 @@ export async function annotationsTo3D(
 
   // When the volume depth was subsampled, original depth index d maps to the
   // (possibly fractional) voxel position d / depthStride, keeping the
-  // annotation at its true physical depth.
+  // annotation at its true physical depth. All extrusions span one original
+  // slice (half of it on each side of the slice center).
   const depthStride = options.geometry.depthStride ?? 1;
+  const halfSliceThickness = options.geometry.spacing[2] / depthStride / 2;
   items.forEach((item, index) => {
     const originalDepth =
       axis === "z" ? item.annotation.location.Z : item.annotation.location.Time;
@@ -527,11 +535,11 @@ export async function annotationsTo3D(
       return;
     }
 
+    const tag = item.annotation.tags[0] ?? "untagged";
     let scalar = 0;
     if (canUsePropertyScalars) {
       scalar = propertyScalars[index] ?? 0;
     } else if (!neutralPropertyScalars) {
-      const tag = item.annotation.tags[0] ?? "untagged";
       if (!tagToScalar.has(tag)) {
         tagToScalar.set(tag, tagToScalar.size);
       }
@@ -548,11 +556,18 @@ export async function annotationsTo3D(
           originalDepth,
           depthIndex,
           scalar,
-          tag: item.annotation.tags[0] ?? "untagged",
+          tag,
         });
         break;
       case "ribbon":
-        addRibbon(item.planarPoints, depthIndex, scalar, world, surfaceMesh);
+        addRibbon(
+          item.planarPoints,
+          depthIndex,
+          scalar,
+          halfSliceThickness,
+          world,
+          surfaceMesh,
+        );
         break;
       case "sphere": {
         const center = item.planarPoints[0];
@@ -582,15 +597,13 @@ export async function annotationsTo3D(
         )
       ).map((indices) => indices.map((index) => prismEntries[index]))
     : prismEntries.map((entry) => [entry]);
-  // Half the world-z distance between consecutive original slices, so lofted
-  // surfaces span the full thickness of their first and last slices.
-  const halfSliceThickness = options.geometry.spacing[2] / depthStride / 2;
   for (const chain of chains) {
     if (chain.length === 1) {
       addPrism(
         chain[0].polygon,
         chain[0].depthIndex,
         chain[0].scalar,
+        halfSliceThickness,
         world,
         surfaceMesh,
       );

--- a/src/utils/annotationsTo3D.ts
+++ b/src/utils/annotationsTo3D.ts
@@ -17,6 +17,12 @@ import {
 } from "@/store/model";
 import { getValueFromObjectAndPath } from "@/utils/paths";
 import { logWarning } from "@/utils/log";
+import {
+  IPlanarPoint,
+  alignRingToReference,
+  overlapFraction,
+  resampleClosedContour,
+} from "@/utils/contourLoft";
 import type { VolumeGeometry } from "@/store/VolumeAPI";
 
 export interface IAnnotationsTo3DOptions {
@@ -32,6 +38,13 @@ export interface IAnnotationsTo3DOptions {
   colorMode: TVolumeSegmentationColorMode;
   propertyPath: string[];
   propertyValues: IAnnotationPropertyValues;
+  // Loft same-tag polygons that overlap in xy on adjacent depth slices into
+  // continuous surfaces instead of per-slice prisms. Defaults to false.
+  loftSurfaces?: boolean;
+  // Minimum xy overlap — as a fraction of the smaller polygon's area, in
+  // [0, 1] — for two annotations on adjacent slices to count as the same
+  // object. 0 (the default) connects any positive overlap.
+  loftOverlapFraction?: number;
 }
 
 export interface IAnnotationsTo3DResult {
@@ -243,6 +256,203 @@ function addRibbon(
   }
 }
 
+// A polygon annotation queued for surface emission, with its depth resolved.
+interface IPrismEntry {
+  polygon: IPlanarPoint[];
+  // Depth in original slice indices (used to find adjacent slices).
+  originalDepth: number;
+  // Depth in (possibly subsampled) volume voxels (used to place geometry).
+  depthIndex: number;
+  scalar: number;
+  tag: string;
+}
+
+// Pairs each polygon with at most one polygon on the next slice — greedy
+// best-overlap matching, like frame-to-frame tracking — and returns the
+// resulting chains. Only same-tag polygons on consecutive original slices
+// whose xy overlap reaches `minOverlapFraction` are linked; a chain of
+// length 1 falls back to a plain prism.
+function buildLoftChains(
+  entries: IPrismEntry[],
+  minOverlapFraction: number,
+): IPrismEntry[][] {
+  const bounds = new Map<IPrismEntry, [number, number, number, number]>();
+  for (const entry of entries) {
+    const xs = entry.polygon.map((point) => point.x);
+    const ys = entry.polygon.map((point) => point.y);
+    bounds.set(entry, [
+      Math.min(...xs),
+      Math.min(...ys),
+      Math.max(...xs),
+      Math.max(...ys),
+    ]);
+  }
+  const boundsIntersect = (a: IPrismEntry, b: IPrismEntry) => {
+    const [aMinX, aMinY, aMaxX, aMaxY] = bounds.get(a)!;
+    const [bMinX, bMinY, bMaxX, bMaxY] = bounds.get(b)!;
+    return aMinX <= bMaxX && bMinX <= aMaxX && aMinY <= bMaxY && bMinY <= aMaxY;
+  };
+
+  const byTagAndDepth = new Map<string, Map<number, IPrismEntry[]>>();
+  for (const entry of entries) {
+    const byDepth = byTagAndDepth.get(entry.tag) ?? new Map();
+    byTagAndDepth.set(entry.tag, byDepth);
+    byDepth.set(entry.originalDepth, [
+      ...(byDepth.get(entry.originalDepth) ?? []),
+      entry,
+    ]);
+  }
+
+  const nextOf = new Map<IPrismEntry, IPrismEntry>();
+  const hasPrevious = new Set<IPrismEntry>();
+  for (const byDepth of byTagAndDepth.values()) {
+    for (const [depth, sliceEntries] of byDepth) {
+      const nextSliceEntries = byDepth.get(depth + 1);
+      if (!nextSliceEntries) {
+        continue;
+      }
+      const candidates: {
+        lower: IPrismEntry;
+        upper: IPrismEntry;
+        overlap: number;
+      }[] = [];
+      for (const lower of sliceEntries) {
+        for (const upper of nextSliceEntries) {
+          if (!boundsIntersect(lower, upper)) {
+            continue;
+          }
+          const overlap = overlapFraction(lower.polygon, upper.polygon);
+          if (overlap > 0 && overlap >= minOverlapFraction) {
+            candidates.push({ lower, upper, overlap });
+          }
+        }
+      }
+      candidates.sort((a, b) => b.overlap - a.overlap);
+      for (const { lower, upper } of candidates) {
+        if (!nextOf.has(lower) && !hasPrevious.has(upper)) {
+          nextOf.set(lower, upper);
+          hasPrevious.add(upper);
+        }
+      }
+    }
+  }
+
+  const chains: IPrismEntry[][] = [];
+  for (const entry of entries) {
+    if (hasPrevious.has(entry)) {
+      continue;
+    }
+    const chain: IPrismEntry[] = [];
+    for (
+      let link: IPrismEntry | undefined = entry;
+      link !== undefined;
+      link = nextOf.get(link)
+    ) {
+      chain.push(link);
+    }
+    chains.push(chain);
+  }
+  return chains;
+}
+
+// Resampled ring sizes for lofted surfaces: enough points to keep blob
+// detail, bounded so huge SAM polygons don't explode the mesh.
+const LOFT_MIN_RING_SIZE = 24;
+const LOFT_MAX_RING_SIZE = 128;
+
+// Lofts a chain of stacked polygons into one continuous closed surface:
+// each contour is resampled to a shared ring size and aligned with the ring
+// below it, consecutive rings are stitched with triangle bands, and skirt
+// rings extend the first/last contours by half a slice so the surface spans
+// the full slice thicknesses. Caps close the two ends.
+function addLoftedChain(
+  chain: IPrismEntry[],
+  halfSliceThickness: number,
+  world: IWorldTransform,
+  mesh: ISurfaceMesh,
+) {
+  const ringSize = Math.min(
+    LOFT_MAX_RING_SIZE,
+    Math.max(LOFT_MIN_RING_SIZE, ...chain.map((entry) => entry.polygon.length)),
+  );
+  const rings: IPlanarPoint[][] = [];
+  for (const entry of chain) {
+    let ring = resampleClosedContour(entry.polygon, ringSize);
+    if (rings.length > 0) {
+      ring = alignRingToReference(ring, rings[rings.length - 1]);
+    }
+    rings.push(ring);
+  }
+
+  const pushRing = (ring: IPlanarPoint[], z: number) => {
+    const baseIndex = mesh.points.length / 3;
+    for (const point of ring) {
+      mesh.points.push(world.toX(point.x), world.toY(point.y), z);
+    }
+    return baseIndex;
+  };
+
+  const lastIndex = chain.length - 1;
+  const ringBases = [
+    pushRing(rings[0], world.zCenter(chain[0].depthIndex) - halfSliceThickness),
+    ...chain.map((entry, index) =>
+      pushRing(rings[index], world.zCenter(entry.depthIndex)),
+    ),
+    pushRing(
+      rings[lastIndex],
+      world.zCenter(chain[lastIndex].depthIndex) + halfSliceThickness,
+    ),
+  ];
+
+  for (let bandIndex = 0; bandIndex < ringBases.length - 1; bandIndex += 1) {
+    const lowerBase = ringBases[bandIndex];
+    const upperBase = ringBases[bandIndex + 1];
+    // The bottom skirt band follows the first annotation's scalar, every
+    // other band the annotation at its top ring.
+    const scalar = chain[Math.min(bandIndex, lastIndex)].scalar;
+    for (let index = 0; index < ringSize; index += 1) {
+      const next = (index + 1) % ringSize;
+      mesh.triangles.push(
+        3,
+        lowerBase + index,
+        lowerBase + next,
+        upperBase + next,
+      );
+      mesh.cellScalars.push(scalar);
+      mesh.triangles.push(
+        3,
+        lowerBase + index,
+        upperBase + next,
+        upperBase + index,
+      );
+      mesh.cellScalars.push(scalar);
+    }
+  }
+
+  const addCap = (ring: IPlanarPoint[], baseIndex: number, scalar: number) => {
+    const flat: number[] = [];
+    for (const point of ring) {
+      flat.push(point.x, point.y);
+    }
+    const capIndices = earcut(flat);
+    for (let index = 0; index < capIndices.length; index += 3) {
+      mesh.triangles.push(
+        3,
+        baseIndex + capIndices[index],
+        baseIndex + capIndices[index + 1],
+        baseIndex + capIndices[index + 2],
+      );
+      mesh.cellScalars.push(scalar);
+    }
+  };
+  addCap(rings[0], ringBases[0], chain[0].scalar);
+  addCap(
+    rings[lastIndex],
+    ringBases[ringBases.length - 1],
+    chain[lastIndex].scalar,
+  );
+}
+
 type TSegmentationKind = "prism" | "ribbon" | "sphere";
 
 interface ISegmentationItem {
@@ -386,6 +596,7 @@ export function annotationsTo3D(
   };
   const spherePoints: number[] = [];
   const sphereScalars: number[] = [];
+  const prismEntries: IPrismEntry[] = [];
   let usedAnnotationCount = 0;
   let minScalar = Number.POSITIVE_INFINITY;
   let maxScalar = Number.NEGATIVE_INFINITY;
@@ -419,7 +630,14 @@ export function annotationsTo3D(
 
     switch (item.kind) {
       case "prism":
-        addPrism(item.planarPoints, depthIndex, scalar, world, surfaceMesh);
+        // Queued rather than emitted: prisms may be lofted together below.
+        prismEntries.push({
+          polygon: item.planarPoints,
+          originalDepth,
+          depthIndex,
+          scalar,
+          tag: item.annotation.tags[0] ?? "untagged",
+        });
         break;
       case "ribbon":
         addRibbon(item.planarPoints, depthIndex, scalar, world, surfaceMesh);
@@ -437,6 +655,26 @@ export function annotationsTo3D(
     }
     usedAnnotationCount += 1;
   });
+
+  const chains = options.loftSurfaces
+    ? buildLoftChains(prismEntries, options.loftOverlapFraction ?? 0)
+    : prismEntries.map((entry) => [entry]);
+  // Half the world-z distance between consecutive original slices, so lofted
+  // surfaces span the full thickness of their first and last slices.
+  const halfSliceThickness = options.geometry.spacing[2] / depthStride / 2;
+  for (const chain of chains) {
+    if (chain.length === 1) {
+      addPrism(
+        chain[0].polygon,
+        chain[0].depthIndex,
+        chain[0].scalar,
+        world,
+        surfaceMesh,
+      );
+    } else {
+      addLoftedChain(chain, halfSliceThickness, world, surfaceMesh);
+    }
+  }
 
   const surfacePolyData = buildSurfacePolyData(surfaceMesh);
   const pointsPolyData = buildPointsPolyData(spherePoints, sphereScalars);

--- a/src/utils/contourLoft.test.ts
+++ b/src/utils/contourLoft.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  alignRingToReference,
+  overlapFraction,
+  polygonArea,
+  resampleClosedContour,
+  signedArea,
+} from "@/utils/contourLoft";
+
+const unitSquare = [
+  { x: 0, y: 0 },
+  { x: 2, y: 0 },
+  { x: 2, y: 2 },
+  { x: 0, y: 2 },
+];
+
+function translated(points: { x: number; y: number }[], dx: number, dy = 0) {
+  return points.map((point) => ({ x: point.x + dx, y: point.y + dy }));
+}
+
+describe("signedArea / polygonArea", () => {
+  it("is positive for counter-clockwise rings and matches the area", () => {
+    expect(signedArea(unitSquare)).toBe(4);
+    expect(signedArea([...unitSquare].reverse())).toBe(-4);
+    expect(polygonArea([...unitSquare].reverse())).toBe(4);
+  });
+});
+
+describe("overlapFraction", () => {
+  it("is 1 for identical polygons", () => {
+    expect(overlapFraction(unitSquare, unitSquare)).toBeCloseTo(1, 6);
+  });
+
+  it("is the intersection area over the smaller polygon", () => {
+    // Shifted by half the width: intersection 2, smaller area 4.
+    expect(overlapFraction(unitSquare, translated(unitSquare, 1))).toBeCloseTo(
+      0.5,
+      6,
+    );
+    // A small square fully inside a big one overlaps 100% of itself.
+    const small = [
+      { x: 0.5, y: 0.5 },
+      { x: 1, y: 0.5 },
+      { x: 1, y: 1 },
+      { x: 0.5, y: 1 },
+    ];
+    expect(overlapFraction(unitSquare, small)).toBeCloseTo(1, 6);
+  });
+
+  it("is 0 for disjoint or degenerate polygons", () => {
+    expect(overlapFraction(unitSquare, translated(unitSquare, 5))).toBe(0);
+    const degenerate = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ];
+    expect(overlapFraction(unitSquare, degenerate)).toBe(0);
+  });
+});
+
+describe("resampleClosedContour", () => {
+  it("spaces points uniformly along the perimeter", () => {
+    expect(resampleClosedContour(unitSquare, 8)).toEqual([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 1 },
+      { x: 2, y: 2 },
+      { x: 1, y: 2 },
+      { x: 0, y: 2 },
+      { x: 0, y: 1 },
+    ]);
+  });
+
+  it("forces counter-clockwise winding", () => {
+    const resampled = resampleClosedContour([...unitSquare].reverse(), 8);
+    expect(signedArea(resampled)).toBeGreaterThan(0);
+  });
+});
+
+describe("alignRingToReference", () => {
+  it("rotates a ring back onto its reference", () => {
+    const reference = resampleClosedContour(unitSquare, 8);
+    const rotated = reference.map(
+      (_, index) => reference[(index + 3) % reference.length],
+    );
+    expect(alignRingToReference(rotated, reference)).toEqual(reference);
+  });
+});

--- a/src/utils/contourLoft.ts
+++ b/src/utils/contourLoft.ts
@@ -34,11 +34,16 @@ export function overlapFraction(a: IPlanarPoint[], b: IPlanarPoint[]): number {
   if (smallerArea === 0) {
     return 0;
   }
+  let intersection: [number, number][][][];
+  try {
+    intersection = polygonClipping.intersection([toRing(a)], [toRing(b)]);
+  } catch {
+    // polygon-clipping can fail on pathological rings (e.g. self-crossing
+    // hand annotations); treat those as non-overlapping.
+    return 0;
+  }
   let intersectionArea = 0;
-  for (const polygon of polygonClipping.intersection(
-    [toRing(a)],
-    [toRing(b)],
-  )) {
+  for (const polygon of intersection) {
     polygon.forEach((ring, ringIndex) => {
       // The first ring is the outer boundary; later rings are holes.
       const ringArea = polygonArea(ring.map(([x, y]) => ({ x, y })));

--- a/src/utils/contourLoft.ts
+++ b/src/utils/contourLoft.ts
@@ -1,0 +1,122 @@
+import polygonClipping from "polygon-clipping";
+
+// 2D contour helpers used to loft stacked annotations into 3D surfaces
+// (see annotationsTo3D.ts).
+
+export interface IPlanarPoint {
+  x: number;
+  y: number;
+}
+
+// Shoelace formula; positive for counter-clockwise rings.
+export function signedArea(points: IPlanarPoint[]): number {
+  let area = 0;
+  for (let index = 0; index < points.length; index += 1) {
+    const a = points[index];
+    const b = points[(index + 1) % points.length];
+    area += a.x * b.y - b.x * a.y;
+  }
+  return area / 2;
+}
+
+export function polygonArea(points: IPlanarPoint[]): number {
+  return Math.abs(signedArea(points));
+}
+
+function toRing(points: IPlanarPoint[]): [number, number][] {
+  return points.map((point) => [point.x, point.y]);
+}
+
+// Area of the xy intersection of two polygons as a fraction of the smaller
+// polygon's area, in [0, 1]. Degenerate polygons yield 0.
+export function overlapFraction(a: IPlanarPoint[], b: IPlanarPoint[]): number {
+  const smallerArea = Math.min(polygonArea(a), polygonArea(b));
+  if (smallerArea === 0) {
+    return 0;
+  }
+  let intersectionArea = 0;
+  for (const polygon of polygonClipping.intersection(
+    [toRing(a)],
+    [toRing(b)],
+  )) {
+    polygon.forEach((ring, ringIndex) => {
+      // The first ring is the outer boundary; later rings are holes.
+      const ringArea = polygonArea(ring.map(([x, y]) => ({ x, y })));
+      intersectionArea += ringIndex === 0 ? ringArea : -ringArea;
+    });
+  }
+  return Math.min(1, intersectionArea / smallerArea);
+}
+
+// Resamples a closed contour to exactly `count` points, uniformly spaced by
+// arc length, with counter-clockwise winding enforced so that resampled
+// rings of different contours correspond point-for-point when lofting.
+export function resampleClosedContour(
+  points: IPlanarPoint[],
+  count: number,
+): IPlanarPoint[] {
+  const ring = signedArea(points) >= 0 ? points : [...points].reverse();
+  const edgeLengths: number[] = [];
+  let perimeter = 0;
+  for (let index = 0; index < ring.length; index += 1) {
+    const a = ring[index];
+    const b = ring[(index + 1) % ring.length];
+    const length = Math.hypot(b.x - a.x, b.y - a.y);
+    edgeLengths.push(length);
+    perimeter += length;
+  }
+  if (perimeter === 0) {
+    return Array.from({ length: count }, () => ({ ...ring[0] }));
+  }
+
+  const step = perimeter / count;
+  const result: IPlanarPoint[] = [];
+  let edgeIndex = 0;
+  let lengthBeforeEdge = 0;
+  for (let index = 0; index < count; index += 1) {
+    const target = index * step;
+    while (
+      edgeIndex < ring.length - 1 &&
+      lengthBeforeEdge + edgeLengths[edgeIndex] <= target
+    ) {
+      lengthBeforeEdge += edgeLengths[edgeIndex];
+      edgeIndex += 1;
+    }
+    const a = ring[edgeIndex];
+    const b = ring[(edgeIndex + 1) % ring.length];
+    const t =
+      edgeLengths[edgeIndex] > 0
+        ? (target - lengthBeforeEdge) / edgeLengths[edgeIndex]
+        : 0;
+    result.push({ x: a.x + t * (b.x - a.x), y: a.y + t * (b.y - a.y) });
+  }
+  return result;
+}
+
+// Rotates `ring` (same length as `reference`) so that its points line up
+// with the reference ring as closely as possible, preventing twisted bands
+// between lofted slices. Both rings must have the same winding.
+export function alignRingToReference(
+  ring: IPlanarPoint[],
+  reference: IPlanarPoint[],
+): IPlanarPoint[] {
+  const count = ring.length;
+  let bestOffset = 0;
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (let offset = 0; offset < count; offset += 1) {
+    let score = 0;
+    for (let index = 0; index < count && score < bestScore; index += 1) {
+      const a = ring[(index + offset) % count];
+      const b = reference[index];
+      score += (a.x - b.x) ** 2 + (a.y - b.y) ** 2;
+    }
+    if (score < bestScore) {
+      bestScore = score;
+      bestOffset = offset;
+    }
+  }
+  if (bestOffset === 0) {
+    return ring;
+  }
+  return ring.map((_, index) => ring[(index + bestOffset) % count]);
+}

--- a/src/utils/loftChains.test.ts
+++ b/src/utils/loftChains.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { ILoftChainInput, buildLoftChainIndices } from "@/utils/loftChains";
+import { computeLoftChains } from "@/utils/loftChainsWorkerClient";
+
+vi.mock("@/utils/log", () => ({
+  logWarning: vi.fn(),
+  logError: vi.fn(),
+}));
+
+function square(
+  x: number,
+  y: number,
+  size: number,
+): ILoftChainInput["polygon"] {
+  return [
+    { x, y },
+    { x: x + size, y },
+    { x: x + size, y: y + size },
+    { x, y: y + size },
+  ];
+}
+
+function input(delta: Partial<ILoftChainInput>): ILoftChainInput {
+  return {
+    polygon: delta.polygon ?? square(0, 0, 2),
+    depth: delta.depth ?? 0,
+    group: delta.group ?? "nucleus",
+  };
+}
+
+describe("buildLoftChainIndices", () => {
+  it("chains overlapping polygons across consecutive depths", () => {
+    const chains = buildLoftChainIndices(
+      [
+        input({ depth: 0 }),
+        input({ depth: 1 }),
+        input({ depth: 2 }),
+        // Disjoint polygon on its own.
+        input({ depth: 1, polygon: square(10, 10, 2) }),
+      ],
+      0,
+    );
+    expect(chains).toEqual([[0, 1, 2], [3]]);
+  });
+
+  it("gives each polygon at most one partner, preferring the best overlap", () => {
+    const chains = buildLoftChainIndices(
+      [
+        // One large polygon below two candidates: a barely-touching one and
+        // a fully-contained one. Only the better overlap is chained.
+        input({ depth: 0, polygon: square(0, 0, 4) }),
+        input({ depth: 1, polygon: square(3.5, 0, 2) }),
+        input({ depth: 1, polygon: square(1, 1, 2) }),
+      ],
+      0,
+    );
+    expect(chains).toEqual([[0, 2], [1]]);
+  });
+
+  it("applies the minimum overlap fraction", () => {
+    const inputs = [
+      input({ depth: 0 }),
+      // Shifted by half the width: 50% overlap of the smaller square.
+      input({ depth: 1, polygon: square(1, 0, 2) }),
+    ];
+    expect(buildLoftChainIndices(inputs, 0.25)).toEqual([[0, 1]]);
+    expect(buildLoftChainIndices(inputs, 0.75)).toEqual([[0], [1]]);
+  });
+
+  it("does not chain across groups or depth gaps", () => {
+    const chains = buildLoftChainIndices(
+      [
+        input({ depth: 0, group: "nucleus" }),
+        input({ depth: 1, group: "cell" }),
+        input({ depth: 2, group: "nucleus" }),
+      ],
+      0,
+    );
+    expect(chains).toEqual([[0], [1], [2]]);
+  });
+});
+
+describe("computeLoftChains", () => {
+  it("falls back to synchronous matching when workers are unavailable", async () => {
+    // vitest's environment has no Worker global, exercising the fallback.
+    expect(typeof Worker).toBe("undefined");
+    const chains = await computeLoftChains(
+      [input({ depth: 0 }), input({ depth: 1 })],
+      0,
+    );
+    expect(chains).toEqual([[0, 1]]);
+  });
+});

--- a/src/utils/loftChains.ts
+++ b/src/utils/loftChains.ts
@@ -1,0 +1,104 @@
+import { IPlanarPoint, overlapFraction } from "@/utils/contourLoft";
+
+// Chain matching for lofted 3D annotation surfaces (see annotationsTo3D.ts).
+// Pure plain-data functions so the work can run in a web worker; use
+// computeLoftChains (loftChainsWorkerClient.ts) from the UI thread.
+
+export interface ILoftChainInput {
+  polygon: IPlanarPoint[];
+  // Depth in original slice indices; only consecutive depths can be linked.
+  depth: number;
+  // Polygons are only linked within the same group (the annotation tag).
+  group: string;
+}
+
+export interface ILoftChainRequest {
+  requestId: number;
+  inputs: ILoftChainInput[];
+  minOverlapFraction: number;
+}
+
+export interface ILoftChainResponse {
+  requestId: number;
+  chains: number[][];
+}
+
+// Pairs each polygon with at most one polygon on the next slice — greedy
+// best-overlap matching, like frame-to-frame tracking — and returns the
+// resulting chains as lists of input indices, ordered by depth. Only
+// same-group polygons on consecutive depths whose xy overlap reaches
+// `minOverlapFraction` (fraction of the smaller polygon's area; 0 links any
+// positive overlap) are joined; unlinked polygons come back as chains of 1.
+export function buildLoftChainIndices(
+  inputs: ILoftChainInput[],
+  minOverlapFraction: number,
+): number[][] {
+  const allBounds = inputs.map(({ polygon }) => {
+    const xs = polygon.map((point) => point.x);
+    const ys = polygon.map((point) => point.y);
+    return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
+  });
+  const boundsIntersect = (a: number, b: number) => {
+    const [aMinX, aMinY, aMaxX, aMaxY] = allBounds[a];
+    const [bMinX, bMinY, bMaxX, bMaxY] = allBounds[b];
+    return aMinX <= bMaxX && bMinX <= aMaxX && aMinY <= bMaxY && bMinY <= aMaxY;
+  };
+
+  const byGroupAndDepth = new Map<string, Map<number, number[]>>();
+  inputs.forEach((input, index) => {
+    const byDepth = byGroupAndDepth.get(input.group) ?? new Map();
+    byGroupAndDepth.set(input.group, byDepth);
+    byDepth.set(input.depth, [...(byDepth.get(input.depth) ?? []), index]);
+  });
+
+  const nextOf = new Map<number, number>();
+  const hasPrevious = new Set<number>();
+  for (const byDepth of byGroupAndDepth.values()) {
+    for (const [depth, sliceIndices] of byDepth) {
+      const nextSliceIndices = byDepth.get(depth + 1);
+      if (!nextSliceIndices) {
+        continue;
+      }
+      const candidates: { lower: number; upper: number; overlap: number }[] =
+        [];
+      for (const lower of sliceIndices) {
+        for (const upper of nextSliceIndices) {
+          if (!boundsIntersect(lower, upper)) {
+            continue;
+          }
+          const overlap = overlapFraction(
+            inputs[lower].polygon,
+            inputs[upper].polygon,
+          );
+          if (overlap > 0 && overlap >= minOverlapFraction) {
+            candidates.push({ lower, upper, overlap });
+          }
+        }
+      }
+      candidates.sort((a, b) => b.overlap - a.overlap);
+      for (const { lower, upper } of candidates) {
+        if (!nextOf.has(lower) && !hasPrevious.has(upper)) {
+          nextOf.set(lower, upper);
+          hasPrevious.add(upper);
+        }
+      }
+    }
+  }
+
+  const chains: number[][] = [];
+  for (let index = 0; index < inputs.length; index += 1) {
+    if (hasPrevious.has(index)) {
+      continue;
+    }
+    const chain: number[] = [];
+    for (
+      let link: number | undefined = index;
+      link !== undefined;
+      link = nextOf.get(link)
+    ) {
+      chain.push(link);
+    }
+    chains.push(chain);
+  }
+  return chains;
+}

--- a/src/utils/loftChains.worker.ts
+++ b/src/utils/loftChains.worker.ts
@@ -1,0 +1,22 @@
+import {
+  ILoftChainRequest,
+  ILoftChainResponse,
+  buildLoftChainIndices,
+} from "@/utils/loftChains";
+
+// Web worker entry: runs the pairwise-overlap chain matching off the UI
+// thread. Spawned by loftChainsWorkerClient.ts.
+
+// The project tsconfig uses the DOM lib, so type the worker scope manually.
+const workerScope = self as unknown as {
+  onmessage: ((event: MessageEvent<ILoftChainRequest>) => void) | null;
+  postMessage(message: ILoftChainResponse): void;
+};
+
+workerScope.onmessage = (event) => {
+  const { requestId, inputs, minOverlapFraction } = event.data;
+  workerScope.postMessage({
+    requestId,
+    chains: buildLoftChainIndices(inputs, minOverlapFraction),
+  });
+};

--- a/src/utils/loftChainsWorkerClient.ts
+++ b/src/utils/loftChainsWorkerClient.ts
@@ -1,0 +1,75 @@
+import {
+  ILoftChainInput,
+  ILoftChainResponse,
+  buildLoftChainIndices,
+} from "@/utils/loftChains";
+import { logWarning } from "@/utils/log";
+
+// UI-thread client for the loft chain-matching worker. The pairwise overlap
+// computation is O(neighbors × polygon complexity) and can take a while on
+// dense segmentations, so it runs in a shared, lazily-created worker. When
+// workers are unavailable (tests, older environments) or the worker breaks,
+// requests transparently fall back to the synchronous implementation.
+
+interface IPendingRequest {
+  inputs: ILoftChainInput[];
+  minOverlapFraction: number;
+  resolve: (chains: number[][]) => void;
+}
+
+let worker: Worker | null = null;
+let workerBroken = false;
+let nextRequestId = 0;
+const pendingRequests = new Map<number, IPendingRequest>();
+
+function failover(reason: unknown) {
+  logWarning("Loft chain worker failed, computing on the UI thread", reason);
+  workerBroken = true;
+  worker?.terminate();
+  worker = null;
+  for (const { inputs, minOverlapFraction, resolve } of [
+    ...pendingRequests.values(),
+  ]) {
+    resolve(buildLoftChainIndices(inputs, minOverlapFraction));
+  }
+  pendingRequests.clear();
+}
+
+function getWorker(): Worker | null {
+  if (workerBroken || typeof Worker === "undefined") {
+    return null;
+  }
+  if (!worker) {
+    try {
+      worker = new Worker(new URL("./loftChains.worker.ts", import.meta.url), {
+        type: "module",
+      });
+    } catch (error) {
+      failover(error);
+      return null;
+    }
+    worker.onmessage = (event: MessageEvent<ILoftChainResponse>) => {
+      const pending = pendingRequests.get(event.data.requestId);
+      pendingRequests.delete(event.data.requestId);
+      pending?.resolve(event.data.chains);
+    };
+    worker.onerror = failover;
+  }
+  return worker;
+}
+
+export function computeLoftChains(
+  inputs: ILoftChainInput[],
+  minOverlapFraction: number,
+): Promise<number[][]> {
+  const activeWorker = getWorker();
+  if (!activeWorker) {
+    return Promise.resolve(buildLoftChainIndices(inputs, minOverlapFraction));
+  }
+  return new Promise((resolve) => {
+    const requestId = nextRequestId;
+    nextRequestId += 1;
+    pendingRequests.set(requestId, { inputs, minOverlapFraction, resolve });
+    activeWorker.postMessage({ requestId, inputs, minOverlapFraction });
+  });
+}


### PR DESCRIPTION
# Summary

Reworks annotation rendering in the 3D volume viewer. Annotations previously rendered as flat, unlit per-slice prisms at a fixed opacity, and point/line annotations were skipped entirely.

## Surface-like rendering
- Extruded geometry gets smooth point normals (`vtkPolyDataNormals`) and Phong shading, so segmentations read as lit surfaces instead of unlit slabs.
- A toolbar slider adjusts segmentation opacity (5–100%, default 55%, persisted in the `volumeView` store), so the volumetric intensity data stays visible through the surfaces. Opacity changes only touch actor properties — no geometry rebuild.

## True lofted surfaces across z
There is no data-model link between annotations outlining the same object on different slices, so contiguity is inferred geometrically: **same-tag polygons on adjacent slices are joined when their xy overlap (fraction of the smaller polygon's area) reaches a configurable threshold** — 0% (default) joins on any overlap. A toolbar toggle enables lofting (on by default) and a dialog sets the threshold.

- Matching is greedy best-overlap with at most one partner per slice (like frame-to-frame tracking), so branching objects loft their main branch and start a new surface for the rest. Bounding boxes prefilter pairs before `polygon-clipping` computes intersection areas.
- Each chain is lofted by resampling contours to a shared ring size (24–128 points, uniform arc length, CCW), rotating each ring to line up with the one below (no twisted bands), and stitching rings with triangle bands. Skirt rings extend the ends by half a slice and caps close the surface.
- Chains of length 1 (or lofting off) keep the per-slice prism rendering.

## More shapes
- **Points render as small shaded spheres** (`vtkSphereMapper` impostors; radius derived from pixel size / slice thickness, capped by volume size).
- **Lines** extrude into vertical ribbons through their slice; **rectangles** extrude like polygons.

## Web worker
The pairwise-overlap chain matching runs in a shared, lazily-created module worker (`loftChains.worker.ts`), keeping the UI thread free during segmentation rebuilds. The client transparently falls back to synchronous matching when `Worker` is unavailable or errors. `annotationsTo3D` is now async; the viewer discards superseded results via a serial counter and keeps previous actors on screen until the replacement is ready.

## Screenshots

Rendered via a standalone harness driving the real conversion + vtk.js pipeline in headless Chromium:

| Lofting off (per-slice prisms) | Lofting on (continuous surfaces) |
|---|---|
| stacked "wedding cake" slabs | smooth closed surfaces, spheres for points, ribbon for the line |

(Screenshots attached in the session; the harness exercised the real worker — verified via the page's worker list — and produced identical geometry to the sync path.)

## Testing
- `pnpm tsc`, `pnpm lint:ci` clean; full suite passes (2135 tests), including new unit tests for contour math (overlap fraction, resampling, ring alignment), chain matching (best-overlap preference, threshold, group/gap isolation), worker-client fallback, and viewer wiring (opacity/loft settings rebuild segmentations without volume refetch).
- `pnpm build` verified the worker bundles as its own chunk.
- Branch reviewed with `/branch-review`; findings addressed in the final commit (threshold commits on slider release to avoid queueing one worker job per drag step, async rebuild failures logged, slice-thickness consistency at subsampled depth, small dedups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GixKMuDws6UvJBrUGHJ5ZD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GixKMuDws6UvJBrUGHJ5ZD)_