### PR TITLE
fix(sam): serialize ONNX session creation to avoid initWasm race

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -376,6 +376,31 @@ Quick API: `__nimbusMem.enable()`, `snapshot('label')`, `print()`, `compare('a',
 
 For the full API, recorded fields, the load-order constraint (don't import stores at top level — register from `main.ts`), instructions for adding new counters or auto-snapshot points, and the cherry-pick procedure for cross-branch comparison: read `codebaseDocumentation/MEMORY_DEBUGGING.md`.
 
+## ONNX / SAM Pipeline (`src/pipelines/onnxModels.ts`, `samPipeline.ts`)
+
+The SAM tools run ONNX models (`onnxruntime-web`, WebGPU) whose WASM loaders and model files are fetched from `/onnx-wasm/` and `/onnx-models/`. Three failure modes here have bitten us in **production only** — they pass locally because the Vite dev server serves assets instantly and with correct MIME types.
+
+- **`.mjs` served as `text/plain` (prod nginx).** Modern `onnxruntime-web` dynamically `import()`s `.mjs` WASM loaders (e.g. `ort-wasm-simd-threaded.asyncify.mjs`) from `env.wasm.wasmPaths`. Production static files are served by **nginx in the AWSDeploy repo** (`templates/startup_haproxy.tftpl`), which uses stock `include mime.types;`. Stock `mime.types` maps `.js` but **not `.mjs`**, so `.mjs` falls through to `text/plain` and the browser refuses the ES-module import (*"Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of text/plain"*). `.wasm` is unaffected (it *is* in stock `mime.types` as `application/wasm`), which is why pre-`.mjs` versions never hit this. Fix lives in **AWSDeploy** (`types { text/javascript mjs; }`), not in this repo — don't add a frontend workaround. Also: `env.wasm.wasmPaths` must be **root-absolute** (`/onnx-wasm/`), or the loader specifier resolves against the current SPA route path.
+
+- **Concurrent session creation → `multiple calls to 'initWasm()' detected`.** onnxruntime-web initializes its shared WASM/WebGPU backend lazily on the first `InferenceSession.create()`, and that init is **not reentrant**. The SAM pipeline creates the encoder (`samPipeline.ts` `createEncoderSession`) and decoder (`createDecoderSession`) sessions from two independent `ComputeNode`s that fire on the same tick, so both creates race the backend init. The window is sub-millisecond locally (loaders served instantly) but wide in prod (each is a network fetch), so it fails deterministically **only when deployed**. `createOnnxInferenceSession` **serializes the `create()` step** through a module-level promise chain so the backend initializes exactly once — keep it that way. Model *downloads* stay parallel; only `create()` is gated. (Pipeline-node compute errors log `this.fun.name`, which is **minified** in prod — `[f2n]`/`[p2n]` are the mangled session-creation functions, not meaningful names.)
+
+- **HTML-shell cache poisoning.** A missing model path is answered with the `index.html` app shell at HTTP 200 (SPA fallback); caching that permanently breaks the tool (*"Failed to load model because protobuf parsing failed"*, INVALID_PROTOBUF). `fetchModelBuffer`/`warmModelCache` detect it (content-type + first byte `0x3c` `<`) and self-heal by dropping the poisoned cache entry.
+
+**General promise pattern (Codex P2, PR #1237):** when you start an async op eagerly but defer its consumer behind a chain — `chain.then(() => started.then(...))` — the `started` promise can reject *before* any handler is attached, which the runtime reports as an **unhandled rejection** (noise in the console and in Sentry) even though a later handler eventually catches it. Settle it into a non-rejecting result the instant it starts, then re-throw inside the chain:
+
+```typescript
+const settled = started.then(
+  (value) => ({ ok: true as const, value }),
+  (error) => ({ ok: false as const, error }),
+);
+const gated = chain.then(() =>
+  settled.then((r) => {
+    if (!r.ok) throw r.error;
+    return use(r.value);
+  }),
+);
+```
+
 ## Style Guidelines
 
 - Use scoped SCSS: `<style lang="scss" scoped>`

--- a/codebaseDocumentation/SAM-ONNX-INITWASM-REVIEW.md
+++ b/codebaseDocumentation/SAM-ONNX-INITWASM-REVIEW.md
@@ -1,0 +1,33 @@
+# PR #1237 review findings — serialize ONNX session creation
+
+Tracker for Codex review on `fix/sam-onnx-initwasm-race`.
+
+## Findings
+
+### F1 — Queued fetch rejection is momentarily unhandled (Codex P2)
+
+- **Location:** `src/pipelines/onnxModels.ts:136` (the serialized-create path)
+- **Summary:** `fetchModelBuffer()` starts immediately, but its `.then` consumer is
+  attached only inside the `sessionCreateChain.then(...)` callback, which runs after
+  the previous create resolves. If a queued model's fetch rejects during that gap
+  (fast 404 / network error / HTML shell) while an earlier `InferenceSession.create()`
+  is still pending, the fetch promise has no rejection handler yet → the runtime fires
+  `unhandledrejection` (and a later `rejectionHandled`), surfacing a recoverable
+  model-load failure as a global error.
+- **Verdict:** fix — real and current; introduced by this PR's serialization.
+- **Status:** fixed — settle the fetch into a non-rejecting `{ok, buffer|error}` result
+  the instant it starts (handlers attached synchronously), then re-throw inside the
+  chain where `sessionPromise`'s consumers handle it. Serialization + parallel
+  downloads preserved.
+
+## Pattern sweep
+
+Pattern: *a promise whose only consumer/handler is attached on a later tick* (deferred
+`.then` on an already-started promise) leaves a window for an unhandled rejection.
+
+Swept the branch diff (`onnxModels.ts` is the only changed source file):
+- `sessionPromise` — has `.catch` attached synchronously ✓
+- `sessionCreateChain = sessionPromise.then(() => {}, () => {})` — both handlers ✓
+- `bufferSettled` (post-fix) — both handlers attached at creation ✓
+
+No other instances.

--- a/src/pipelines/onnxModels.test.ts
+++ b/src/pipelines/onnxModels.test.ts
@@ -232,6 +232,61 @@ describe("createOnnxInferenceSession", () => {
     expect(createMock).toHaveBeenCalledTimes(2);
   });
 
+  it("a queued model whose fetch fails rejects cleanly without an unhandled rejection", async () => {
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+    const unhandled: unknown[] = [];
+    const onUnhandled = (event: PromiseRejectionEvent) => {
+      unhandled.push(event.reason);
+    };
+    // Node reports via process; jsdom/browsers via the window event. Cover both.
+    const processOn = (
+      globalThis as unknown as {
+        process?: { on?: Function; off?: Function };
+      }
+    ).process;
+    const nodeHandler = (reason: unknown) => unhandled.push(reason);
+    processOn?.on?.("unhandledRejection", nodeHandler);
+    globalThis.addEventListener?.("unhandledrejection", onUnhandled);
+
+    try {
+      // The encoder's create() stays pending, holding the serialization chain.
+      let resolveEncoderCreate!: (value: unknown) => void;
+      createMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveEncoderCreate = resolve;
+        }),
+      );
+      // The decoder's download fails fast while the encoder create is pending.
+      fetchMock.mockImplementation((path: string) =>
+        path.includes("decoder")
+          ? Promise.reject(new Error("decoder 404"))
+          : Promise.resolve(makeResponse(modelBuffer)),
+      );
+
+      const { createOnnxInferenceSession } = await importFreshModule();
+      const encoderPromise = createOnnxInferenceSession("/models/encoder.onnx");
+      const decoderPromise = createOnnxInferenceSession("/models/decoder.onnx");
+
+      // Let the decoder fetch reject while the encoder create is still pending.
+      // The fetch rejection must already be absorbed here — this is what the
+      // fix guarantees — even though the decoder's session rejection is
+      // (correctly) still queued behind the encoder create.
+      await flush();
+      expect(unhandled).toEqual([]);
+
+      // Releasing the encoder create advances the chain; only now does the
+      // decoder's session promise surface its rejection, with its own error.
+      resolveEncoderCreate({ fake: "encoder" });
+      await expect(encoderPromise).resolves.toEqual({ fake: "encoder" });
+      await expect(decoderPromise).rejects.toThrow("decoder 404");
+      await flush();
+      expect(unhandled).toEqual([]);
+    } finally {
+      processOn?.off?.("unhandledRejection", nodeHandler);
+      globalThis.removeEventListener?.("unhandledrejection", onUnhandled);
+    }
+  });
+
   it("a failed create does not wedge later session creation", async () => {
     createMock
       .mockRejectedValueOnce(new Error("create blew up"))

--- a/src/pipelines/onnxModels.test.ts
+++ b/src/pipelines/onnxModels.test.ts
@@ -203,6 +203,49 @@ describe("createOnnxInferenceSession", () => {
     expect(cachePut).toHaveBeenCalledTimes(1);
   });
 
+  it("serializes InferenceSession.create so the backend only initializes once", async () => {
+    // Two distinct model paths (encoder + decoder) requested concurrently, as
+    // the SAM pipeline does. ORT's backend init is not reentrant, so the second
+    // create() must not start until the first has resolved.
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+    let resolveFirstCreate!: (value: unknown) => void;
+    const firstCreate = new Promise((resolve) => {
+      resolveFirstCreate = resolve;
+    });
+    createMock
+      .mockReturnValueOnce(firstCreate)
+      .mockResolvedValueOnce({ fake: "decoder" });
+
+    const { createOnnxInferenceSession } = await importFreshModule();
+    const encoderPromise = createOnnxInferenceSession("/models/encoder.onnx");
+    const decoderPromise = createOnnxInferenceSession("/models/decoder.onnx");
+
+    // Let both downloads settle. Only the first create() should have started;
+    // the second is queued behind it even though its buffer is ready.
+    await flush();
+    expect(createMock).toHaveBeenCalledTimes(1);
+
+    // Finishing the first create() lets the second proceed.
+    resolveFirstCreate({ fake: "encoder" });
+    await expect(encoderPromise).resolves.toEqual({ fake: "encoder" });
+    await expect(decoderPromise).resolves.toEqual({ fake: "decoder" });
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("a failed create does not wedge later session creation", async () => {
+    createMock
+      .mockRejectedValueOnce(new Error("create blew up"))
+      .mockResolvedValueOnce({ fake: "session" });
+
+    const { createOnnxInferenceSession } = await importFreshModule();
+    await expect(
+      createOnnxInferenceSession("/models/encoder.onnx"),
+    ).rejects.toThrow("create blew up");
+    // The chain must recover so the next model still loads.
+    const session = await createOnnxInferenceSession("/models/decoder.onnx");
+    expect(session).toEqual({ fake: "session" });
+  });
+
   it("does not cache failures: a retry after an error attempts a new fetch", async () => {
     fetchMock.mockRejectedValueOnce(new Error("network down"));
     const { createOnnxInferenceSession } = await importFreshModule();

--- a/src/pipelines/onnxModels.ts
+++ b/src/pipelines/onnxModels.ts
@@ -128,12 +128,25 @@ export async function createOnnxInferenceSession(
   if (!(modelPath in sessionCache)) {
     // Kick off the (slow) model download immediately so concurrent requests
     // still fetch their models in parallel — only the backend init is gated.
-    const bufferPromise = fetchModelBuffer(modelPath);
+    // Settle it into a promise that never rejects on its own: the create()
+    // step below is queued behind sessionCreateChain, so a bare fetch promise
+    // could reject while still waiting its turn — before any handler is
+    // attached — which the runtime reports as an unhandled rejection. Re-throw
+    // inside the chain, where sessionPromise's consumers handle it.
+    const bufferSettled = fetchModelBuffer(modelPath).then(
+      (buffer) => ({ ok: true as const, buffer }),
+      (error) => ({ ok: false as const, error }),
+    );
     // Chain the create() step behind any in-flight create so no two run at
     // once. Once the first has fully initialized the backend, the rest are
     // safe; serializing them all is the simplest way to guarantee that.
     const sessionPromise = sessionCreateChain.then(() =>
-      bufferPromise.then((buffer) => InferenceSession.create(buffer, options)),
+      bufferSettled.then((result) => {
+        if (!result.ok) {
+          throw result.error;
+        }
+        return InferenceSession.create(result.buffer, options);
+      }),
     );
     // Advance the chain regardless of this session's outcome (and without
     // retaining the session object), so one failed create can't wedge the

--- a/src/pipelines/onnxModels.ts
+++ b/src/pipelines/onnxModels.ts
@@ -110,13 +110,37 @@ export async function warmModelCache(modelPath: string): Promise<void> {
   }
 }
 
+// onnxruntime-web lazily initializes its shared WASM/WebGPU backend on the
+// first InferenceSession.create() call, and that initialization is NOT
+// reentrant: if a second create() begins while the first is still initializing
+// the backend, ORT throws "multiple calls to 'initWasm()' detected." The SAM
+// pipeline creates the encoder and decoder sessions from two independent
+// compute nodes that fire concurrently, so their create() calls race. The
+// window is tiny on localhost (the .mjs/.wasm loaders are served instantly) but
+// wide in production (each is a network fetch), which is why this only surfaced
+// once deployed. Serialize create() so the backend initializes exactly once.
+let sessionCreateChain: Promise<unknown> = Promise.resolve();
+
 export async function createOnnxInferenceSession(
   modelPath: string,
   options?: InferenceSession.SessionOptions,
 ) {
   if (!(modelPath in sessionCache)) {
-    const sessionPromise = fetchModelBuffer(modelPath).then((buffer) =>
-      InferenceSession.create(buffer, options),
+    // Kick off the (slow) model download immediately so concurrent requests
+    // still fetch their models in parallel — only the backend init is gated.
+    const bufferPromise = fetchModelBuffer(modelPath);
+    // Chain the create() step behind any in-flight create so no two run at
+    // once. Once the first has fully initialized the backend, the rest are
+    // safe; serializing them all is the simplest way to guarantee that.
+    const sessionPromise = sessionCreateChain.then(() =>
+      bufferPromise.then((buffer) => InferenceSession.create(buffer, options)),
+    );
+    // Advance the chain regardless of this session's outcome (and without
+    // retaining the session object), so one failed create can't wedge the
+    // rest.
+    sessionCreateChain = sessionPromise.then(
+      () => {},
+      () => {},
     );
     // Don't cache failures: a transient network error would otherwise
     // permanently break the tool until the page is reloaded


### PR DESCRIPTION
## Context

After merging #1219 (`onnxruntime-web` 1.19.0-dev → 1.27.0), the SAM tool broke in **production only** — it worked locally. Two distinct root causes were exposed; this PR is the second. Both are needed to fully restore SAM in prod.

### 1. `.mjs` MIME type (fixed in AWSDeploy, not here)
ORT 1.27 dynamically `import()`s `.mjs` WASM loaders from `/onnx-wasm/`. The prod nginx (`include mime.types;`) maps `.js` but **not `.mjs`**, so those files were served as `text/plain`; browsers refuse to load an ES module with a non-JS MIME type. (Pre-1.27 only `.wasm` was needed, and `.wasm` *is* in stock `mime.types` — which is why it never showed before.) Fixed by adding `text/javascript mjs;` to the nginx config in the AWSDeploy template.

### 2. Concurrent `initWasm()` — **this PR**
Once the `.mjs` loaded, a deeper error surfaced: `no available backend found. ERR: [webgpu] Error: multiple calls to 'initWasm()' detected.`

onnxruntime-web lazily initializes its shared WASM/WebGPU backend on the first `InferenceSession.create()`, and that init is **not reentrant**. The SAM pipeline creates the encoder (`samPipeline.ts:491`) and decoder (`samPipeline.ts:536`) sessions from two independent `ComputeNode`s that fire on the same tick, so both `create()` calls hit `initializeWebAssembly()` concurrently and ORT 1.27 throws on the second.

**Why prod only:** `initializeWebAssembly()` fetches the `.mjs` loader + `.wasm` binary. On localhost that's instant, so the init window is sub-millisecond and the two creates almost never overlap. In prod each is a network round-trip, so the second `create()` reliably lands mid-init.

(The `[f2n]`/`[p2n]` node IDs in the console are just the minified names of the two session-creation functions — `computePipeline.ts:209` logs `this.fun.name`.)

## Fix

Serialize the `InferenceSession.create()` step through a promise chain in `createOnnxInferenceSession` so the backend initializes exactly once. Model **downloads still run in parallel** — only the `create()` step is gated — so tool load time is unaffected (the encoder was always the long pole; the decoder isn't needed until the user gives a prompt).

## Testing

- `npx vitest run src/pipelines/onnxModels.test.ts` → 17/17 (2 new regression tests: `create()` never runs concurrently across distinct models; a failed `create()` doesn't wedge the chain)
- Full suite: 2172/2172 pass
- `pnpm tsc` clean, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)