### PR TITLE
ui: extend the dataset-view design language to the rest of the app

### DIFF
--- a/src/components/CollectionItemRow.vue
+++ b/src/components/CollectionItemRow.vue
@@ -39,7 +39,7 @@
             ?.chips"
           :key="'chip ' + i + ' collection ' + collection._id"
           class="ma-1 colored-chip"
-          :style="{ '--chip-color': chipItem.color }"
+          :style="{ '--chip-color': `rgb(var(--v-theme-${chipItem.color}))` }"
           @click.stop="navigateToChip(chipItem)"
         >
           {{ chipItem.text }}
@@ -51,7 +51,7 @@
         v-else-if="computedChipsIds.has(collection._id)"
         size="x-small"
         class="ma-1"
-        color="grey-lighten-1"
+        color="secondary"
       >
         Loading datasets...
       </v-chip>

--- a/src/components/CollectionList.test.ts
+++ b/src/components/CollectionList.test.ts
@@ -297,7 +297,7 @@ describe("CollectionList", () => {
     });
     expect(result.chips).toHaveLength(2);
     expect(result.chips[0].text).toBe("Dataset A");
-    expect(result.chips[0].color).toBe("#e57373");
+    expect(result.chips[0].color).toBe("dataset");
     expect(result.chips[0].to).toEqual({
       name: "dataset",
       params: { datasetId: "ds1" },

--- a/src/components/CollectionList.vue
+++ b/src/components/CollectionList.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="collection-list-wrapper">
     <!-- Current folder path display -->
-    <div class="folder-path-display pa-2 grey lighten-5">
+    <div class="folder-path-display pa-2">
       <div class="d-flex align-center">
-        <v-icon class="mr-2" size="20" color="grey-darken-2">mdi-folder</v-icon>
-        <span class="text-body-2 mr-2" style="color: #424242"
+        <v-icon class="mr-2" size="20" color="secondary">mdi-folder</v-icon>
+        <span class="text-body-2 text-medium-emphasis mr-2"
           >Collections in:</span
         >
         <girder-breadcrumb
@@ -14,7 +14,7 @@
           readonly
           class="folder-breadcrumb"
         />
-        <span v-else class="text-body-2" style="color: #424242">{{
+        <span v-else class="text-body-2 text-medium-emphasis">{{
           fallbackFolderPath
         }}</span>
       </div>
@@ -41,9 +41,11 @@
         v-if="!loading && filteredCollections.length === 0"
         class="text-center pa-4"
       >
-        <v-icon size="64" color="grey">mdi-file-tree</v-icon>
-        <div class="text-h6 text-grey mt-2">No collections found</div>
-        <div class="text-body-2 text-grey">
+        <v-icon size="64" color="secondary">mdi-file-tree</v-icon>
+        <div class="text-body-1 font-weight-medium text-medium-emphasis mt-2">
+          No collections found
+        </div>
+        <div class="text-body-2 text-medium-emphasis">
           {{
             searchQuery
               ? "Try adjusting your search terms"
@@ -60,7 +62,7 @@
           class="collection-item"
           :class="{ 'collection-item-hover': !loading }"
         >
-          <v-icon color="#4baeff" size="24">mdi-file-tree</v-icon>
+          <v-icon color="collection" size="24">mdi-file-tree</v-icon>
 
           <v-list-item-title class="collection-title">
             {{ collection.name }}
@@ -313,7 +315,7 @@ async function collectionToChips(collection: IUPennCollection) {
 
       const chip: IChipAttrs = {
         text: datasetInfo.name,
-        color: "#e57373",
+        color: "dataset",
       };
 
       chip.to = {
@@ -402,7 +404,7 @@ async function bulkCollectionsToChips(
 
         const chip: IChipAttrs = {
           text: datasetInfo.name,
-          color: "#e57373",
+          color: "dataset",
           to: {
             name: "dataset",
             params: { datasetId: String(view.datasetId) },
@@ -495,26 +497,24 @@ defineExpose({
 }
 
 .collection-item {
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--nimbus-border);
   transition: background-color 0.2s;
   cursor: pointer;
 
   &:hover.collection-item-hover {
-    background-color: #f5f5f5;
+    background-color: var(--nimbus-glass-hover);
   }
 }
 
 .collection-title {
   font-weight: 500;
-  color: #1976d2;
-}
-
-.collection-item-hover:hover .collection-title {
-  color: #1565c0;
+  color: rgb(var(--v-theme-collection));
 }
 
 .folder-path-display {
   margin-bottom: 4px;
+  background: var(--nimbus-glass);
+  border-radius: var(--nimbus-radius-sm);
 }
 
 .folder-breadcrumb {
@@ -526,10 +526,10 @@ defineExpose({
 }
 
 .folder-breadcrumb :deep(.v-breadcrumbs__divider) {
-  color: #999;
+  color: var(--nimbus-text-faint);
 }
 
 .folder-breadcrumb :deep(.v-breadcrumbs__item) {
-  color: #424242;
+  color: var(--nimbus-text-secondary);
 }
 </style>

--- a/src/components/CustomFileManager.test.ts
+++ b/src/components/CustomFileManager.test.ts
@@ -500,7 +500,7 @@ describe("CustomFileManager", () => {
       const result = await vm.itemToChips({ _id: "ds1", _modelType: "folder" });
       expect(result.chips).toHaveLength(1);
       expect(result.chips[0].text).toBe("Dataset");
-      expect(result.chips[0].color).toBe("grey");
+      expect(result.chips[0].color).toBe("dataset");
       expect(result.type).toBe("dataset");
     });
 

--- a/src/components/CustomFileManager.vue
+++ b/src/components/CustomFileManager.vue
@@ -359,7 +359,7 @@ async function itemToChips(selectable: IGirderSelectAble) {
   const chipOption = chipOptions[type];
   const headerChip: IChipAttrs = {
     text: chipOption.text,
-    color: "grey",
+    color: type === "dataset" ? "dataset" : "collection",
   };
   if (props.clickableChips) {
     headerChip.to = {
@@ -442,7 +442,7 @@ async function flushBatchResolve() {
     if (!current) return;
 
     const extra: IChipAttrs = {
-      color: type === "dataset" ? "#4baeff" : "#e57373",
+      color: type === "dataset" ? "collection" : "dataset",
       text: chipText,
       to: props.clickableChips
         ? {
@@ -771,18 +771,18 @@ onBeforeUnmount(() => {
 // so we target it via the file manager wrapper, not .itemRow.
 .custom-file-manager-wrapper .v-icon.mdi-package {
   // datasets - teal to match primary theme color
-  color: #26a69a;
+  color: rgb(var(--v-theme-primary));
 }
 .custom-file-manager-wrapper .v-icon.mdi-file-tree {
   // configurations - teal to match primary theme color
-  color: #26a69a;
+  color: rgb(var(--v-theme-primary));
 }
 </style>
 
 <style lang="scss" scoped>
 .type-indicator {
   border-radius: 4px; // More rectangular
-  font-family: "Roboto Mono", monospace; // Monospace font
+  font-family: var(--nimbus-font-mono);
   font-size: 9px;
   letter-spacing: 0.5px;
   height: 16px;

--- a/src/components/FileItemRow.test.ts
+++ b/src/components/FileItemRow.test.ts
@@ -69,6 +69,6 @@ describe("FileItemRow", () => {
     // Check the stub element exists with the expected color attribute.
     const chip = wrapper.find("v-chip-stub.type-indicator");
     expect(chip.exists()).toBe(true);
-    expect(chip.attributes("color")).toBe("grey");
+    expect(chip.attributes("color")).toBe("secondary");
   });
 });

--- a/src/components/FileItemRow.vue
+++ b/src/components/FileItemRow.vue
@@ -14,7 +14,7 @@
       v-else-if="computedChipsIds.has(item._id)"
       size="x-small"
       class="ma-1 type-indicator"
-      color="grey"
+      color="secondary"
     >
       Loading info...
     </v-chip>
@@ -78,7 +78,7 @@
         :key="'chip ' + i + ' item ' + item._id"
         class="ma-1 colored-chip"
         :style="{
-          '--chip-color': chipItem.color,
+          '--chip-color': `rgb(var(--v-theme-${chipItem.color}))`,
         }"
         :to="chipItem.to"
         @click.stop

--- a/src/components/Files/FileDropzone.vue
+++ b/src/components/Files/FileDropzone.vue
@@ -14,7 +14,7 @@
     >
       <slot name="default">
         <v-icon size="50px">mdi-file-upload</v-icon>
-        <div class="title mt-3">
+        <div class="text-body-1 font-weight-medium mt-3">
           <template v-if="multiple">
             Drag files here or click to select them
           </template>

--- a/src/components/ProjectList.vue
+++ b/src/components/ProjectList.vue
@@ -32,9 +32,11 @@
         v-if="!loading && filteredProjects.length === 0"
         class="text-center pa-4"
       >
-        <v-icon size="64" color="grey">mdi-folder-star</v-icon>
-        <div class="text-h6 text-grey mt-2">No projects found</div>
-        <div class="text-body-2 text-grey">
+        <v-icon size="64" color="secondary">mdi-folder-star</v-icon>
+        <div class="text-body-1 font-weight-medium text-medium-emphasis mt-2">
+          No projects found
+        </div>
+        <div class="text-body-2 text-medium-emphasis">
           {{
             searchQuery
               ? "Try adjusting your search terms"
@@ -51,7 +53,7 @@
           @click="navigateToProject(project)"
         >
           <template #prepend>
-            <v-icon color="#8e24aa" size="24">mdi-folder-star</v-icon>
+            <v-icon color="project" size="24">mdi-folder-star</v-icon>
           </template>
 
           <v-list-item-title class="project-title">
@@ -73,20 +75,20 @@
               <v-chip
                 size="x-small"
                 variant="outlined"
-                color="grey"
+                color="secondary"
                 class="mr-1"
               >
                 {{ project.meta.datasets.length }} dataset{{
                   project.meta.datasets.length !== 1 ? "s" : ""
                 }}
               </v-chip>
-              <v-chip size="x-small" variant="outlined" color="grey">
+              <v-chip size="x-small" variant="outlined" color="secondary">
                 {{ project.meta.collections.length }} collection{{
                   project.meta.collections.length !== 1 ? "s" : ""
                 }}
               </v-chip>
               <v-spacer />
-              <span class="text-caption text-grey">
+              <span class="text-caption text-medium-emphasis">
                 Updated {{ formatDateString(project.updated) }}
               </span>
             </div>
@@ -399,6 +401,6 @@ defineExpose({
 
 .project-title {
   font-weight: 500;
-  color: #8e24aa;
+  color: rgb(var(--v-theme-project));
 }
 </style>

--- a/src/components/RecentProjects.test.ts
+++ b/src/components/RecentProjects.test.ts
@@ -65,8 +65,8 @@ describe("RecentProjects", () => {
     const wrapper = mountComponent();
     expect(wrapper.vm.getStatusColor("exported")).toBe("success");
     expect(wrapper.vm.getStatusColor("exporting")).toBe("warning");
-    expect(wrapper.vm.getStatusColor("draft")).toBe("grey");
-    expect(wrapper.vm.getStatusColor("unknown")).toBe("grey");
+    expect(wrapper.vm.getStatusColor("draft")).toBe("secondary");
+    expect(wrapper.vm.getStatusColor("unknown")).toBe("secondary");
   });
 
   it("emits project-clicked when a project is clicked", async () => {

--- a/src/components/RecentProjects.vue
+++ b/src/components/RecentProjects.vue
@@ -3,8 +3,8 @@
     <v-progress-linear v-if="loading" indeterminate />
 
     <div v-else-if="projects.length === 0" class="empty-state pa-4 text-center">
-      <v-icon size="48" color="grey">mdi-folder-star-outline</v-icon>
-      <div class="text-body-2 text-grey mt-2">
+      <v-icon size="48" color="secondary">mdi-folder-star-outline</v-icon>
+      <div class="text-body-2 text-medium-emphasis mt-2">
         No projects yet. Create one to organize datasets for export.
       </div>
     </div>
@@ -17,7 +17,7 @@
               @click="handleProjectClick(project)"
               v-bind="activatorProps"
             >
-              <v-icon color="#8e24aa">mdi-folder-star</v-icon>
+              <v-icon color="project">mdi-folder-star</v-icon>
               <v-list-item-title>
                 {{ project.name }}
               </v-list-item-title>
@@ -43,7 +43,7 @@
                 </template>
               </v-list-item-subtitle>
               <span class="my-0 d-flex flex-column justify-center">
-                <div class="text-caption text-grey text-left">
+                <div class="text-caption text-medium-emphasis text-left">
                   <div>Updated:</div>
                   <div style="line-height: 1.1">
                     {{ formatDate(project.updated) }}
@@ -91,7 +91,7 @@ function getStatusColor(status: string): string {
     case "exporting":
       return "warning";
     default:
-      return "grey";
+      return "secondary";
   }
 }
 

--- a/src/components/ZenodoCommunityDisplay.vue
+++ b/src/components/ZenodoCommunityDisplay.vue
@@ -45,7 +45,7 @@
                   alt="Community logo"
                 />
                 <div>
-                  <h3 class="text-h5 mb-1">{{ community.title }}</h3>
+                  <h3 class="page-title mb-1">{{ community.title }}</h3>
                   <p class="mb-0">{{ community.description }}</p>
                 </div>
               </div>
@@ -247,7 +247,8 @@ defineExpose({
 
 .sample-dataset-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  border-color: var(--nimbus-border-strong);
+  background: var(--nimbus-glass-hover);
 }
 
 .text-truncate-3 {

--- a/src/layout/UserMenu.vue
+++ b/src/layout/UserMenu.vue
@@ -20,10 +20,8 @@
             class="mb-2 text-center"
           />
           <div class="text-center mb-8">
-            <h2 class="text-h5 font-weight-bold mb-2">
-              Welcome to NimbusImage!
-            </h2>
-            <p class="text-subtitle-1">
+            <h2 class="page-title mb-2">Welcome to NimbusImage!</h2>
+            <p class="text-body-2 text-medium-emphasis">
               A cloud-based image analysis platform from the Raj Lab at the
               University of Pennsylvania and Kitware
             </p>

--- a/src/layout/UserMenuLoginForm.vue
+++ b/src/layout/UserMenuLoginForm.vue
@@ -33,8 +33,10 @@
     </v-form>
     <template v-else>
       <div class="text-center mb-8">
-        <h2 class="text-h5 font-weight-bold mb-2">Sign up for NimbusImage!</h2>
-        <p class="text-subtitle-1">Create a new account to get started.</p>
+        <h2 class="page-title mb-2">Sign up for NimbusImage!</h2>
+        <p class="text-body-2 text-medium-emphasis">
+          Create a new account to get started.
+        </p>
       </div>
       <v-form @submit.prevent="signUp" class="my-8">
         <v-text-field

--- a/src/layout/UserProfileSettings.vue
+++ b/src/layout/UserProfileSettings.vue
@@ -5,12 +5,12 @@
     </v-card-title>
     <v-card-text>
       <v-container>
-        <div>
-          <h3>Username:</h3>
+        <div class="mb-3">
+          <div class="panel-section-title mb-1">Username</div>
           <p>{{ store.userName }}</p>
         </div>
-        <div>
-          <h3>Girder domain:</h3>
+        <div class="mb-3">
+          <div class="panel-section-title mb-1">Girder domain</div>
           <p>{{ girderUrlFromApiRoot(store.girderRest.apiRoot) }}</p>
         </div>
         <v-btn variant="flat" color="error" size="small" @click="logout">

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -67,6 +67,10 @@ const vuetify = createVuetify({
           success: "#27a644",
           warning: "#d4a72c",
           info: "#5b9bd5",
+          // Resource accents shared across chips/icons app-wide
+          dataset: "#e57373",
+          collection: "#4baeff",
+          project: "#8e24aa",
         },
       },
       light: {
@@ -84,6 +88,10 @@ const vuetify = createVuetify({
           success: "#16a34a",
           warning: "#ca8a04",
           info: "#2563eb",
+          // Resource accents shared across chips/icons app-wide
+          dataset: "#e57373",
+          collection: "#1e88e5",
+          project: "#8e24aa",
         },
       },
     },

--- a/src/style.scss
+++ b/src/style.scss
@@ -58,6 +58,19 @@ pre,
   letter-spacing: -0.01em;
 }
 
+/* Page-level heading: the display serif at a fixed editorial size.
+   For route-level titles and welcome/marketing headers — not for
+   section labels (use .panel-section-title) or card titles. */
+.page-title {
+  font-family: var(--nimbus-font-display);
+  font-style: italic;
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: rgb(var(--v-theme-on-surface));
+}
+
 /* Form elements have their own UA font by default; make sure they inherit.
    Without this, a v-btn rendered as <button> uses the browser's default font
    while a v-btn with :to (rendered as <a>) inherits the app font — causing
@@ -398,10 +411,24 @@ body {
   color: rgb(var(--v-theme-on-surface)) !important;
 }
 
+/* Resource-accent chips (tonal) keep their tinted text — these mark
+   datasets / collections / projects consistently across the app. */
+.v-chip.text-dataset {
+  color: rgb(var(--v-theme-dataset)) !important;
+}
+.v-chip.text-collection {
+  color: rgb(var(--v-theme-collection)) !important;
+}
+.v-chip.text-project {
+  color: rgb(var(--v-theme-project)) !important;
+}
+
 .v-theme--dark
   .v-chip:not([style*="background-color"]):not(.bg-primary):not(
     .bg-success
-  ):not(.bg-error):not(.bg-warning):not(.bg-info) {
+  ):not(.bg-error):not(.bg-warning):not(.bg-info):not(.text-dataset):not(
+    .text-collection
+  ):not(.text-project):not(.bg-dataset):not(.bg-collection):not(.bg-project) {
   background: rgba(255, 255, 255, 0.15) !important;
   border: 1px solid rgba(255, 255, 255, 0.15) !important;
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -4,7 +4,7 @@
       <v-overlay
         :model-value="isNavigating"
         contained
-        scrim="white"
+        scrim="background"
         :opacity="0.8"
         z-index="9999"
         class="d-flex align-center justify-center"
@@ -144,7 +144,7 @@
           <v-col class="fill-height">
             <section class="mb-4 home-section">
               <div class="d-flex align-center mb-4">
-                <span class="text-h6 font-weight-medium mr-4">Browse</span>
+                <span class="panel-section-title mr-4">Browse</span>
                 <v-btn-toggle
                   v-model="browseMode"
                   mandatory
@@ -239,7 +239,7 @@
       <!-- Upload Choice Dialog -->
       <v-dialog v-model="showUploadDialog" max-width="800px" persistent>
         <v-card>
-          <v-card-title class="headline d-flex align-center">
+          <v-card-title class="d-flex align-center">
             Create dataset
             <v-btn
               variant="text"
@@ -366,9 +366,7 @@
             </v-alert>
 
             <v-card class="mb-4">
-              <v-card-title class="text-subtitle-1 pa-3"
-                >Location:</v-card-title
-              >
+              <div class="panel-section-title pa-3">Location</div>
               <v-card-text class="pt-0">
                 <girder-location-chooser
                   v-model="selectedLocation"
@@ -1411,18 +1409,22 @@ defineExpose({
   min-height: 0;
 }
 
-.drag-active {
-  border: 2px dashed white;
-}
-
 .upload-card {
   cursor: pointer;
   position: relative;
-  border: 2px dashed rgba(255, 255, 255, 0.3);
+  border: 2px dashed var(--nimbus-border-strong);
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+
+  &:hover {
+    border-color: rgba(var(--v-theme-primary), 0.5);
+    background-color: var(--nimbus-glass-hover);
+  }
 
   &.drag-active {
-    border: 2px dashed var(--v-primary-base);
-    background-color: rgba(var(--v-primary-base), 0.1);
+    border: 2px dashed rgb(var(--v-theme-primary));
+    background-color: rgba(var(--v-theme-primary), 0.1);
   }
 }
 
@@ -1434,55 +1436,6 @@ defineExpose({
   }
 }
 
-.section-title {
-  padding: 0;
-  height: auto;
-  display: block;
-}
-
-.pulse-btn {
-  animation: subtle-pulse 0.75s 1 ease-in-out;
-  transition: all 0.3s ease;
-  position: relative; /* Needed for the pseudo-element */
-}
-
-/* Use a pseudo-element for the pulsing effect to avoid affecting the button content */
-.pulse-btn::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  border-radius: inherit;
-  box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.5);
-  animation: subtle-pulse-shadow 9s 3 ease-in-out;
-}
-
-@keyframes subtle-pulse {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-@keyframes subtle-pulse-shadow {
-  0% {
-    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.5);
-  }
-  70% {
-    box-shadow: 0 0 0 8px rgba(76, 175, 80, 0);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0);
-  }
-}
-
 .loading-container {
   display: flex;
   flex-direction: column;
@@ -1491,10 +1444,10 @@ defineExpose({
 }
 
 .loading-text {
-  color: #424242; /* Dark gray text for contrast on white background */
-  font-size: 1.5rem; /* Medium weight for better visibility */
-  font-weight: 500; /* Medium weight for better visibility */
-  margin-top: 16px; /* Space between spinner and text */
+  color: rgb(var(--v-theme-on-background));
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin-top: 16px;
   text-align: center;
 }
 </style>

--- a/src/views/configuration/ConfigurationInfo.vue
+++ b/src/views/configuration/ConfigurationInfo.vue
@@ -128,7 +128,6 @@
                 :key="index"
                 size="small"
                 color="warning"
-                text-color="white"
                 class="mr-1 mb-1"
               >
                 <v-icon size="small" start>mdi-alert</v-icon>

--- a/src/views/configuration/DuplicateImportConfiguration.vue
+++ b/src/views/configuration/DuplicateImportConfiguration.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <div class="headline py-4">
+    <div class="page-title py-4">
       Copy one or several existing collections to add to dataset
       {{ datasetName }}
     </div>

--- a/src/views/configuration/NewConfiguration.vue
+++ b/src/views/configuration/NewConfiguration.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <div class="headline py-4">Create a new collection from a dataset</div>
+    <div class="page-title py-4">Create a new collection from a dataset</div>
     <v-form v-model="valid">
       <v-text-field v-model="name" label="Name" :rules="rules" />
       <v-textarea v-model="description" label="Description" />

--- a/src/views/dataset/Dataset.vue
+++ b/src/views/dataset/Dataset.vue
@@ -4,7 +4,7 @@
     <v-overlay
       :model-value="isLoading"
       contained
-      scrim="white"
+      scrim="background"
       :opacity="0.8"
       z-index="9999"
       class="d-flex align-center justify-center"
@@ -87,10 +87,10 @@ defineExpose({ isReady, isLoading, datasetReady, loadDataset });
 }
 
 .loading-text {
-  color: #424242; /* Dark gray text for contrast on white background */
-  font-size: 1.5rem; /* Larger text */
-  font-weight: 500; /* Medium weight for better visibility */
-  margin-top: 16px; /* Space between spinner and text */
+  color: rgb(var(--v-theme-on-background));
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin-top: 16px;
   text-align: center;
 }
 </style>

--- a/src/views/dataset/DatasetInfo.vue
+++ b/src/views/dataset/DatasetInfo.vue
@@ -40,7 +40,7 @@
             </v-btn>
           </v-toolbar>
           <v-card-text>
-            <v-table class="elevation-3 ma-2">
+            <v-table class="info-table ma-2">
               <tbody>
                 <tr v-for="item in report" :key="item.name">
                   <td class="text-right" width="30%">{{ item.name }}</td>
@@ -152,7 +152,7 @@
               </v-card>
             </v-dialog>
             <v-card class="ma-3">
-              <v-card-title class="title">
+              <v-card-title>
                 {{
                   datasetViewItems.length > 0
                     ? "Select a collection"
@@ -913,9 +913,14 @@ defineExpose({
   transition: all 0.2s ease;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: var(--nimbus-glass-hover);
     transform: scale(1.1);
   }
+}
+
+.info-table {
+  border: 1px solid var(--nimbus-border);
+  border-radius: var(--nimbus-radius);
 }
 
 .pulse-btn {
@@ -933,7 +938,7 @@ defineExpose({
   right: 0;
   bottom: 0;
   border-radius: inherit;
-  box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.5);
+  box-shadow: 0 0 0 0 rgba(var(--v-theme-success), 0.5);
   animation: subtle-pulse-shadow 3s infinite ease-in-out;
 }
 
@@ -951,22 +956,22 @@ defineExpose({
 
 @keyframes subtle-pulse-shadow {
   0% {
-    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.5);
+    box-shadow: 0 0 0 0 rgba(var(--v-theme-success), 0.5);
   }
   70% {
-    box-shadow: 0 0 0 8px rgba(76, 175, 80, 0);
+    box-shadow: 0 0 0 8px rgba(var(--v-theme-success), 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0);
+    box-shadow: 0 0 0 0 rgba(var(--v-theme-success), 0);
   }
 }
 
 .selectable-list-item {
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--nimbus-radius-sm);
 
   &:hover {
-    background-color: rgba(255, 255, 255, 0.05);
+    background-color: var(--nimbus-glass-hover);
   }
 }
 </style>

--- a/src/views/dataset/MultiSourceConfiguration.test.ts
+++ b/src/views/dataset/MultiSourceConfiguration.test.ts
@@ -2387,7 +2387,7 @@ describe("MultiSourceConfiguration", () => {
       const vm = wrapper.vm as any;
       const dim = { id: 0, guess: "C", size: 3, source: "file", data: {} };
       expect(vm.getAssignedDimensionColor(dim)).toBe(
-        "rgba(255, 255, 255, 0.3)",
+        "var(--nimbus-text-faint)",
       );
     });
 

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -1,7 +1,9 @@
 <template>
   <v-container>
     <v-card class="pa-4 my-4">
-      <v-list-subheader :data-tour="TOUR_ANCHORS.variables" class="headline"
+      <v-list-subheader
+        :data-tour="TOUR_ANCHORS.variables"
+        class="panel-section-title"
         >Variables</v-list-subheader
       >
       <v-divider class="my-2" />
@@ -30,7 +32,7 @@
         v-if="highlightedFilenameSegments.length > 0"
         class="filename-highlight-container mb-4 pa-3"
       >
-        <div class="text-caption text-grey mb-1">
+        <div class="text-caption text-medium-emphasis mb-1">
           Example filename with extracted variables:
         </div>
         <div class="filename-highlight-text">
@@ -55,7 +57,7 @@
             ></span>
             <span class="text-caption">
               {{ legend.label }}
-              <span v-if="legend.showGuess" class="text-grey-darken-1">
+              <span v-if="legend.showGuess" class="text-medium-emphasis">
                 (guessed: {{ legend.guess }})
               </span>
             </span>
@@ -164,7 +166,7 @@
             initProgressPercent
           }}%)
         </span>
-        <span v-else class="text-red">
+        <span v-else class="text-error">
           Failed on {{ initError.name }}: {{ initError.message }}
         </span>
       </v-card-title>
@@ -205,7 +207,9 @@
     </v-card>
     <v-card class="pa-4 my-4" v-else>
       <div class="d-flex">
-        <v-list-subheader :data-tour="TOUR_ANCHORS.assignments" class="headline"
+        <v-list-subheader
+          :data-tour="TOUR_ANCHORS.assignments"
+          class="panel-section-title"
           >Assignments</v-list-subheader
         >
         <v-spacer />
@@ -386,7 +390,9 @@
     <v-card class="mt-4" v-if="isUploading">
       <v-card-text>
         <div class="d-flex align-center mb-2">
-          <div class="text-subtitle-1 mr-3">{{ progressStatusText }}</div>
+          <div class="text-body-2 text-medium-emphasis mr-3">
+            {{ progressStatusText }}
+          </div>
           <v-spacer></v-spacer>
           <v-btn
             size="small"
@@ -407,7 +413,7 @@
           color="primary"
         >
           <template v-slot:default>
-            <span class="text-white">{{ Math.ceil(transcodeProgress) }}%</span>
+            <span class="font-mono">{{ Math.ceil(transcodeProgress) }}%</span>
           </template>
         </v-progress-linear>
       </v-card-text>
@@ -416,7 +422,7 @@
     <!-- Log Dialog -->
     <v-dialog v-model="showLogDialog" max-width="800px">
       <v-card>
-        <v-card-title class="headline">
+        <v-card-title>
           Transcoding Log
           <v-spacer></v-spacer>
           <v-tooltip location="bottom">
@@ -1091,7 +1097,7 @@ function getAssignedDimensionColor(item: TAssignmentOption): string {
   if (dim && dim in variableColors) {
     return variableColors[dim as TUpDim];
   }
-  return "rgba(255, 255, 255, 0.3)";
+  return "var(--nimbus-text-faint)";
 }
 
 function getSlotClasses(dimension: TUpDim): Record<string, boolean> {
@@ -2071,27 +2077,28 @@ defineExpose({
   min-height: 200px;
   overflow-y: auto;
   white-space: pre-wrap;
-  font-family: monospace;
+  font-family: var(--nimbus-font-mono);
   font-size: 12px;
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--nimbus-glass);
+  border: 1px solid var(--nimbus-border);
   padding: 12px;
-  border-radius: 4px;
+  border-radius: var(--nimbus-radius-sm);
   width: 100%;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--nimbus-text-secondary);
 }
 
 .filename-highlight-container {
-  background-color: rgba(0, 0, 0, 0.03);
-  border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  background-color: var(--nimbus-glass);
+  border-radius: var(--nimbus-radius-sm);
+  border: 1px solid var(--nimbus-border);
 }
 
 .filename-highlight-text {
-  font-family: "Roboto Mono", "Consolas", "Monaco", monospace;
+  font-family: var(--nimbus-font-mono);
   font-size: 14px;
   padding: 8px 12px;
-  background-color: rgba(0, 0, 0, 0.05);
-  border-radius: 4px;
+  background-color: var(--nimbus-glass);
+  border-radius: var(--nimbus-radius-sm);
   overflow-x: auto;
   white-space: nowrap;
 }
@@ -2127,9 +2134,9 @@ defineExpose({
   align-items: center;
   gap: 16px;
   padding: 12px 16px;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--nimbus-glass);
+  border-radius: var(--nimbus-radius-sm);
+  border: 1px solid var(--nimbus-border);
 }
 
 .variables-summary__item {
@@ -2140,23 +2147,24 @@ defineExpose({
 
 .variables-summary__item--total {
   padding-left: 8px;
-  border-left: 1px solid rgba(255, 255, 255, 0.15);
+  border-left: 1px solid var(--nimbus-border-strong);
 }
 
 .variables-summary__value {
+  font-family: var(--nimbus-font-mono);
   font-size: 20px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .variables-summary__label {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--nimbus-text-muted);
 }
 
 .variables-summary__divider {
   font-size: 16px;
-  color: rgba(255, 255, 255, 0.3);
+  color: var(--nimbus-text-faint);
 }
 
 /* Variables List */
@@ -2168,7 +2176,7 @@ defineExpose({
 }
 
 .variables-list-empty {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--nimbus-text-muted);
   font-style: italic;
   padding: 16px;
 }
@@ -2179,13 +2187,13 @@ defineExpose({
   align-items: center;
   gap: 16px;
   padding: 10px 12px;
-  background: rgba(255, 255, 255, 0.02);
-  border-radius: 4px;
+  background: var(--nimbus-glass);
+  border-radius: var(--nimbus-radius-sm);
   transition: background 0.15s ease;
 }
 
 .variable-row:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--nimbus-glass-hover);
 }
 
 .variable-row__accent {
@@ -2199,14 +2207,14 @@ defineExpose({
 .variable-row__name {
   font-weight: 500;
   font-size: 14px;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgb(var(--v-theme-on-surface));
   min-width: 160px;
   flex-shrink: 0;
 }
 
 .variable-row__values {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--nimbus-text-secondary);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2218,19 +2226,19 @@ defineExpose({
 }
 
 .variable-row__values-icon {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--nimbus-text-faint);
   cursor: pointer;
   flex-shrink: 0;
   transition: color 0.15s ease;
 }
 
 .variable-row__values-icon:hover {
-  color: rgba(255, 255, 255, 0.8);
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .variable-row__source {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--nimbus-text-muted);
   display: flex;
   align-items: center;
   text-transform: capitalize;
@@ -2240,7 +2248,7 @@ defineExpose({
 
 .variable-row__size {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--nimbus-text-secondary);
   font-weight: 500;
   min-width: 70px;
   flex-shrink: 0;
@@ -2263,7 +2271,7 @@ defineExpose({
 
 .variable-row__unassigned {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.25);
+  color: var(--nimbus-text-faint);
 }
 
 /* Assignment Slots Container */
@@ -2285,8 +2293,8 @@ defineExpose({
   min-width: 100px;
   padding: 8px 12px;
   border-left: 4px solid;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 0 4px 4px 0;
+  background: var(--nimbus-glass);
+  border-radius: 0 var(--nimbus-radius-sm) var(--nimbus-radius-sm) 0;
   display: flex;
   align-items: baseline;
   gap: 8px;
@@ -2295,39 +2303,39 @@ defineExpose({
 .assignment-slot__dimension-name {
   font-weight: 500;
   font-size: 14px;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .assignment-slot__dimension-code {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.5);
-  font-family: monospace;
+  color: var(--nimbus-text-muted);
+  font-family: var(--nimbus-font-mono);
 }
 
 /* The Slot */
 .assignment-slot {
   flex: 1;
   min-height: 44px;
-  border-radius: 6px;
+  border-radius: var(--nimbus-radius-sm);
   display: flex;
   align-items: center;
   transition: all 0.2s ease;
 }
 
 .assignment-slot--filled {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--nimbus-glass);
+  border: 1px solid var(--nimbus-border-strong);
 }
 
 .assignment-slot--empty-available {
-  border: 2px dashed rgba(255, 255, 255, 0.3);
+  border: 2px dashed rgba(var(--v-theme-on-surface), 0.3);
   background: transparent;
   cursor: pointer;
 }
 
 .assignment-slot--empty-available:hover {
-  border-color: rgba(255, 255, 255, 0.5);
-  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(var(--v-theme-on-surface), 0.5);
+  background: var(--nimbus-glass-hover);
 }
 
 .assignment-slot--empty-none {
@@ -2336,7 +2344,7 @@ defineExpose({
 }
 
 .assignment-slot--immutable {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--nimbus-glass);
 }
 
 /* Badge inside slot */
@@ -2353,12 +2361,12 @@ defineExpose({
 .assignment-slot__badge-name {
   font-weight: 500;
   font-size: 14px;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .assignment-slot__badge-values {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--nimbus-text-muted);
   margin-left: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2367,7 +2375,7 @@ defineExpose({
 
 .assignment-slot__badge-size {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--nimbus-text-muted);
   margin-left: 8px;
   font-weight: 500;
 }
@@ -2384,7 +2392,7 @@ defineExpose({
 
 .assignment-slot__placeholder {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--nimbus-text-faint);
   font-style: italic;
 }
 
@@ -2405,12 +2413,12 @@ defineExpose({
 .dropdown-item-name {
   font-weight: 500;
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .dropdown-item-values {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--nimbus-text-muted);
 }
 
 /* Values Popover */
@@ -2431,7 +2439,7 @@ defineExpose({
 .values-popover__count {
   font-size: 12px;
   font-weight: 400;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--nimbus-text-muted);
 }
 
 .values-popover__list {
@@ -2449,13 +2457,13 @@ defineExpose({
 
 .values-popover__index {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--nimbus-text-faint);
   min-width: 24px;
-  font-family: monospace;
+  font-family: var(--nimbus-font-mono);
 }
 
 .values-popover__value {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--nimbus-text-secondary);
 }
 </style>

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -49,7 +49,9 @@
           >
             <template #default>
               <v-icon size="50px">mdi-file-upload</v-icon>
-              <div class="title mt-3">{{ dropzoneMessage }}</div>
+              <div class="text-body-1 font-weight-medium mt-3">
+                {{ dropzoneMessage }}
+              </div>
             </template>
           </file-dropzone>
         </template>
@@ -71,7 +73,9 @@
       >
         <template #default>
           <v-icon size="50px">mdi-file-upload</v-icon>
-          <div class="title mt-3">Add more files to this dataset</div>
+          <div class="text-body-1 font-weight-medium mt-3">
+            Add more files to this dataset
+          </div>
         </template>
       </file-dropzone>
 
@@ -194,7 +198,7 @@
                 ? 'success'
                 : idx === store.uploadWorkflow.currentDatasetIndex
                   ? 'primary'
-                  : 'grey'
+                  : 'secondary'
             "
             size="small"
             class="mr-1"
@@ -233,7 +237,7 @@
           class="d-none"
         />
         <!-- Show status text and spinner when auto-processing -->
-        <div class="title mb-2">
+        <div class="text-body-1 font-weight-medium mb-2">
           {{
             isBatchMode && !isProcessingFirstDataset
               ? "Applying configuration to dataset"
@@ -246,7 +250,9 @@
         <v-card class="mt-4" v-if="configurationLogs && !pipelineError">
           <v-card-text>
             <div class="d-flex align-center mb-2">
-              <div class="text-subtitle-1 mr-3">{{ progressStatusText }}</div>
+              <div class="text-body-2 text-medium-emphasis mr-3">
+                {{ progressStatusText }}
+              </div>
               <v-spacer></v-spacer>
               <v-btn
                 size="small"
@@ -267,7 +273,7 @@
               color="primary"
             >
               <template v-slot:default>
-                <span class="text-white"
+                <span class="font-mono"
                   >{{ Math.ceil(transcodeProgress) }}%</span
                 >
               </template>
@@ -276,7 +282,9 @@
         </v-card>
       </template>
       <template v-if="creatingView">
-        <div class="title mb-2">Configuring the dataset</div>
+        <div class="text-body-1 font-weight-medium mb-2">
+          Configuring the dataset
+        </div>
         <v-progress-circular indeterminate />
         <dataset-info
           ref="viewCreation"
@@ -288,7 +296,7 @@
     <!-- Log Dialog -->
     <v-dialog v-model="showLogDialog" max-width="800px">
       <v-card>
-        <v-card-title class="headline">
+        <v-card-title>
           Transcoding Log
           <v-spacer></v-spacer>
           <v-tooltip location="bottom">
@@ -334,7 +342,7 @@
     <!-- Batch mode error dialog -->
     <v-dialog v-model="showBatchErrorDialog" persistent max-width="500">
       <v-card>
-        <v-card-title class="headline text-error">
+        <v-card-title class="text-error">
           <v-icon start color="error">mdi-alert-circle</v-icon>
           Dataset Failed
         </v-card-title>
@@ -1330,12 +1338,13 @@ defineExpose({
   min-height: 200px;
   overflow-y: auto;
   white-space: pre-wrap;
-  font-family: monospace;
+  font-family: var(--nimbus-font-mono);
   font-size: 12px;
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--nimbus-glass);
+  border: 1px solid var(--nimbus-border);
   padding: 12px;
-  border-radius: 4px;
+  border-radius: var(--nimbus-radius-sm);
   width: 100%;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--nimbus-text-secondary);
 }
 </style>

--- a/src/views/project/ProjectInfo.vue
+++ b/src/views/project/ProjectInfo.vue
@@ -139,8 +139,8 @@
       <v-card-text>
         <v-progress-linear v-if="loadingDatasets" indeterminate />
         <div v-else-if="allDatasetItems.length === 0" class="text-center pa-4">
-          <v-icon size="48" color="grey">mdi-folder-outline</v-icon>
-          <div class="text-body-2 text-grey mt-2">
+          <v-icon size="48" color="secondary">mdi-folder-outline</v-icon>
+          <div class="text-body-2 text-medium-emphasis mt-2">
             No datasets in this project yet.
           </div>
         </div>
@@ -148,8 +148,8 @@
           v-else-if="datasetFilter && filteredDatasetItems.length === 0"
           class="text-center pa-4"
         >
-          <v-icon size="48" color="grey">mdi-magnify</v-icon>
-          <div class="text-body-2 text-grey mt-2">
+          <v-icon size="48" color="secondary">mdi-magnify</v-icon>
+          <div class="text-body-2 text-medium-emphasis mt-2">
             No datasets match "{{ datasetFilter }}"
           </div>
         </div>
@@ -163,7 +163,10 @@
                 class="font-weight-medium d-flex align-center flex-wrap"
               >
                 <span>{{ item.info?.name || "Loading..." }}</span>
-                <span v-if="item.info?.size" class="ml-2 text-grey text-body-2">
+                <span
+                  v-if="item.info?.size"
+                  class="ml-2 text-medium-emphasis text-body-2"
+                >
                   ({{ formatSize(item.info.size) }})
                 </span>
                 <v-chip
@@ -171,8 +174,7 @@
                   :key="collId"
                   size="x-small"
                   class="ml-2"
-                  color="#4baeff"
-                  text-color="white"
+                  color="collection"
                   :to="{
                     name: 'configuration',
                     params: { configurationId: collId },
@@ -253,8 +255,10 @@
       <v-card-text>
         <v-progress-linear v-if="loadingCollections" indeterminate />
         <div v-else-if="collectionItems.length === 0" class="text-center pa-4">
-          <v-icon size="48" color="grey">mdi-folder-multiple-outline</v-icon>
-          <div class="text-body-2 text-grey mt-2">
+          <v-icon size="48" color="secondary"
+            >mdi-folder-multiple-outline</v-icon
+          >
+          <div class="text-body-2 text-medium-emphasis mt-2">
             No collections in this project yet.
           </div>
         </div>
@@ -262,8 +266,8 @@
           v-else-if="collectionFilter && filteredCollectionItems.length === 0"
           class="text-center pa-4"
         >
-          <v-icon size="48" color="grey">mdi-magnify</v-icon>
-          <div class="text-body-2 text-grey mt-2">
+          <v-icon size="48" color="secondary">mdi-magnify</v-icon>
+          <div class="text-body-2 text-medium-emphasis mt-2">
             No collections match "{{ collectionFilter }}"
           </div>
         </div>
@@ -318,7 +322,7 @@
                   {{ datasetInfoCache[dv.datasetId]?.name || "Loading..." }}
                   <span
                     v-if="datasetInfoCache[dv.datasetId]?.size"
-                    class="ml-2 text-grey"
+                    class="ml-2 text-medium-emphasis"
                   >
                     ({{
                       formatSize(datasetInfoCache[dv.datasetId]?.size || 0)
@@ -1211,7 +1215,7 @@ defineExpose({
 
 // Only add hover effect to group headers as they are clickable
 :deep(.v-list-group__header:hover) {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: var(--nimbus-glass-hover);
 }
 
 // Ensure list item actions align properly with content


### PR DESCRIPTION
## Summary

The modular-workspace refresh (#1178) deliberately left the home / list views untouched. This PR brings the rest of the app — Home, dataset/configuration/project views, login, and the browse list components — into line with the same design language, without changing any behavior.

## What changed

**Typography**
- Dead Vuetify-2 classes (`.headline`, `.title`) and `text-h5/h6`-as-section-label replaced with the canonical `panel-section-title` (Home "Browse"/"Location", MultiSourceConfiguration "Variables"/"Assignments", profile settings labels) or plain `v-card-title` (globally 14px since #1178)
- New `.page-title` utility in `style.scss` — the Instrument Serif display face at a fixed editorial size — used sparingly for route-level and welcome headings (login "Welcome to NimbusImage!", signup, Zenodo community title, new-collection pages). This is the first in-app use of the display font outside the mockups
- Data moments (transcode %, variable count stats, filename highlighting, job logs) now use `--nimbus-font-mono`

**Theme correctness (the biggest functional win)**
- MultiSourceConfiguration's ~400-line style block was entirely dark-mode-only `rgba(255,255,255,x)` literals; CollectionList's was entirely light-mode-only hex (`#e0e0e0`, `#f5f5f5`, `#424242`). Both are now `--nimbus-*` token-based and correct in both themes
- Loading overlays use `scrim="background"` + `on-background` text instead of hardcoded white scrim / `#424242` text
- Home's upload dropzone border was invisible in light mode (`rgba(255,255,255,0.3)`) and referenced dead Vuetify-2 vars (`--v-primary-base`); now `--nimbus-border-strong` with a proper primary drag state and hover treatment

**Resource accent tokens**
- The scattered hex literals that consistently marked resource types (`#e57373` datasets, `#4baeff` collections/configurations, `#8e24aa` projects) are promoted to named theme colors `dataset` / `collection` / `project` in both themes (collection deepened to `#1e88e5` in light for contrast)
- Chips, icons, and list titles use the semantic names; the relation-chip rows map them through `rgb(var(--v-theme-…))`
- The global dark-chip neutralizer in `style.scss` now exempts these accents so the tint actually renders (it was flattening every non-status chip to gray)
- File-manager type chips are now colored by resource type instead of gray

**Color-literal cleanup**
- `color="grey"`, `text-grey`, `grey lighten-5`, `text-color="white"` → `secondary` / `text-medium-emphasis` / theme-aware equivalents
- Green pulse animation (`rgba(76,175,80,…)`) → `--v-theme-success`; removed a dead copy of the pulse CSS from Home.vue
- `elevation-3` table → token border; Zenodo card hover shadow → border/glass-hover lift

Deliberately untouched: the dimension data-viz palette in MultiSourceConfiguration (`#4CAF50`/`#2196F3`/`#FF9800`/`#9C27B0` with white text — saturated fills that work in both themes), and datasetView chrome itself.

## Test plan

- [x] `pnpm tsc`, `pnpm lint:ci` clean
- [x] Full vitest suite: 121 files, 2113 tests pass (5 assertions updated for the new semantic chip colors)
- [x] In-browser check (dark + light): home, Datasets and Files / Collections / Projects browse tabs — accent chips tinted correctly, upload card visible in light mode, panel-section-title headers render
- [ ] Advanced import (MultiSourceConfiguration) visual pass in light mode — the style block was mechanically token-migrated; worth one look at Variables/Assignments while importing a dataset
- [ ] Login screen (logged-out) — welcome heading now uses the display serif

🤖 Generated with [Claude Code](https://claude.com/claude-code)