### PR TITLE
Add folder upload support

### DIFF
--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -436,6 +436,16 @@ const gated = chain.then(() =>
 );
 ```
 
+## Native File / Folder Pickers (`src/utils/fileUpload.ts`)
+
+Folder upload (picker button + drag-and-drop) is centralized in `src/utils/fileUpload.ts`: `selectFiles()`, `selectFilesFromFolder()`, `getFilesFromDrop(event)`, and `filterFilesByAccept(files, accept)`. Extraction is delegated to the `file-selector` library (recurses into dropped folders, normalizes `<input>` change events). Two traps here each shipped as a silent "pick a folder and nothing happens":
+
+- **Never use a window-`focus` timeout to detect dialog cancellation.** The detached-`<input>` trick (`document.createElement('input'); input.click()`) needs to know when the dialog closes. A tempting fallback is "when the window regains focus, wait Nms; if no `change` fired, treat as cancel." This **loses a race for `webkitdirectory` folder picks**: Chrome interposes an *"Upload N files to this site?"* confirmation, and `input.files` isn't populated (no `change`) until the user accepts it — often **seconds** after the window already refocused when the OS dialog closed. The focus-timeout fires in that gap and resolves with an empty selection, discarding the real folder (measured live: focus at +4.5s, timeout resolves `[]` at +5.0s, real `change` ignored at +7.0s). Regular single-file picks have no confirmation dialog, so `change` wins the race there — which is why the bug looks like "only folders are broken." **No focus heuristic can ever work for folders** because focus returns before the files are known. Rely on the standardized `cancel` event (dismissal) + `change` (selection); both are supported in every browser we target (Chrome 113+, Firefox 91+, Safari 16.4+), so no fallback is needed.
+
+- **A picker promise that never resolves is indistinguishable from "nothing happened."** `file-selector`'s `fromEvent` can reject (an unreadable directory entry, a `getAsFileSystemHandle` failure). If the `await fromEvent(...)` inside the picker's settle handler throws *after* the `settled` guard is set, `resolve()` is never called and every `await selectFilesFromFolder()` **hangs forever**; on the drop path it surfaces as an unhandled rejection. Wrap extraction in try/catch → `logError(...)` + resolve/return `[]` so an error degrades to "no selection."
+
+- **`accept` filtering is caller-applied for folder/DnD only.** The native `<input :accept>` is enforced by the browser for click-to-select, but folder selection and drag-and-drop **bypass it entirely** — that's why `filterFilesByAccept` exists and is called on those two paths (not on the native `onChange`). Caveat: folder/DnD files frequently have an empty `file.type` (browsers assign no MIME to `.tif`/`.nd2`/`.czi`), so **prefer extension tokens** (`.tif,.nd2`) over MIME tokens (`image/*`) in any `accept` you pass — a MIME token silently drops empty-`type` files.
+
 ## Style Guidelines
 
 - Use scoped SCSS: `<style lang="scss" scoped>`

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "driver.js": "^1.4.0",
     "earcut": "^3.0.2",
     "fflate": "^0.7.4",
+    "file-selector": "^2.1.2",
     "fs-extra": "^10.0.0",
     "gif.js": "^0.2.0",
     "html2canvas": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       fflate:
         specifier: ^0.7.4
         version: 0.7.4
+      file-selector:
+        specifier: ^2.1.2
+        version: 2.1.2
       fs-extra:
         specifier: ^10.0.0
         version: 10.1.0
@@ -2831,6 +2834,10 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
+
   file-type@3.9.0:
     resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
     engines: {node: '>=0.10.0'}
@@ -4362,6 +4369,9 @@ packages:
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -7717,6 +7727,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
+
   file-type@3.9.0: {}
 
   file-type@5.2.0: {}
@@ -9329,6 +9343,8 @@ snapshots:
       typescript: 5.9.3
 
   tslib@2.6.2: {}
+
+  tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/src/components/Files/FileDropzone.test.ts
+++ b/src/components/Files/FileDropzone.test.ts
@@ -35,13 +35,13 @@ describe("FileDropzone", () => {
     expect(wrapper.emitted("update:modelValue")![0][0]).toEqual([file]);
   });
 
-  it("emits files from a drop event", () => {
+  it("emits files from a drop event", async () => {
     const wrapper = mountComponent();
     const file = new File(["content"], "dropped.txt");
 
-    wrapper.find(".dropzone-wrapper").trigger("drop", {
+    await wrapper.vm.onDrop({
       dataTransfer: { files: [file] },
-    });
+    } as unknown as DragEvent);
 
     expect(wrapper.emitted("update:modelValue")).toBeTruthy();
     expect(wrapper.emitted("update:modelValue")![0][0]).toEqual([file]);

--- a/src/components/Files/FileDropzone.vue
+++ b/src/components/Files/FileDropzone.vue
@@ -46,7 +46,11 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { getFilesFromDrop, selectFilesFromFolder } from "@/utils/fileUpload";
+import {
+  getFilesFromDrop,
+  selectFilesFromFolder,
+  filterFilesByAccept,
+} from "@/utils/fileUpload";
 
 const props = withDefaults(
   defineProps<{
@@ -84,12 +88,20 @@ function onChange(event: Event) {
 
 async function onDrop(event: DragEvent) {
   dropzoneClass.value = null;
-  const dropped = await getFilesFromDrop(event);
+  // Folders and drag-and-drop bypass the input's `accept` attribute, so honor
+  // it here to keep unsupported files out of the dataset.
+  const dropped = filterFilesByAccept(
+    await getFilesFromDrop(event),
+    props.accept,
+  );
   files.value = props.multiple ? dropped : dropped.slice(0, 1);
 }
 
 async function selectFolder() {
-  const folderFiles = await selectFilesFromFolder();
+  const folderFiles = filterFilesByAccept(
+    await selectFilesFromFolder(),
+    props.accept,
+  );
   if (folderFiles.length > 0) {
     files.value = folderFiles;
   }

--- a/src/components/Files/FileDropzone.vue
+++ b/src/components/Files/FileDropzone.vue
@@ -46,10 +46,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import {
-  getFilesFromDataTransfer,
-  selectFilesFromFolder,
-} from "@/utils/fileUpload";
+import { getFilesFromDrop, selectFilesFromFolder } from "@/utils/fileUpload";
 
 const props = withDefaults(
   defineProps<{
@@ -87,7 +84,7 @@ function onChange(event: Event) {
 
 async function onDrop(event: DragEvent) {
   dropzoneClass.value = null;
-  const dropped = await getFilesFromDataTransfer(event.dataTransfer);
+  const dropped = await getFilesFromDrop(event);
   files.value = props.multiple ? dropped : dropped.slice(0, 1);
 }
 

--- a/src/components/Files/FileDropzone.vue
+++ b/src/components/Files/FileDropzone.vue
@@ -16,11 +16,22 @@
         <v-icon size="50px">mdi-file-upload</v-icon>
         <div class="text-body-1 font-weight-medium mt-3">
           <template v-if="multiple">
-            Drag files here or click to select them
+            Drag files or a folder here or click to select them
           </template>
           <template v-else> Drag a file here or click to select one </template>
         </div>
       </slot>
+      <div v-if="multiple && directory" class="mt-2" style="z-index: 2">
+        <v-btn
+          variant="text"
+          size="small"
+          color="primary"
+          @click.stop="selectFolder"
+        >
+          <v-icon start>mdi-folder-upload</v-icon>
+          Select a folder instead
+        </v-btn>
+      </div>
       <slot name="afterMessage"></slot>
     </v-row>
     <input
@@ -35,6 +46,10 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
+import {
+  getFilesFromDataTransfer,
+  selectFilesFromFolder,
+} from "@/utils/fileUpload";
 
 const props = withDefaults(
   defineProps<{
@@ -42,12 +57,14 @@ const props = withDefaults(
     message?: string;
     multiple?: boolean;
     accept?: string;
+    directory?: boolean;
   }>(),
   {
     modelValue: () => [],
     message: "",
     multiple: true,
     accept: undefined,
+    directory: true,
   },
 );
 
@@ -68,13 +85,20 @@ function onChange(event: Event) {
   files.value = [...fileList];
 }
 
-function onDrop(event: DragEvent) {
+async function onDrop(event: DragEvent) {
   dropzoneClass.value = null;
-  const dropped = [...(event.dataTransfer?.files || [])];
+  const dropped = await getFilesFromDataTransfer(event.dataTransfer);
   files.value = props.multiple ? dropped : dropped.slice(0, 1);
 }
 
-defineExpose({ dropzoneClass, onDrop });
+async function selectFolder() {
+  const folderFiles = await selectFilesFromFolder();
+  if (folderFiles.length > 0) {
+    files.value = folderFiles;
+  }
+}
+
+defineExpose({ dropzoneClass, onDrop, selectFolder });
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Files/FileDropzone.vue
+++ b/src/components/Files/FileDropzone.vue
@@ -21,7 +21,7 @@
           <template v-else> Drag a file here or click to select one </template>
         </div>
       </slot>
-      <div v-if="multiple && directory" class="mt-2" style="z-index: 2">
+      <div v-if="multiple && directory" class="mt-2 folder-select-action">
         <v-btn
           variant="text"
           size="small"
@@ -147,6 +147,13 @@ $img: linear-gradient(
     opacity: 0;
     z-index: 1;
     cursor: pointer;
+  }
+
+  // Raise the folder button above the invisible full-cover .file-input
+  // (z-index: 1) so clicks reach the button instead of opening the file
+  // dialog. It is a flex item of the message row, so z-index applies.
+  .folder-select-action {
+    z-index: 2;
   }
 }
 

--- a/src/utils/fileUpload.test.ts
+++ b/src/utils/fileUpload.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { getFilesFromDataTransfer } from "./fileUpload";
+
+function makeFile(name: string): File {
+  return new File(["content"], name);
+}
+
+// Minimal fakes for the File and Directory Entries API used by folder drops.
+function fileEntry(name: string): FileSystemFileEntry {
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    file: (resolve: (file: File) => void) => resolve(makeFile(name)),
+  } as unknown as FileSystemFileEntry;
+}
+
+function directoryEntry(
+  name: string,
+  children: FileSystemEntry[],
+): FileSystemDirectoryEntry {
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    createReader: () => {
+      let returned = false;
+      return {
+        // Return all children on the first call, then an empty batch to signal
+        // the end, mirroring the real readEntries contract.
+        readEntries: (resolve: (entries: FileSystemEntry[]) => void) => {
+          resolve(returned ? [] : children);
+          returned = true;
+        },
+      };
+    },
+  } as unknown as FileSystemDirectoryEntry;
+}
+
+function dataTransfer(
+  entries: (FileSystemEntry | null)[],
+  files: File[],
+): DataTransfer {
+  const items = entries.map((entry) => ({
+    webkitGetAsEntry: () => entry,
+  }));
+  return { items, files } as unknown as DataTransfer;
+}
+
+describe("getFilesFromDataTransfer", () => {
+  it("returns an empty array for a null DataTransfer", async () => {
+    expect(await getFilesFromDataTransfer(null)).toEqual([]);
+  });
+
+  it("falls back to plain files when the entries API is unavailable", async () => {
+    const file = makeFile("plain.tif");
+    const dt = { files: [file] } as unknown as DataTransfer;
+    expect(await getFilesFromDataTransfer(dt)).toEqual([file]);
+  });
+
+  it("returns dropped top-level files", async () => {
+    const dt = dataTransfer([fileEntry("a.tif")], [makeFile("a.tif")]);
+    const files = await getFilesFromDataTransfer(dt);
+    expect(files.map((f) => f.name)).toEqual(["a.tif"]);
+  });
+
+  it("recurses into dropped folders, including nested subfolders", async () => {
+    const tree = directoryEntry("root", [
+      fileEntry("a.tif"),
+      fileEntry("b.tif"),
+      directoryEntry("nested", [fileEntry("c.tif")]),
+    ]);
+    const dt = dataTransfer([tree], []);
+    const files = await getFilesFromDataTransfer(dt);
+    expect(files.map((f) => f.name).sort()).toEqual([
+      "a.tif",
+      "b.tif",
+      "c.tif",
+    ]);
+  });
+
+  it("handles a mix of dropped files and folders", async () => {
+    const dt = dataTransfer(
+      [fileEntry("top.tif"), directoryEntry("folder", [fileEntry("in.tif")])],
+      [],
+    );
+    const files = await getFilesFromDataTransfer(dt);
+    expect(files.map((f) => f.name).sort()).toEqual(["in.tif", "top.tif"]);
+  });
+});

--- a/src/utils/fileUpload.test.ts
+++ b/src/utils/fileUpload.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // The folder-traversal itself is delegated to (and tested by) `file-selector`.
 // These tests cover the logic this module adds on top: extracting File objects
@@ -8,7 +8,11 @@ vi.mock("file-selector", () => ({
 }));
 
 import { fromEvent } from "file-selector";
-import { getFilesFromDrop, filterFilesByAccept } from "./fileUpload";
+import {
+  getFilesFromDrop,
+  filterFilesByAccept,
+  selectFilesFromFolder,
+} from "./fileUpload";
 
 const mockFromEvent = vi.mocked(fromEvent);
 
@@ -57,6 +61,98 @@ describe("getFilesFromDrop", () => {
   it("returns an empty array when nothing is extracted", async () => {
     mockFromEvent.mockResolvedValue([]);
     expect(await getFilesFromDrop(dropEvent)).toEqual([]);
+  });
+
+  it("returns an empty array (does not reject) when extraction throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFromEvent.mockRejectedValue(new Error("unreadable directory entry"));
+    expect(await getFilesFromDrop(dropEvent)).toEqual([]);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("selectFilesFromFolder", () => {
+  // Capture the detached <input> the picker creates so the test can drive its
+  // native events (in jsdom, input.click() opens no dialog and fires nothing).
+  function captureCreatedInput(): { getInput: () => HTMLInputElement } {
+    const holder: { input: HTMLInputElement | null } = { input: null };
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = realCreateElement(tag);
+      if (tag === "input") {
+        holder.input = el as HTMLInputElement;
+      }
+      return el;
+    });
+    return {
+      getInput: () => {
+        if (!holder.input) {
+          throw new Error("picker never created an <input>");
+        }
+        return holder.input;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    mockFromEvent.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("resolves with the selection when the folder dialog fires `change`", async () => {
+    mockFromEvent.mockResolvedValue([makeFile("a.tif"), makeFile("b.tif")]);
+    const { getInput } = captureCreatedInput();
+
+    const promise = selectFilesFromFolder();
+    getInput().dispatchEvent(new Event("change"));
+
+    expect((await promise).map((f) => f.name)).toEqual(["a.tif", "b.tif"]);
+  });
+
+  it("resolves empty (does not hang) when extraction throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFromEvent.mockRejectedValue(new Error("unreadable selection"));
+    const { getInput } = captureCreatedInput();
+
+    const promise = selectFilesFromFolder();
+    getInput().dispatchEvent(new Event("change"));
+
+    expect(await promise).toEqual([]);
+  });
+
+  it("resolves with an empty array when the dialog is cancelled", async () => {
+    const { getInput } = captureCreatedInput();
+
+    const promise = selectFilesFromFolder();
+    getInput().dispatchEvent(new Event("cancel"));
+
+    expect(await promise).toEqual([]);
+  });
+
+  // Regression guard for the folder-picker race: a directory pick makes the
+  // window regain focus when the OS dialog closes, but `change` (carrying the
+  // files) does not fire until the user confirms Chrome's "Upload N files?"
+  // prompt — often seconds later. A window-focus timeout must not resolve the
+  // promise early with an empty selection and discard the real `change`.
+  it("does not drop the selection when `change` fires long after focus returns", async () => {
+    vi.useFakeTimers();
+    mockFromEvent.mockResolvedValue([makeFile("a.tif"), makeFile("b.tif")]);
+    const { getInput } = captureCreatedInput();
+
+    const promise = selectFilesFromFolder();
+
+    // OS dialog closed -> window refocuses, but no files are known yet.
+    window.dispatchEvent(new Event("focus"));
+    // User spends well over half a second confirming the upload prompt.
+    await vi.advanceTimersByTimeAsync(1500);
+    // Confirmation accepted: the real selection finally arrives.
+    getInput().dispatchEvent(new Event("change"));
+
+    expect((await promise).map((f) => f.name)).toEqual(["a.tif", "b.tif"]);
   });
 });
 

--- a/src/utils/fileUpload.test.ts
+++ b/src/utils/fileUpload.test.ts
@@ -8,12 +8,12 @@ vi.mock("file-selector", () => ({
 }));
 
 import { fromEvent } from "file-selector";
-import { getFilesFromDrop } from "./fileUpload";
+import { getFilesFromDrop, filterFilesByAccept } from "./fileUpload";
 
 const mockFromEvent = vi.mocked(fromEvent);
 
-function makeFile(name: string): File {
-  return new File(["content"], name);
+function makeFile(name: string, type = ""): File {
+  return new File(["content"], name, { type });
 }
 
 const dropEvent = { type: "drop" } as unknown as DragEvent;
@@ -57,5 +57,40 @@ describe("getFilesFromDrop", () => {
   it("returns an empty array when nothing is extracted", async () => {
     mockFromEvent.mockResolvedValue([]);
     expect(await getFilesFromDrop(dropEvent)).toEqual([]);
+  });
+});
+
+describe("filterFilesByAccept", () => {
+  const files = [
+    makeFile("image.tif", "image/tiff"),
+    makeFile("photo.PNG", "image/png"),
+    makeFile("notes.csv", "text/csv"),
+    makeFile("readme.txt", "text/plain"),
+  ];
+
+  it("returns all files when accept is empty or undefined", () => {
+    expect(filterFilesByAccept(files)).toEqual(files);
+    expect(filterFilesByAccept(files, "")).toEqual(files);
+    expect(filterFilesByAccept(files, "  ")).toEqual(files);
+  });
+
+  it("filters by extension tokens (case-insensitively)", () => {
+    const result = filterFilesByAccept(files, ".tif,.png");
+    expect(result.map((f) => f.name)).toEqual(["image.tif", "photo.PNG"]);
+  });
+
+  it("filters by wildcard MIME tokens", () => {
+    const result = filterFilesByAccept(files, "image/*");
+    expect(result.map((f) => f.name)).toEqual(["image.tif", "photo.PNG"]);
+  });
+
+  it("filters by exact MIME tokens", () => {
+    const result = filterFilesByAccept(files, "text/csv");
+    expect(result.map((f) => f.name)).toEqual(["notes.csv"]);
+  });
+
+  it("keeps a file that matches any of several tokens", () => {
+    const result = filterFilesByAccept(files, ".tif, text/plain");
+    expect(result.map((f) => f.name)).toEqual(["image.tif", "readme.txt"]);
   });
 });

--- a/src/utils/fileUpload.test.ts
+++ b/src/utils/fileUpload.test.ts
@@ -1,101 +1,42 @@
-import { describe, it, expect } from "vitest";
-import { getFilesFromDataTransfer } from "./fileUpload";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The folder-traversal itself is delegated to (and tested by) `file-selector`.
+// These tests cover the logic this module adds on top: extracting File objects
+// from whatever `fromEvent` returns and sorting them by natural name order.
+vi.mock("file-selector", () => ({
+  fromEvent: vi.fn(),
+}));
+
+import { fromEvent } from "file-selector";
+import { getFilesFromDrop } from "./fileUpload";
+
+const mockFromEvent = vi.mocked(fromEvent);
 
 function makeFile(name: string): File {
   return new File(["content"], name);
 }
 
-// Minimal fakes for the File and Directory Entries API used by folder drops.
-function fileEntry(name: string): FileSystemFileEntry {
-  return {
-    isFile: true,
-    isDirectory: false,
-    name,
-    file: (resolve: (file: File) => void) => resolve(makeFile(name)),
-  } as unknown as FileSystemFileEntry;
-}
+const dropEvent = { type: "drop" } as unknown as DragEvent;
 
-function directoryEntry(
-  name: string,
-  children: FileSystemEntry[],
-): FileSystemDirectoryEntry {
-  return {
-    isFile: false,
-    isDirectory: true,
-    name,
-    createReader: () => {
-      let returned = false;
-      return {
-        // Return all children on the first call, then an empty batch to signal
-        // the end, mirroring the real readEntries contract.
-        readEntries: (resolve: (entries: FileSystemEntry[]) => void) => {
-          resolve(returned ? [] : children);
-          returned = true;
-        },
-      };
-    },
-  } as unknown as FileSystemDirectoryEntry;
-}
-
-function dataTransfer(
-  entries: (FileSystemEntry | null)[],
-  files: File[],
-): DataTransfer {
-  const items = entries.map((entry) => ({
-    webkitGetAsEntry: () => entry,
-  }));
-  return { items, files } as unknown as DataTransfer;
-}
-
-describe("getFilesFromDataTransfer", () => {
-  it("returns an empty array for a null DataTransfer", async () => {
-    expect(await getFilesFromDataTransfer(null)).toEqual([]);
+describe("getFilesFromDrop", () => {
+  beforeEach(() => {
+    mockFromEvent.mockReset();
   });
 
-  it("falls back to plain files when the entries API is unavailable", async () => {
-    const file = makeFile("plain.tif");
-    const dt = { files: [file] } as unknown as DataTransfer;
-    expect(await getFilesFromDataTransfer(dt)).toEqual([file]);
+  it("returns the files extracted from the drop event", async () => {
+    mockFromEvent.mockResolvedValue([makeFile("a.tif"), makeFile("b.tif")]);
+    const files = await getFilesFromDrop(dropEvent);
+    expect(mockFromEvent).toHaveBeenCalledWith(dropEvent);
+    expect(files.map((f) => f.name)).toEqual(["a.tif", "b.tif"]);
   });
 
-  it("returns dropped top-level files", async () => {
-    const dt = dataTransfer([fileEntry("a.tif")], [makeFile("a.tif")]);
-    const files = await getFilesFromDataTransfer(dt);
-    expect(files.map((f) => f.name)).toEqual(["a.tif"]);
-  });
-
-  it("recurses into dropped folders, including nested subfolders", async () => {
-    const tree = directoryEntry("root", [
-      fileEntry("a.tif"),
-      fileEntry("b.tif"),
-      directoryEntry("nested", [fileEntry("c.tif")]),
+  it("sorts files in natural (numeric-aware) name order", async () => {
+    mockFromEvent.mockResolvedValue([
+      makeFile("frame10.tif"),
+      makeFile("frame2.tif"),
+      makeFile("frame1.tif"),
     ]);
-    const dt = dataTransfer([tree], []);
-    const files = await getFilesFromDataTransfer(dt);
-    expect(files.map((f) => f.name).sort()).toEqual([
-      "a.tif",
-      "b.tif",
-      "c.tif",
-    ]);
-  });
-
-  it("handles a mix of dropped files and folders", async () => {
-    const dt = dataTransfer(
-      [fileEntry("top.tif"), directoryEntry("folder", [fileEntry("in.tif")])],
-      [],
-    );
-    const files = await getFilesFromDataTransfer(dt);
-    expect(files.map((f) => f.name).sort()).toEqual(["in.tif", "top.tif"]);
-  });
-
-  it("returns files in natural (numeric-aware) name order", async () => {
-    const tree = directoryEntry("root", [
-      fileEntry("frame10.tif"),
-      fileEntry("frame2.tif"),
-      fileEntry("frame1.tif"),
-    ]);
-    const dt = dataTransfer([tree], []);
-    const files = await getFilesFromDataTransfer(dt);
+    const files = await getFilesFromDrop(dropEvent);
     // Natural sort keeps frame2 before frame10 (a plain lexical sort would not).
     expect(files.map((f) => f.name)).toEqual([
       "frame1.tif",
@@ -104,11 +45,17 @@ describe("getFilesFromDataTransfer", () => {
     ]);
   });
 
-  it("sorts the plain-files fallback by name", async () => {
-    const dt = {
-      files: [makeFile("b.tif"), makeFile("a.tif")],
-    } as unknown as DataTransfer;
-    const files = await getFilesFromDataTransfer(dt);
-    expect(files.map((f) => f.name)).toEqual(["a.tif", "b.tif"]);
+  it("drops non-File entries (e.g. DataTransferItem) defensively", async () => {
+    mockFromEvent.mockResolvedValue([
+      makeFile("real.tif"),
+      { kind: "file" } as unknown as DataTransferItem,
+    ]);
+    const files = await getFilesFromDrop(dropEvent);
+    expect(files.map((f) => f.name)).toEqual(["real.tif"]);
+  });
+
+  it("returns an empty array when nothing is extracted", async () => {
+    mockFromEvent.mockResolvedValue([]);
+    expect(await getFilesFromDrop(dropEvent)).toEqual([]);
   });
 });

--- a/src/utils/fileUpload.test.ts
+++ b/src/utils/fileUpload.test.ts
@@ -87,4 +87,28 @@ describe("getFilesFromDataTransfer", () => {
     const files = await getFilesFromDataTransfer(dt);
     expect(files.map((f) => f.name).sort()).toEqual(["in.tif", "top.tif"]);
   });
+
+  it("returns files in natural (numeric-aware) name order", async () => {
+    const tree = directoryEntry("root", [
+      fileEntry("frame10.tif"),
+      fileEntry("frame2.tif"),
+      fileEntry("frame1.tif"),
+    ]);
+    const dt = dataTransfer([tree], []);
+    const files = await getFilesFromDataTransfer(dt);
+    // Natural sort keeps frame2 before frame10 (a plain lexical sort would not).
+    expect(files.map((f) => f.name)).toEqual([
+      "frame1.tif",
+      "frame2.tif",
+      "frame10.tif",
+    ]);
+  });
+
+  it("sorts the plain-files fallback by name", async () => {
+    const dt = {
+      files: [makeFile("b.tif"), makeFile("a.tif")],
+    } as unknown as DataTransfer;
+    const files = await getFilesFromDataTransfer(dt);
+    expect(files.map((f) => f.name)).toEqual(["a.tif", "b.tif"]);
+  });
 });

--- a/src/utils/fileUpload.ts
+++ b/src/utils/fileUpload.ts
@@ -36,6 +36,19 @@ function fileFromEntry(entry: FileSystemFileEntry): Promise<File> {
   return new Promise((resolve, reject) => entry.file(resolve, reject));
 }
 
+// Sort files by name using natural (numeric-aware) ordering so image sequences
+// like frame1, frame2, frame10 come back in the expected order. Files gathered
+// from a folder drop or a folder picker have no inherent order, so we sort them
+// for deterministic dataset naming and dimension assignment.
+function sortByName(files: File[]): File[] {
+  return files.sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }),
+  );
+}
+
 async function filesFromEntry(entry: FileSystemEntry): Promise<File[]> {
   if (entry.isFile) {
     return [await fileFromEntry(entry as FileSystemFileEntry)];
@@ -69,7 +82,7 @@ export async function getFilesFromDataTransfer(
     typeof items[0].webkitGetAsEntry === "function";
 
   if (!supportsEntries) {
-    return [...dataTransfer.files];
+    return sortByName([...dataTransfer.files]);
   }
 
   // webkitGetAsEntry() must be called synchronously while the drop event is
@@ -84,31 +97,72 @@ export async function getFilesFromDataTransfer(
   }
 
   if (entries.length === 0) {
-    return [...dataTransfer.files];
+    return sortByName([...dataTransfer.files]);
   }
 
   const files = await Promise.all(entries.map(filesFromEntry));
-  return files.flat();
+  return sortByName(files.flat());
 }
 
 /**
- * Open a native folder picker and resolve with every file contained in the
- * chosen folder (recursively). Resolves with an empty array if the user
- * cancels the dialog.
+ * Open a native file/folder picker and resolve with the selected files,
+ * sorted by name. Resolves with an empty array if the dialog is dismissed.
+ *
+ * Creates a fresh detached <input> on every call: calling .click() on a
+ * newly-created, unattached input avoids Chrome's issue where a programmatic
+ * .click() on an existing DOM-attached input can be silently blocked.
  */
-export function selectFilesFromFolder(): Promise<File[]> {
+function openFilePicker(
+  options: { directory?: boolean } = {},
+): Promise<File[]> {
   return new Promise((resolve) => {
     const input = document.createElement("input");
     input.type = "file";
     input.multiple = true;
-    // `webkitdirectory` turns the picker into a folder chooser. It is not in
-    // the standard HTMLInputElement typings, so set it via attribute.
-    input.setAttribute("webkitdirectory", "");
-    input.addEventListener("change", () => {
-      resolve([...(input.files ?? [])]);
-    });
-    // Some browsers fire `cancel` when the dialog is dismissed; resolve empty.
-    input.addEventListener("cancel", () => resolve([]));
+    if (options.directory) {
+      // `webkitdirectory` turns the picker into a folder chooser. It is not in
+      // the standard HTMLInputElement typings, so set it via attribute.
+      input.setAttribute("webkitdirectory", "");
+    }
+
+    let settled = false;
+    const settle = (files: File[]) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      window.removeEventListener("focus", onCancel, true);
+      resolve(sortByName(files));
+    };
+
+    // The `change` event fires with the selection once the dialog closes.
+    input.addEventListener("change", () => settle([...(input.files ?? [])]));
+    // The `cancel` event fires when the dialog is dismissed (modern browsers).
+    input.addEventListener("cancel", () => settle([]));
+    // Fallback for browsers without `cancel`: when the dialog closes the window
+    // regains focus. If no `change` fired shortly after, treat it as a cancel
+    // so the promise always settles. `change` populates input.files before it
+    // fires, so it always wins the race when a selection was made.
+    const onCancel = () => window.setTimeout(() => settle([]), 500);
+    window.addEventListener("focus", onCancel, true);
+
     input.click();
   });
+}
+
+/**
+ * Open a native file picker (multiple files) and resolve with the selected
+ * files, sorted by name.
+ */
+export function selectFiles(): Promise<File[]> {
+  return openFilePicker();
+}
+
+/**
+ * Open a native folder picker and resolve with every file contained in the
+ * chosen folder (recursively), sorted by name. Resolves with an empty array if
+ * the user cancels the dialog.
+ */
+export function selectFilesFromFolder(): Promise<File[]> {
+  return openFilePicker({ directory: true });
 }

--- a/src/utils/fileUpload.ts
+++ b/src/utils/fileUpload.ts
@@ -38,6 +38,40 @@ export async function getFilesFromDrop(event: DragEvent): Promise<File[]> {
   return toSortedFiles(await fromEvent(event));
 }
 
+function matchesAcceptToken(file: File, token: string): boolean {
+  if (token.startsWith(".")) {
+    // Extension token, e.g. ".tif"
+    return file.name.toLowerCase().endsWith(token.toLowerCase());
+  }
+  const type = file.type.toLowerCase();
+  if (token.endsWith("/*")) {
+    // Wildcard MIME token, e.g. "image/*"
+    return type.startsWith(token.slice(0, token.indexOf("/") + 1));
+  }
+  // Exact MIME token, e.g. "image/png"
+  return type === token;
+}
+
+/**
+ * Filter files against an HTML `accept` attribute string (comma-separated
+ * extensions and/or MIME types, e.g. ".tif,.png,image/*"). An empty/undefined
+ * accept means "accept everything". This mirrors the constraint the native
+ * file input applies, which browsers do NOT enforce for folder selection or
+ * drag-and-drop, so callers must apply it themselves for those paths.
+ */
+export function filterFilesByAccept(files: File[], accept?: string): File[] {
+  const tokens = (accept ?? "")
+    .split(",")
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length > 0);
+  if (tokens.length === 0) {
+    return files;
+  }
+  return files.filter((file) =>
+    tokens.some((token) => matchesAcceptToken(file, token)),
+  );
+}
+
 /**
  * Open a native file/folder picker and resolve with the selected files,
  * sorted by name. Resolves with an empty array if the dialog is dismissed.

--- a/src/utils/fileUpload.ts
+++ b/src/utils/fileUpload.ts
@@ -1,46 +1,19 @@
 // Helpers for turning a folder selection or a folder drag-and-drop into a flat
 // list of File objects.
 //
-// Two browser APIs are involved:
-//  - The HTML directory picker (`<input type="file" webkitdirectory>`) returns
-//    every file in the chosen folder tree directly on `input.files`, so those
-//    just need to be collected.
-//  - Dragging a folder onto a dropzone only exposes the folder through the
-//    (non-standard but widely supported) File and Directory Entries API on
-//    `DataTransferItem.webkitGetAsEntry()`. `DataTransfer.files` alone does not
-//    recurse into dropped directories, so we walk the entry tree ourselves.
-
-function readEntriesBatch(
-  reader: FileSystemDirectoryReader,
-): Promise<FileSystemEntry[]> {
-  return new Promise((resolve, reject) => {
-    reader.readEntries(resolve, reject);
-  });
-}
-
-// readEntries only returns a bounded number of entries per call (100 in
-// Chromium), so it must be called repeatedly until it returns an empty batch.
-async function readAllDirectoryEntries(
-  reader: FileSystemDirectoryReader,
-): Promise<FileSystemEntry[]> {
-  const entries: FileSystemEntry[] = [];
-  let batch = await readEntriesBatch(reader);
-  while (batch.length > 0) {
-    entries.push(...batch);
-    batch = await readEntriesBatch(reader);
-  }
-  return entries;
-}
-
-function fileFromEntry(entry: FileSystemFileEntry): Promise<File> {
-  return new Promise((resolve, reject) => entry.file(resolve, reject));
-}
+// The actual extraction is delegated to `file-selector` (the library
+// react-dropzone uses): its `fromEvent` handles both a drop's DataTransfer
+// (recursing into dropped folders via the File and Directory Entries API) and
+// an <input> change event, normalizing both into File objects that also carry
+// their in-folder `path`/`relativePath`. We add natural-order sorting on top so
+// image sequences upload deterministically.
+import { fromEvent, FileWithPath } from "file-selector";
 
 // Sort files by name using natural (numeric-aware) ordering so image sequences
 // like frame1, frame2, frame10 come back in the expected order. Files gathered
 // from a folder drop or a folder picker have no inherent order, so we sort them
 // for deterministic dataset naming and dimension assignment.
-function sortByName(files: File[]): File[] {
+function sortByName<T extends File>(files: T[]): T[] {
   return files.sort((a, b) =>
     a.name.localeCompare(b.name, undefined, {
       numeric: true,
@@ -49,59 +22,20 @@ function sortByName(files: File[]): File[] {
   );
 }
 
-async function filesFromEntry(entry: FileSystemEntry): Promise<File[]> {
-  if (entry.isFile) {
-    return [await fileFromEntry(entry as FileSystemFileEntry)];
-  }
-  if (entry.isDirectory) {
-    const reader = (entry as FileSystemDirectoryEntry).createReader();
-    const childEntries = await readAllDirectoryEntries(reader);
-    const nested = await Promise.all(childEntries.map(filesFromEntry));
-    return nested.flat();
-  }
-  return [];
+// `fromEvent` can return DataTransferItem entries for non-drop drag events;
+// for our drop/change cases it returns File objects. Keep only real files.
+function toSortedFiles(items: (FileWithPath | DataTransferItem)[]): File[] {
+  return sortByName(
+    items.filter((item): item is FileWithPath => item instanceof File),
+  );
 }
 
 /**
- * Extract all files from a drop's DataTransfer, recursing into any dropped
- * folders. Falls back to the plain `files` list when the entries API is
- * unavailable (e.g. older browsers), in which case dropped folders are ignored
- * by the browser as before.
+ * Extract all files from a drop event, recursing into any dropped folders and
+ * returning them sorted by name.
  */
-export async function getFilesFromDataTransfer(
-  dataTransfer: DataTransfer | null,
-): Promise<File[]> {
-  if (!dataTransfer) {
-    return [];
-  }
-
-  const items = dataTransfer.items;
-  const supportsEntries =
-    items &&
-    items.length > 0 &&
-    typeof items[0].webkitGetAsEntry === "function";
-
-  if (!supportsEntries) {
-    return sortByName([...dataTransfer.files]);
-  }
-
-  // webkitGetAsEntry() must be called synchronously while the drop event is
-  // being handled, before any await, because the DataTransferItemList is
-  // cleared once the handler returns.
-  const entries: FileSystemEntry[] = [];
-  for (const item of items) {
-    const entry = item.webkitGetAsEntry();
-    if (entry) {
-      entries.push(entry);
-    }
-  }
-
-  if (entries.length === 0) {
-    return sortByName([...dataTransfer.files]);
-  }
-
-  const files = await Promise.all(entries.map(filesFromEntry));
-  return sortByName(files.flat());
+export async function getFilesFromDrop(event: DragEvent): Promise<File[]> {
+  return toSortedFiles(await fromEvent(event));
 }
 
 /**
@@ -126,24 +60,24 @@ function openFilePicker(
     }
 
     let settled = false;
-    const settle = (files: File[]) => {
+    const settle = async (event: Event | null) => {
       if (settled) {
         return;
       }
       settled = true;
       window.removeEventListener("focus", onCancel, true);
-      resolve(sortByName(files));
+      resolve(event ? toSortedFiles(await fromEvent(event)) : []);
     };
 
     // The `change` event fires with the selection once the dialog closes.
-    input.addEventListener("change", () => settle([...(input.files ?? [])]));
+    input.addEventListener("change", (event) => settle(event));
     // The `cancel` event fires when the dialog is dismissed (modern browsers).
-    input.addEventListener("cancel", () => settle([]));
+    input.addEventListener("cancel", () => settle(null));
     // Fallback for browsers without `cancel`: when the dialog closes the window
     // regains focus. If no `change` fired shortly after, treat it as a cancel
     // so the promise always settles. `change` populates input.files before it
     // fires, so it always wins the race when a selection was made.
-    const onCancel = () => window.setTimeout(() => settle([]), 500);
+    const onCancel = () => window.setTimeout(() => settle(null), 500);
     window.addEventListener("focus", onCancel, true);
 
     input.click();

--- a/src/utils/fileUpload.ts
+++ b/src/utils/fileUpload.ts
@@ -8,6 +8,7 @@
 // their in-folder `path`/`relativePath`. We add natural-order sorting on top so
 // image sequences upload deterministically.
 import { fromEvent, FileWithPath } from "file-selector";
+import { logError } from "@/utils/log";
 
 // Sort files by name using natural (numeric-aware) ordering so image sequences
 // like frame1, frame2, frame10 come back in the expected order. Files gathered
@@ -35,7 +36,15 @@ function toSortedFiles(items: (FileWithPath | DataTransferItem)[]): File[] {
  * returning them sorted by name.
  */
 export async function getFilesFromDrop(event: DragEvent): Promise<File[]> {
-  return toSortedFiles(await fromEvent(event));
+  try {
+    return toSortedFiles(await fromEvent(event));
+  } catch (error) {
+    // file-selector can reject on exotic drops (e.g. a directory entry it
+    // cannot read). Degrade to "nothing dropped" rather than leaving the
+    // async drop handler with an unhandled rejection.
+    logError("Failed to read dropped files", error);
+    return [];
+  }
 }
 
 function matchesAcceptToken(file: File, token: string): boolean {
@@ -99,20 +108,29 @@ function openFilePicker(
         return;
       }
       settled = true;
-      window.removeEventListener("focus", onCancel, true);
-      resolve(event ? toSortedFiles(await fromEvent(event)) : []);
+      try {
+        resolve(event ? toSortedFiles(await fromEvent(event)) : []);
+      } catch (error) {
+        // Never leave the picker promise unresolved: an error extracting the
+        // selection must still settle (as "no selection"), or every caller
+        // awaiting selectFiles()/selectFilesFromFolder() would hang forever.
+        logError("Failed to read selected files", error);
+        resolve([]);
+      }
     };
 
     // The `change` event fires with the selection once the dialog closes.
     input.addEventListener("change", (event) => settle(event));
-    // The `cancel` event fires when the dialog is dismissed (modern browsers).
+    // The `cancel` event fires when the dialog is dismissed. It is supported in
+    // every browser we target (Chrome 113+, Firefox 91+, Safari 16.4+).
+    //
+    // We deliberately do NOT add a window-`focus` fallback to force settlement.
+    // For a folder pick, the window regains focus the moment the OS dialog
+    // closes, but `input.files` is not populated until the user accepts
+    // Chrome's "Upload N files?" confirmation, which fires `change` seconds
+    // later. A focus-triggered timeout would settle with an empty selection in
+    // that gap and silently discard the chosen folder.
     input.addEventListener("cancel", () => settle(null));
-    // Fallback for browsers without `cancel`: when the dialog closes the window
-    // regains focus. If no `change` fired shortly after, treat it as a cancel
-    // so the promise always settles. `change` populates input.files before it
-    // fires, so it always wins the race when a selection was made.
-    const onCancel = () => window.setTimeout(() => settle(null), 500);
-    window.addEventListener("focus", onCancel, true);
 
     input.click();
   });

--- a/src/utils/fileUpload.ts
+++ b/src/utils/fileUpload.ts
@@ -1,0 +1,114 @@
+// Helpers for turning a folder selection or a folder drag-and-drop into a flat
+// list of File objects.
+//
+// Two browser APIs are involved:
+//  - The HTML directory picker (`<input type="file" webkitdirectory>`) returns
+//    every file in the chosen folder tree directly on `input.files`, so those
+//    just need to be collected.
+//  - Dragging a folder onto a dropzone only exposes the folder through the
+//    (non-standard but widely supported) File and Directory Entries API on
+//    `DataTransferItem.webkitGetAsEntry()`. `DataTransfer.files` alone does not
+//    recurse into dropped directories, so we walk the entry tree ourselves.
+
+function readEntriesBatch(
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> {
+  return new Promise((resolve, reject) => {
+    reader.readEntries(resolve, reject);
+  });
+}
+
+// readEntries only returns a bounded number of entries per call (100 in
+// Chromium), so it must be called repeatedly until it returns an empty batch.
+async function readAllDirectoryEntries(
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> {
+  const entries: FileSystemEntry[] = [];
+  let batch = await readEntriesBatch(reader);
+  while (batch.length > 0) {
+    entries.push(...batch);
+    batch = await readEntriesBatch(reader);
+  }
+  return entries;
+}
+
+function fileFromEntry(entry: FileSystemFileEntry): Promise<File> {
+  return new Promise((resolve, reject) => entry.file(resolve, reject));
+}
+
+async function filesFromEntry(entry: FileSystemEntry): Promise<File[]> {
+  if (entry.isFile) {
+    return [await fileFromEntry(entry as FileSystemFileEntry)];
+  }
+  if (entry.isDirectory) {
+    const reader = (entry as FileSystemDirectoryEntry).createReader();
+    const childEntries = await readAllDirectoryEntries(reader);
+    const nested = await Promise.all(childEntries.map(filesFromEntry));
+    return nested.flat();
+  }
+  return [];
+}
+
+/**
+ * Extract all files from a drop's DataTransfer, recursing into any dropped
+ * folders. Falls back to the plain `files` list when the entries API is
+ * unavailable (e.g. older browsers), in which case dropped folders are ignored
+ * by the browser as before.
+ */
+export async function getFilesFromDataTransfer(
+  dataTransfer: DataTransfer | null,
+): Promise<File[]> {
+  if (!dataTransfer) {
+    return [];
+  }
+
+  const items = dataTransfer.items;
+  const supportsEntries =
+    items &&
+    items.length > 0 &&
+    typeof items[0].webkitGetAsEntry === "function";
+
+  if (!supportsEntries) {
+    return [...dataTransfer.files];
+  }
+
+  // webkitGetAsEntry() must be called synchronously while the drop event is
+  // being handled, before any await, because the DataTransferItemList is
+  // cleared once the handler returns.
+  const entries: FileSystemEntry[] = [];
+  for (const item of items) {
+    const entry = item.webkitGetAsEntry();
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+
+  if (entries.length === 0) {
+    return [...dataTransfer.files];
+  }
+
+  const files = await Promise.all(entries.map(filesFromEntry));
+  return files.flat();
+}
+
+/**
+ * Open a native folder picker and resolve with every file contained in the
+ * chosen folder (recursively). Resolves with an empty array if the user
+ * cancels the dialog.
+ */
+export function selectFilesFromFolder(): Promise<File[]> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.multiple = true;
+    // `webkitdirectory` turns the picker into a folder chooser. It is not in
+    // the standard HTMLInputElement typings, so set it via attribute.
+    input.setAttribute("webkitdirectory", "");
+    input.addEventListener("change", () => {
+      resolve([...(input.files ?? [])]);
+    });
+    // Some browsers fire `cancel` when the dialog is dismissed; resolve empty.
+    input.addEventListener("cancel", () => resolve([]));
+    input.click();
+  });
+}

--- a/src/views/Home.test.ts
+++ b/src/views/Home.test.ts
@@ -898,7 +898,7 @@ describe("Home", () => {
   // 18. handleDrop
   // =========================================================================
   describe("handleDrop", () => {
-    it("sets pendingFiles and shows upload dialog from drop event", () => {
+    it("sets pendingFiles and shows upload dialog from drop event", async () => {
       const wrapper = mountComponent();
       const vm = wrapper.vm as any;
       vm.isDragging = true;
@@ -909,7 +909,7 @@ describe("Home", () => {
         dataTransfer: { files: [file] },
       } as unknown as DragEvent;
 
-      vm.handleDrop(event);
+      await vm.handleDrop(event);
 
       expect(vm.isDragging).toBe(false);
       expect(vm.pendingFiles).toHaveLength(1);
@@ -917,13 +917,13 @@ describe("Home", () => {
       expect(vm.showUploadDialog).toBe(true);
     });
 
-    it("does nothing when no files in drop event", () => {
+    it("does nothing when no files in drop event", async () => {
       const wrapper = mountComponent();
       const vm = wrapper.vm as any;
       vm.isDragging = true;
 
       const event = { dataTransfer: { files: [] } } as any;
-      vm.handleDrop(event);
+      await vm.handleDrop(event);
 
       expect(vm.isDragging).toBe(false);
       expect(vm.showUploadDialog).toBe(false);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -521,6 +521,7 @@ import RecentDatasets from "@/components/RecentDatasets.vue";
 import { isConfigurationItem, isDatasetFolder } from "@/utils/girderSelectable";
 import {
   getFilesFromDataTransfer,
+  selectFiles,
   selectFilesFromFolder,
 } from "@/utils/fileUpload";
 import { formatDateNumber, formatDate } from "@/utils/date";
@@ -1022,49 +1023,25 @@ function comprehensiveUpload(
   router.push({ name: "newdataset" });
 }
 
-async function handleDrop(event: DragEvent) {
-  isDragging.value = false;
-  const files = await getFilesFromDataTransfer(event.dataTransfer);
+function beginUpload(files: File[]) {
   if (files.length > 0) {
     pendingFiles.value = files;
     initializeUploadDialog();
     showUploadDialog.value = true;
   }
+}
+
+async function handleDrop(event: DragEvent) {
+  isDragging.value = false;
+  beginUpload(await getFilesFromDataTransfer(event.dataTransfer));
+}
+
+async function openFileSelector() {
+  beginUpload(await selectFiles());
 }
 
 async function openFolderSelector() {
-  const files = await selectFilesFromFolder();
-  if (files.length > 0) {
-    pendingFiles.value = files;
-    initializeUploadDialog();
-    showUploadDialog.value = true;
-  }
-}
-
-function openFileSelector() {
-  // Create a temporary <input type="file"> on each click.
-  // Calling .click() on a freshly-created, detached input avoids Chrome's
-  // issue where programmatic .click() on an existing DOM-attached input
-  // (inside Vuetify's <v-card>) is silently blocked.
-  const input = document.createElement("input");
-  input.type = "file";
-  input.multiple = true;
-  input.addEventListener("change", handleFileSelect);
-  input.click();
-}
-
-function handleFileSelect(event: Event) {
-  const input = event.target as HTMLInputElement;
-  const files = Array.from(input.files || []);
-
-  if (files.length > 0) {
-    pendingFiles.value = files;
-    initializeUploadDialog();
-    showUploadDialog.value = true;
-  }
-
-  // Reset the input
-  input.value = "";
+  beginUpload(await selectFilesFromFolder());
 }
 
 function initializeUploadDialog() {
@@ -1344,7 +1321,7 @@ defineExpose({
   handleDrop,
   openFileSelector,
   openFolderSelector,
-  handleFileSelect,
+  beginUpload,
   initializeUploadDialog,
   handleAcceptDefaults,
   handleConfigureDataset,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -520,7 +520,7 @@ import ZenodoCommunityDisplay from "@/components/ZenodoCommunityDisplay.vue";
 import RecentDatasets from "@/components/RecentDatasets.vue";
 import { isConfigurationItem, isDatasetFolder } from "@/utils/girderSelectable";
 import {
-  getFilesFromDataTransfer,
+  getFilesFromDrop,
   selectFiles,
   selectFilesFromFolder,
 } from "@/utils/fileUpload";
@@ -1033,7 +1033,7 @@ function beginUpload(files: File[]) {
 
 async function handleDrop(event: DragEvent) {
   isDragging.value = false;
-  beginUpload(await getFilesFromDataTransfer(event.dataTransfer));
+  beginUpload(await getFilesFromDrop(event));
 }
 
 async function openFileSelector() {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -50,7 +50,7 @@
                     class="text-h6 text-white text-center"
                     style="pointer-events: none"
                   >
-                    Drop files here to upload
+                    Drop files or a folder here to upload
                   </div>
                 </v-overlay>
 
@@ -63,10 +63,21 @@
                   <div class="text-center">
                     <div class="text-h6 mb-2">Upload files</div>
                     <div class="text-body-2 mb-2">
-                      Click or drag here to upload files. You can choose to
-                      accept default settings or configure advanced options
-                      after selecting files.
+                      Click or drag here to upload files. You can also drag a
+                      folder or use the button below to upload every file in a
+                      folder. You can choose to accept default settings or
+                      configure advanced options after selecting files.
                     </div>
+                    <v-btn
+                      variant="tonal"
+                      color="primary"
+                      size="small"
+                      class="mb-2"
+                      @click.stop="openFolderSelector"
+                    >
+                      <v-icon start>mdi-folder-upload</v-icon>
+                      Upload a folder
+                    </v-btn>
                     <div class="text-caption">
                       Dataset will be uploaded to folder:
                       <strong>{{ locationName }}</strong>
@@ -508,6 +519,10 @@ import ZenodoImporter from "@/components/ZenodoImporter.vue";
 import ZenodoCommunityDisplay from "@/components/ZenodoCommunityDisplay.vue";
 import RecentDatasets from "@/components/RecentDatasets.vue";
 import { isConfigurationItem, isDatasetFolder } from "@/utils/girderSelectable";
+import {
+  getFilesFromDataTransfer,
+  selectFilesFromFolder,
+} from "@/utils/fileUpload";
 import { formatDateNumber, formatDate } from "@/utils/date";
 import { logError } from "@/utils/log";
 import Persister from "@/store/Persister";
@@ -1007,9 +1022,18 @@ function comprehensiveUpload(
   router.push({ name: "newdataset" });
 }
 
-function handleDrop(event: DragEvent) {
+async function handleDrop(event: DragEvent) {
   isDragging.value = false;
-  const files = Array.from(event.dataTransfer?.files || []);
+  const files = await getFilesFromDataTransfer(event.dataTransfer);
+  if (files.length > 0) {
+    pendingFiles.value = files;
+    initializeUploadDialog();
+    showUploadDialog.value = true;
+  }
+}
+
+async function openFolderSelector() {
+  const files = await selectFilesFromFolder();
   if (files.length > 0) {
     pendingFiles.value = files;
     initializeUploadDialog();
@@ -1319,6 +1343,7 @@ defineExpose({
   onLocationUpdate,
   handleDrop,
   openFileSelector,
+  openFolderSelector,
   handleFileSelect,
   initializeUploadDialog,
   handleAcceptDefaults,


### PR DESCRIPTION
## Summary

Adds the ability to upload an entire folder and get all of the files within it, in addition to selecting individual files. Previously users could upload one or many files, but not a folder.

This works two ways:
- **Drag-and-drop a folder** onto the upload area — every file inside (including nested subfolders) is collected into the dataset.
- **Click "Upload a folder" / "Select a folder instead"** — opens a native folder picker.

Folders are flattened to their contained files (subfolder structure isn't preserved), which matches how NimbusImage builds a multi-file dataset.

## Changes

- **`src/utils/fileUpload.ts`** (new) — shared upload helpers:
  - `getFilesFromDrop(event)` — extracts files from a drop, recursing into dropped folders. Delegates the folder traversal to the [`file-selector`](https://www.npmjs.com/package/file-selector) library (the same one react-dropzone uses), which handles browser quirks and preserves each file's in-folder path.
  - `selectFiles()` / `selectFilesFromFolder()` — open a native file or folder picker via a shared `openFilePicker` helper.
  - Results are sorted by natural (numeric-aware) name order so image sequences (`frame1`, `frame2`, `frame10`) upload deterministically.
- **`src/components/Files/FileDropzone.vue`** — dropping a folder now flattens all contained files; adds a "Select a folder instead" button. This automatically covers the New Dataset dropzones, which reuse this component.
- **`src/views/Home.vue`** — the upload card supports folder drag-and-drop and adds an "Upload a folder" button; the picker/drop logic is deduped into a shared `beginUpload` helper.
- **Dependency:** adds `file-selector` (`^2.1.2`).

## Testing

- `pnpm tsc`, `pnpm lint:ci`, and `pnpm build` all clean.
- Full suite passes (2281 tests), including new tests for the sort/filter logic in `fileUpload.ts` and updated async drop tests.
- Note: the native picker and `DataTransferItem` entries can't be exercised in jsdom, so a manual drag-a-folder check in a real browser is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAuZjJTyyMDaUEMnCMrjXs