### PR TITLE
Agentic data analysis in the AI panel (builds on #1231, supersedes #1221)

### DIFF
--- a/codebaseDocumentation/AI_PANEL_DATA_ANALYSIS_SPEC.md
+++ b/codebaseDocumentation/AI_PANEL_DATA_ANALYSIS_SPEC.md
@@ -13,18 +13,29 @@
 > `src/agent/executors.ts`, the tool schemas + "Analyzing data" prompt
 > section in the `girder-claude-chat` data files, `kind:"plot"` transcript
 > items with `AiPanelPlot.vue` (lazy Plotly), and IndexedDB plot
-> persistence. `pnpm tsc` / `lint:ci` clean; 125 `src/agent` tests pass.
+> persistence. `pnpm tsc` / `lint:ci` clean; 189 `src/agent` + `src/store`
+> tests pass.
 >
-> **Live-verified** against dataset `69f4eb65aaba948c2d7b9b24` (2,618 nuclei
-> with computed intensity + morphology properties): histogram, scatter
-> (colorByTag → per-tag WebGL traces), box (groupByTag), and query
-> restriction all render inline and read back correct stats (matched
-> MongoDB ground truth: Area n=5237, mean 367.9, std 106.6, range 25-975;
-> query→nucleus dropped n to 2618). Confirmed the raw-data invariant on the
-> wire (plot tool_results ~23 KB, no raw value arrays), conversation +
-> full plot data persisted and re-rendered across reload, a mixed
-> analysis→`set_annotation_filter` turn with working revert, and that the
-> production build code-splits Plotly into its own 4.6 MB lazy chunk.
+> **Follow-up fixes on this branch** (from live testing):
+> - **Live-set intersection** (§2, §5.1) — analysis excludes property values
+>   orphaned by deleted annotations; backend cleanup gap filed as
+>   [issue #1243](https://github.com/arjunrajlaboratory/NimbusImage/issues/1243).
+> - **Hydration guard** — fixed a pre-existing race in `aiPanel.ts` where
+>   clearing the conversation during the post-reload IndexedDB hydration could
+>   strand the `hydrating` send-guard and silently block all sends (dedicated
+>   `hydrationGeneration` counter + regression test).
+>
+> **Live-verified** against dataset `69f4eb65aaba948c2d7b9b24`: histogram,
+> scatter (colorByTag → per-tag WebGL traces), box (groupByTag), and query
+> restriction all render inline and read back correct stats. Stats matched
+> MongoDB ground truth for the 2,618 live nuclei (Area mean 367.9, std 106.6,
+> range 25-975); after the live-set fix the unrestricted scatter shows 2,618
+> points (was 5,237 = 2,618 nuclei + 2,619 orphaned values). Confirmed the
+> raw-data invariant on the wire (plot tool_results ~23 KB, no raw value
+> arrays), conversation + full plot data persisted and re-rendered across
+> reload, a mixed analysis→`set_annotation_filter` turn with working revert,
+> and that the production build code-splits Plotly into its own 4.6 MB lazy
+> chunk.
 >
 > Companion docs: `AI_PANEL_SPEC.md` (panel architecture),
 > `AI_PANEL_REVIEW.md` (review tracker).
@@ -95,6 +106,13 @@ browser-held annotation/value set, same as the whole app. Server-side
 aggregation (the #1221 approach) becomes relevant only if datasets outgrow
 frontend memory — see `AI_PANEL_SPEC.md` §4.1. The tool *semantics* here
 are chosen to survive that migration (aggregates in, aggregates out).
+
+Scope of "the annotations": analysis is restricted to annotations that
+currently exist (the live in-memory set), not to every property-value document.
+The two can diverge — the backend leaves property values orphaned after
+annotation deletion (issue #1243) — and analysis must reflect real objects, so
+the tools intersect with the live set (§5.1). A query narrows within that set;
+no query means all live annotations.
 
 ## 3. Data flow
 
@@ -271,14 +289,24 @@ export function computeStats(values: number[]): IPathStats; // mean/std/median/p
 export function uniformHistogram(values: number[], buckets: number): IHistogramBucket[];
 ```
 
-Plus a `collectPathValues(path, allowedIds?)` helper in `executors.ts`
-(needs the stores): returns `[annotationId, number][]` from
-`propertyStore.propertyValues`, restricted by an optional id set from
-`queryAnnotations`. The extended `get_property_values`, both `get_*`
-inspection tools and all three plot tools share it. Each analysis executor
-starts with `await propertyStore.fetchPropertyValues()` — the precedent set
-by the existing `get_property_values` executor, and what makes "compute
-then plot" turns see fresh values.
+Plus a `collectPathValues(path, allowedIds)` helper in `executors.ts`
+(needs the stores): returns `[annotationId, number][]` by walking a set of
+annotation ids and reading `propertyStore.propertyValues[id]`. **It iterates
+the query's matches when a query was given (`queryAnnotations`, already
+restricted to live annotations), else every id in the live annotation set
+(`liveAnnotationIdSet()` = `annotationStore.annotations` ids) — never the raw
+`propertyValues` keys.** This matters: property-value documents can outlive
+their annotation (a backend cleanup gap leaves values orphaned after
+deletion — tracked in
+[issue #1243](https://github.com/arjunrajlaboratory/NimbusImage/issues/1243)),
+so iterating `propertyValues` directly would count deleted annotations and add
+a spurious "untagged" group to tag-grouped plots. The extended
+`get_property_values`, `get_property_histogram`, and all three plot tools go
+through `collectPathValues`; `get_sample_values` applies the same live-set
+intersection inline. Each analysis executor starts with
+`await propertyStore.fetchPropertyValues()` — the precedent set by the existing
+`get_property_values` executor, and what makes "compute then plot" turns see
+fresh values.
 
 ### 5.2 New module: `src/agent/plotRegistry.ts`
 
@@ -476,19 +504,31 @@ Also verify the Plotly chunk is absent from the initial bundle
 (`pnpm build` output / network tab: plotly chunk loads only when the first
 plot renders).
 
-## 9. Open questions
+## 9. Resolved decisions & open questions
 
-1. **Tag grouping uses the first tag only** (#1221 behavior, keeps traces
-   bounded). Multi-tag annotations appear once, under their first tag. If
-   this proves confusing, an explicit `groupByTags: string[]` (one trace
-   per listed tag, membership-based, annotations may repeat) is a later
-   schema-compatible addition.
-2. **Should plot tools auto-refresh values?** They call
+**Resolved during implementation:**
+
+- **Tag grouping uses the first tag only** (kept — #1221 behavior, bounds the
+  trace count). A multi-tag annotation appears once, under its first tag. An
+  explicit `groupByTags: string[]` (one trace per listed tag, membership-based,
+  annotations may repeat) stays a later schema-compatible addition if this
+  proves confusing; not doing it now.
+- **Orphaned property values are excluded** (§2 "Scope", §5.1). Live testing
+  surfaced a spurious "untagged" group in tag-grouped plots: property-value
+  documents for deleted annotations that the backend never cleaned up
+  (~2,619 of 5,237 on the test dataset). Fixed client-side by intersecting with
+  the live annotation set; the backend data-hygiene bug is filed as
+  [issue #1243](https://github.com/arjunrajlaboratory/NimbusImage/issues/1243)
+  and is independent of this feature.
+
+**Still open:**
+
+1. **Should plot tools auto-refresh values?** They call
    `fetchPropertyValues()` per call (matching `get_property_values`);
    on very large datasets several calls per turn re-download the value
    pages. If this shows up in practice, add a per-turn fetch memo in the
    executor context rather than changing tool semantics.
-3. **Correlation/regression tool?** A `get_correlation` (Pearson/Spearman
+2. **Correlation/regression tool?** A `get_correlation` (Pearson/Spearman
    for two paths) would ground "summarize the correlation" numerically
    instead of the model estimating from a plot it cannot see. Cheap to add
    in `analysis.ts`; deferred to keep v1 minimal — the stats tools already

--- a/codebaseDocumentation/AI_PANEL_DATA_ANALYSIS_SPEC.md
+++ b/codebaseDocumentation/AI_PANEL_DATA_ANALYSIS_SPEC.md
@@ -1,11 +1,30 @@
 # AI Panel — Agentic Data Analysis (Design Spec)
 
-> **Status: spec, not yet implemented.** Branch
+> **Status: implemented and live-verified** on branch
 > `claude/ai-panel-data-analysis`, forked from the AI-panel branch
 > (`claude/ai-panel-interface-spec-9k6gsv`, PR #1231). Supersedes the
 > standalone analysis panel of PR #1221
 > (`claude/analysis-panel-agents-mgi32d`), which should be closed once this
 > lands.
+>
+> **Implemented (commits on this branch):** phase 1 — `src/agent/analysis.ts`
+> stat helpers + `src/agent/plotRegistry.ts` + `plotly.js-dist-min` dep;
+> phases 2-3 — five new executors and the extended `get_property_values` in
+> `src/agent/executors.ts`, the tool schemas + "Analyzing data" prompt
+> section in the `girder-claude-chat` data files, `kind:"plot"` transcript
+> items with `AiPanelPlot.vue` (lazy Plotly), and IndexedDB plot
+> persistence. `pnpm tsc` / `lint:ci` clean; 125 `src/agent` tests pass.
+>
+> **Live-verified** against dataset `69f4eb65aaba948c2d7b9b24` (2,618 nuclei
+> with computed intensity + morphology properties): histogram, scatter
+> (colorByTag → per-tag WebGL traces), box (groupByTag), and query
+> restriction all render inline and read back correct stats (matched
+> MongoDB ground truth: Area n=5237, mean 367.9, std 106.6, range 25-975;
+> query→nucleus dropped n to 2618). Confirmed the raw-data invariant on the
+> wire (plot tool_results ~23 KB, no raw value arrays), conversation +
+> full plot data persisted and re-rendered across reload, a mixed
+> analysis→`set_annotation_filter` turn with working revert, and that the
+> production build code-splits Plotly into its own 4.6 MB lazy chunk.
 >
 > Companion docs: `AI_PANEL_SPEC.md` (panel architecture),
 > `AI_PANEL_REVIEW.md` (review tracker).

--- a/codebaseDocumentation/AI_PANEL_DATA_ANALYSIS_SPEC.md
+++ b/codebaseDocumentation/AI_PANEL_DATA_ANALYSIS_SPEC.md
@@ -1,0 +1,476 @@
+# AI Panel — Agentic Data Analysis (Design Spec)
+
+> **Status: spec, not yet implemented.** Branch
+> `claude/ai-panel-data-analysis`, forked from the AI-panel branch
+> (`claude/ai-panel-interface-spec-9k6gsv`, PR #1231). Supersedes the
+> standalone analysis panel of PR #1221
+> (`claude/analysis-panel-agents-mgi32d`), which should be closed once this
+> lands.
+>
+> Companion docs: `AI_PANEL_SPEC.md` (panel architecture),
+> `AI_PANEL_REVIEW.md` (review tracker).
+
+## 1. Goal
+
+Let the Nimbus AI panel answer *data* questions about computed annotation
+property values — "plot intensity vs area colored by tag and summarize the
+correlation", "is the spot-count distribution bimodal?", "compare nucleus
+area across my tags" — by giving the existing agent:
+
+1. **Richer statistics** (std, median, quartiles) than today's
+   `get_property_values` count/mean/min/max.
+2. **Inspection tools** (histogram buckets, sample rows) so it looks at the
+   data before drawing conclusions.
+3. **Plot-creation tools** (scatter, histogram, box) whose output renders as
+   interactive Plotly charts inline in the panel transcript.
+
+PR #1221 built this as a *separate* panel with a *server-side* agent loop.
+That PR is used here as inspiration only — its tool semantics, caps, and
+Plotly rendering carry over; its architecture does not.
+
+## 2. Why build on the AI panel (and what changes vs PR #1221)
+
+PR #1221 ran the whole agent loop in the Girder plugin because it predated
+the panel's frontend loop. On this branch the loop already runs in the
+browser (`src/store/aiPanel.ts`), the backend is a stateless relay
+(`POST /claude_agent`), and — decisively — **the frontend already holds all
+per-annotation property values in memory**:
+
+- `propertyStore.propertyValues` (`src/store/properties.ts:74`) — the full
+  `{annotationId → nested values}` map, fetched via the paged
+  `annotation_property_values` endpoint (uncapped, `markRaw`).
+- `propertyStore.computedPropertyPaths` — every computed value path.
+- `annotationStore.annotations` — tags/shape per annotation (for grouping).
+- `queryAnnotations` + `validateAnnotationQuery` in
+  `src/agent/executors.ts` — the shared annotation-query resolver every
+  targeting tool already uses.
+
+So the analysis tools become **plain frontend executors** — no new backend
+endpoints, no second agent loop, no new access-control or rate-limiting
+surface. The `/claude_agent` relay, gating, transcript, persistence and
+per-user rate limits are reused as-is.
+
+**The PR #1221 invariant is preserved**: raw values never enter the model's
+context. Plot executors assemble the full Plotly trace arrays *client-side*
+and register them in a panel-local plot registry; the model receives only
+`{plotId, title, pointCount}` as the tool result. Statistics/histogram
+tools return aggregates.
+
+What this buys over #1221's separate panel:
+
+- **One conversation.** Analysis interleaves with interface control:
+  "compute area on the nuclei, plot it, then filter the viewer to the top
+  decile and color them red" is a single agent turn mixing
+  `compute_property`, `create_histogram_plot`, `set_annotation_filter`,
+  and `color_annotations`.
+- **Query-based restriction for free.** Every analysis tool accepts the
+  same `query` object (`tags`/`shape`/`channel`/`currentFrameOnly`/`ids`)
+  as `list_annotations`, so "plot intensity of just the spot-tagged
+  annotations on this frame" needs no new machinery. #1221 only had
+  `color_by_tag`.
+- **Existing safety rails**: dataset-identity checks per tool call,
+  stop/cancel, conversation persistence, user-change clearing.
+
+Known ceiling (inherited, not added): the analysis operates on the
+browser-held annotation/value set, same as the whole app. Server-side
+aggregation (the #1221 approach) becomes relevant only if datasets outgrow
+frontend memory — see `AI_PANEL_SPEC.md` §4.1. The tool *semantics* here
+are chosen to survive that migration (aggregates in, aggregates out).
+
+## 3. Data flow
+
+```
+User: "plot intensity vs area colored by tag"
+  └─ aiPanel.sendUserMessage → POST /claude_agent (unchanged relay)
+       └─ model calls get_property_values → executor summarizes from
+          propertyStore.propertyValues → stats JSON back to model
+       └─ model calls create_scatter_plot {xPropertyPath, yPropertyPath,
+          colorByTag, title}
+            └─ executor: fetchPropertyValues() → resolve paths per
+               annotation → group by first tag → build Plotly traces
+            └─ plotRegistry.register(plot)          [data stays here]
+            └─ tool result to model: {plotId, title, pointCount}
+            └─ transcript item {kind: "plot", plotId} → AiPanelPlot.vue
+               lazy-imports plotly.js-dist-min and renders the chart
+       └─ model writes a short markdown summary referencing plot titles
+```
+
+## 4. Tool surface
+
+Six changes to `agent_tools.json` + `src/agent/executors.ts`: one extended
+tool, five new. All are **read-only w.r.t. stored data** (plots are panel
+state, not dataset state) → **none are gated**, none join
+`VIEW_STATE_TOOLS` (revert doesn't remove plots).
+
+Conventions (match the existing surface, not #1221): camelCase input
+fields; property paths are **arrays of segments** (`["propId", "subId"]`),
+exactly the `propertyPath` arrays that `get_property_values` returns and
+`set_annotation_filter.propertyFilters` consumes — the model already knows
+this currency. Every numeric result is rounded to 6 significant digits.
+
+### 4.1 Extend `get_property_values` (existing)
+
+Add to each per-path stats entry: `std` (population-of-sample stdev, 0 for
+n=1), `median`, `p25`, `p75` (inclusive quantiles on the sorted array), all
+rounded. Keep existing fields (`propertyId`, `property`, `path`,
+`propertyPath`, `count`, `mean`, `min`, `max` — round `mean`/`min`/`max`
+too). The single pass in `executors.ts:1422` gains one sort per path;
+arrays are in-memory, this is fine. Update the tool description: "…summary
+statistics (count, mean, std, min, max, median, p25, p75)…".
+
+### 4.2 `get_property_histogram` (new)
+
+Binned distribution of one property path, computed client-side with
+uniform bins over `[min, max]`.
+
+```jsonc
+{
+  "name": "get_property_histogram",
+  "description": "Get a binned histogram (min, max, count per bucket) for one numeric property value path across annotations, optionally restricted by a query (same shape as list_annotations). Use this to inspect the distribution shape (skew, modality, outliers) of a property before deciding what to plot or conclude. Read-only.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "propertyPath": {
+        "type": "array", "items": { "type": "string" },
+        "description": "Property value path segments, as returned by get_property_values' propertyPath."
+      },
+      "buckets": {
+        "type": "integer", "minimum": 1, "maximum": 200,
+        "description": "Number of buckets (default 50, max 200)."
+      },
+      "query": { "type": "object", "description": "Annotation filter (same fields as list_annotations' query)." }
+    },
+    "required": ["propertyPath"],
+    "additionalProperties": false
+  }
+}
+```
+
+Result: `{ buckets: [{min, max, count}, …], totalCount }`. Empty/all
+non-numeric values → `ToolExecutionError` ("no numeric values for path …;
+see get_property_values for available paths") so the model can recover.
+Constant-valued data (min == max) → single bucket.
+
+### 4.3 `get_sample_values` (new)
+
+```jsonc
+{
+  "name": "get_sample_values",
+  "description": "Get up to n sample rows (annotation id, tags, plus the value for each requested property path) so you can eyeball raw data before drawing conclusions. Rows are sampled evenly across the dataset, not the first n. Read-only; default 20 rows, max 100.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "propertyPaths": {
+        "type": "array",
+        "items": { "type": "array", "items": { "type": "string" } },
+        "description": "Property value paths (each an array of segments)."
+      },
+      "n": { "type": "integer", "minimum": 1, "maximum": 100 },
+      "query": { "type": "object", "description": "Annotation filter (same fields as list_annotations' query)." }
+    },
+    "required": ["propertyPaths"],
+    "additionalProperties": false
+  }
+}
+```
+
+Result rows: `{annotationId, tags, "<dotted.path>": value|null}`. Sampling
+= every k-th matching annotation id (deterministic `downsample` helper).
+
+### 4.4 `create_scatter_plot` (new)
+
+```jsonc
+{
+  "name": "create_scatter_plot",
+  "description": "Create an interactive scatter plot of one property against another, rendered inline in the panel. Annotations missing a numeric value on either axis are dropped. Optionally color points by each annotation's first tag, and/or restrict annotations with a query. Returns a plotId and point count — the raw points are never sent back to you, they render directly for the user. Refer to the plot by its title in your reply.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "xPropertyPath": { "type": "array", "items": { "type": "string" } },
+      "yPropertyPath": { "type": "array", "items": { "type": "string" } },
+      "title": { "type": "string" },
+      "xLabel": { "type": "string", "description": "Optional x-axis label; defaults to the property's full name." },
+      "yLabel": { "type": "string" },
+      "colorByTag": { "type": "boolean", "description": "One trace per first-tag (untagged grouped together)." },
+      "query": { "type": "object", "description": "Annotation filter (same fields as list_annotations' query)." }
+    },
+    "required": ["xPropertyPath", "yPropertyPath", "title"],
+    "additionalProperties": false
+  }
+}
+```
+
+Executor: intersect annotations having numeric values on both paths;
+downsample to `MAX_PLOT_POINTS` (50 000) with "(downsampled)" appended to
+the title; traces are `scattergl`, `mode: "markers"`,
+`marker: {size: 5, opacity: 0.7}`. Result:
+`{plotId, title, pointCount, downsampled}`.
+Zero overlapping points → `ToolExecutionError` naming both paths' counts.
+
+### 4.5 `create_histogram_plot` (new)
+
+Same binning as `get_property_histogram` (default 50, max 200 buckets),
+rendered as a Plotly `bar` trace with bin centers/widths (`bargap: 0`).
+Inputs: `propertyPath` (required), `title` (required), `buckets`, `xLabel`,
+`query`. Result: `{plotId, title, bucketCount}`.
+
+### 4.6 `create_box_plot` (new)
+
+Inputs: `propertyPaths` (array of paths, required), `title` (required),
+`groupByTag` (boolean — valid only with exactly one path: one box per
+first-tag), `query`. Each trace's values downsampled to `MAX_BOX_POINTS`
+(20 000); trace names are the property full name (or tag). Result:
+`{plotId, title, traceCount}`.
+
+### 4.7 Axis-label defaulting
+
+When `xLabel`/`yLabel` is omitted, default to
+`propertyStore.getFullNameFromPath(path)` (falls back to the dotted path
+if unnamed) — this is what users see elsewhere in the app.
+
+## 5. Frontend design
+
+### 5.1 New module: `src/agent/analysis.ts`
+
+Pure helpers, unit-testable without the store (ports of #1221's Python
+helpers):
+
+```typescript
+export const MAX_PLOT_POINTS = 50000;
+export const MAX_BOX_POINTS = 20000;
+export const MAX_HISTOGRAM_BUCKETS = 200;
+export const MAX_SAMPLE_ROWS = 100;
+export const SIGNIFICANT_DIGITS = 6;
+
+export function roundSignificant(value: number | null): number | null;
+// Every-k-th deterministic downsample; returns [items, wasDownsampled].
+export function downsample<T>(items: T[], limit: number): [T[], boolean];
+// Walk path segments through a nested values object; number | null.
+// (typeof === "number" && !isNaN — no boolean hazard in JS.)
+export function resolvePathValue(values: any, path: string[]): number | null;
+export function computeStats(values: number[]): IPathStats; // mean/std/median/p25/p75/min/max/count
+export function uniformHistogram(values: number[], buckets: number): IHistogramBucket[];
+```
+
+Plus a `collectPathValues(path, allowedIds?)` helper in `executors.ts`
+(needs the stores): returns `[annotationId, number][]` from
+`propertyStore.propertyValues`, restricted by an optional id set from
+`queryAnnotations`. The extended `get_property_values`, both `get_*`
+inspection tools and all three plot tools share it. Each analysis executor
+starts with `await propertyStore.fetchPropertyValues()` — the precedent set
+by the existing `get_property_values` executor, and what makes "compute
+then plot" turns see fresh values.
+
+### 5.2 New module: `src/agent/plotRegistry.ts`
+
+Plot data must not live in Vuex (large arrays, no reactivity wanted — same
+reasoning as `wireMessages`) and executors must not import the aiPanel
+store (circular import). A tiny module both sides import:
+
+```typescript
+export interface IAgentPlot {
+  id: string;          // "plot-<n>", monotonically increasing
+  title: string;
+  data: unknown[];     // Plotly traces
+  layout: Record<string, unknown>; // titles/axis labels only; theming applied at render
+}
+export function registerPlot(plot: Omit<IAgentPlot, "id">): IAgentPlot;
+export function getPlot(id: string): IAgentPlot | undefined;
+export function listPlots(): IAgentPlot[];       // for persistence
+export function restorePlots(plots: IAgentPlot[]): void; // hydration; keeps id counter ahead
+export function clearPlots(): void;
+```
+
+### 5.3 Wiring plots into the transcript
+
+- `IToolExecutionResult` (`src/agent/executors.ts`) gains
+  `plots?: IAgentPlot[]` alongside the existing `images` channel. Plot
+  executors register with `registerPlot` and return the created plot there.
+- `aiPanel.executeToolUse` pushes, after the tool card, one
+  `{kind: "plot", plotId, text: title}` item per returned plot.
+  `IAgentPanelItem` gains `kind: "plot"` and optional `plotId`.
+- `clearConversation` calls `clearPlots()`.
+
+### 5.4 New component: `src/components/AiPanelPlot.vue`
+
+Props: `plotId: string`. Direct adaptation of #1221's `AnalysisPlot.vue`:
+
+- Looks up `getPlot(plotId)`; if missing (pruned from persistence), renders
+  a muted placeholder: *"This plot wasn't saved — ask the assistant to
+  recreate it."*
+- Lazy `import("plotly.js-dist-min")` inside the render call so Plotly
+  (~1 MB gzipped) never lands in the main bundle; module-level cache;
+  handle the CJS interop (`module.default ?? module`).
+- Layout: `autosize`, height 300, tight margins, transparent
+  paper/plot background, font color from
+  `theme.current.value.colors["on-surface"]`, then spread the registered
+  plot's own layout. Config `{responsive: true, displaylogo: false}`.
+- Render once on mount (registry entries are immutable — no deep watch,
+  unlike #1221). `Plotly.purge` on unmount.
+- Errors → `logError` + placeholder text, never a crash in the transcript.
+
+`AiPanel.vue` template gains one branch:
+`<ai-panel-plot v-else-if="item.kind === 'plot'" :plot-id="item.plotId!" />`
+styled `align-self: stretch`. Panel dimensions unchanged (plots ~470 px
+wide is fine for v1); a click-to-enlarge `v-dialog` is optional polish.
+
+### 5.5 Persistence (`src/agent/conversationStore.ts`)
+
+`IStoredAgentConversation` gains `plots?: IAgentPlot[]`. On save
+(`aiPanel.sendUserMessage` finally-block), include `listPlots()` subject
+to caps; on hydrate (`handleAuthenticatedUserChange`), `restorePlots`.
+Caps, applied at save time:
+
+- Keep only plots referenced by a current item, newest-first, max
+  `MAX_STORED_PLOTS = 12`.
+- Skip any single plot whose `JSON.stringify` length exceeds 3 000 000
+  chars (a 50k-point scatter is ≈1.5 M — fits; a many-trace monster
+  doesn't).
+
+Dropped plots simply hit the `AiPanelPlot` placeholder after reload —
+never an error. The wire conversation is unaffected (tool results only
+ever contained `{plotId, …}`), so `pruneOldScreenshots` needs no changes.
+
+### 5.6 `describeAgentToolCall` entries
+
+Human-readable one-liners (guarding all field access, as the function
+requires): `get_property_histogram` → `Read histogram of <dotted path>`;
+`get_sample_values` → `Read N sample values`; `create_scatter_plot` →
+`Create scatter plot "<title>"`; likewise histogram/box. Tool-card
+`detail` via `toolResultDetail`: add a `pointCount` case ("12,340
+points").
+
+### 5.7 Dependency
+
+`plotly.js-dist-min ^3.6.0` (dependencies) + the one-line ambient module
+declaration `src/plotly-dist-min.d.ts` (both exactly as in PR #1221).
+`dompurify`/`marked` are already on this branch via
+`utils/renderMarkdown.ts` — no change.
+
+## 6. Backend changes
+
+**No Python changes.** Two data files in
+`devops/girder/plugins/girder-claude-chat/girder_claude_chat/`:
+
+1. `agent_tools.json` — the five new tool definitions + the updated
+   `get_property_values` description (§4).
+2. `agent_system_prompt.txt` — add one "Analyzing data" section after the
+   "Reading data efficiently" section:
+
+   ```
+   Analyzing data:
+   - For data-analysis requests ("plot X vs Y", "how is X distributed",
+     "compare X across tags"), inspect before you conclude: use
+     get_property_values (statistics) and get_property_histogram; use
+     get_sample_values if you need to eyeball raw rows.
+   - Then create plots with create_scatter_plot / create_histogram_plot /
+     create_box_plot — they render as interactive charts in the panel, so
+     favor creating a plot over describing one. Typically 1-3 plots.
+     All plot tools accept the same query filter as list_annotations,
+     so plot exactly the subset the user asked about.
+   - Property paths for all analysis tools are the propertyPath arrays
+     returned by get_property_values.
+   - Refer to plots by their title in your summary, and finish with a
+     concise quantitative summary. If a property is missing or
+     non-numeric, say so rather than fabricating results.
+   ```
+
+**Deployment note:** the plugin is baked into the Girder image — after
+editing either file, `docker compose build girder && docker compose up -d`
+(a restart is not enough) before live testing.
+
+## 7. Explicitly out of scope (v1)
+
+- **Server-side aggregation endpoints** — the browser already holds the
+  values; revisit only when datasets outgrow frontend memory
+  (`AI_PANEL_SPEC.md` §4.1).
+- **A separate analysis panel / endpoint** — PR #1221's
+  `claude_analysis` endpoint, `AnalysisPanel.vue`, `AnalysisAPI.ts` are
+  superseded; that PR gets closed, not merged.
+- **Other plot types** (violin, heatmap, line/time-series) — the plumbing
+  (registry → AiPanelPlot) makes each a small executor + schema addition
+  later. Time-series over T using annotation location is the most likely
+  next ask.
+- **Plot export** (PNG/CSV download) — Plotly's modebar already gives
+  camera-icon PNG export for free; nothing custom.
+- **Derived/computed columns** (ratios, log transforms) — that's the
+  code-execution tier (Option B in `AI_PANEL_SPEC.md` §5), not curated
+  tools.
+
+## 8. Implementation plan (subagent-sized tasks)
+
+Sequential phases; each leaves `pnpm tsc && pnpm lint:ci && pnpm test`
+green. Suggested delegation in brackets — anything touching
+`executors.ts`/`aiPanel.ts` semantics should be Sonnet-or-better; pure
+ports and tests can go lower.
+
+**Phase 1 — helpers + registry (no behavior change).** [sonnet, or haiku
+with review] Create `src/agent/analysis.ts` (§5.1) and
+`src/agent/plotRegistry.ts` (§5.2) with unit tests
+(`analysis.test.ts`, `plotRegistry.test.ts`): stats vs hand-computed
+values (incl. n=1, empty), downsample determinism and size bound,
+histogram edge cases (constant values, single bucket, empty), rounding.
+Add the `plotly.js-dist-min` dependency + `src/plotly-dist-min.d.ts`
+(`pnpm install` to update the lockfile).
+
+**Phase 2 — executors + tool definitions.** [sonnet] In
+`src/agent/executors.ts`: `collectPathValues` helper; extend
+`get_property_values` stats; add the five executors (§4) returning
+`plots` in `IToolExecutionResult`; extend `describeAgentToolCall` and
+export types. Update `agent_tools.json` and `agent_system_prompt.txt`
+(§6). Extend `executors.test.ts` following its existing mock patterns
+(reactive store mocks — see the AnnotationViewer-harness notes): stats
+correctness through the executor, query restriction via `queryAnnotations`,
+error paths (unknown path, zero numeric values, `groupByTag` with two
+paths), downsampling trigger, plot registration side-effect.
+
+**Phase 3 — panel UI + persistence.** [sonnet] `AiPanelPlot.vue` (§5.4);
+`AiPanel.vue` plot branch; `aiPanel.ts` (`kind: "plot"` items, push plots
+from `executeToolUse`, `clearPlots` on clear, save/hydrate plots per
+§5.5); `conversationStore.ts` record field. Unit-test the persistence
+caps (drop-beyond-12, oversize skip) in `conversationStore.test.ts`.
+
+**Phase 4 — live verification.** [main session — browser tools] Rebuild
+the girder container (§6 note). On
+`http://localhost:5173/#/datasetView/69f4eb85aaba948c2d7b9da5/view`:
+
+1. If the dataset has no computed properties yet, drive the agent's own
+   `create_property`/`compute_property` flow first — that's the intended
+   end-to-end story.
+2. "How is <property> distributed?" → expect stats + histogram tool calls,
+   an inline histogram plot, and a summary that matches the numbers.
+3. "Plot <propA> vs <propB> colored by tag" → scatter with per-tag traces,
+   correct axis labels, legend; hover works; model reply references the
+   plot title and does not enumerate raw values (check the wire request in
+   devtools network tab: tool_result for the plot is just the small JSON).
+4. "Compare <property> across tags" → box plot.
+5. Restriction: "…only for the spot-tagged annotations" → point count in
+   the tool card matches the tag count from `get_annotation_summary`.
+6. Reload the page → conversation restores, plots re-render from
+   IndexedDB (and a >12-plots session shows placeholders for the oldest).
+7. Clear conversation → plots gone; switch user → gone.
+8. Mixed turn: "plot area, then filter the viewer to annotations with area
+   above the median and color them red" — analysis + interface tools
+   cooperating in one turn.
+
+Also verify the Plotly chunk is absent from the initial bundle
+(`pnpm build` output / network tab: plotly chunk loads only when the first
+plot renders).
+
+## 9. Open questions
+
+1. **Tag grouping uses the first tag only** (#1221 behavior, keeps traces
+   bounded). Multi-tag annotations appear once, under their first tag. If
+   this proves confusing, an explicit `groupByTags: string[]` (one trace
+   per listed tag, membership-based, annotations may repeat) is a later
+   schema-compatible addition.
+2. **Should plot tools auto-refresh values?** They call
+   `fetchPropertyValues()` per call (matching `get_property_values`);
+   on very large datasets several calls per turn re-download the value
+   pages. If this shows up in practice, add a per-turn fetch memo in the
+   executor context rather than changing tool semantics.
+3. **Correlation/regression tool?** A `get_correlation` (Pearson/Spearman
+   for two paths) would ground "summarize the correlation" numerically
+   instead of the model estimating from a plot it cannot see. Cheap to add
+   in `analysis.ts`; deferred to keep v1 minimal — the stats tools already
+   prevent outright fabrication.

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
@@ -72,6 +72,22 @@ Reading data efficiently:
   The user can see them in the interface. Report counts and a few notable
   examples, not every row.
 
+Analyzing data:
+- For data-analysis requests ("plot X vs Y", "how is X distributed",
+  "compare X across tags"), inspect before you conclude: use
+  get_property_values (statistics) and get_property_histogram; use
+  get_sample_values if you need to eyeball raw rows.
+- Then create plots with create_scatter_plot / create_histogram_plot /
+  create_box_plot — they render as interactive charts in the panel, so
+  favor creating a plot over describing one. Typically 1-3 plots.
+  All plot tools accept the same query filter as list_annotations,
+  so plot exactly the subset the user asked about.
+- Property paths for all analysis tools are the propertyPath arrays
+  returned by get_property_values.
+- Refer to plots by their title in your summary, and finish with a
+  concise quantitative summary. If a property is missing or
+  non-numeric, say so rather than fabricating results.
+
 Style:
 - Keep replies short. Your actions are self-evidencing — the user sees them
   happen and sees the transcript, so don't narrate each call. Summarize the

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
@@ -590,7 +590,7 @@
   },
   {
     "name": "get_property_values",
-    "description": "Read computed property values as summary statistics (count, mean, min, max) per property value path — not a per-annotation dump. Optionally restrict to one propertyId and/or filter the annotations with a query (same shape as list_annotations). Read-only. Use to answer questions like 'what's the mean intensity of my nuclei?'.",
+    "description": "Read computed property values as summary statistics (count, mean, std, min, max, median, p25, p75) per property value path — not a per-annotation dump. Optionally restrict to one propertyId and/or filter the annotations with a query (same shape as list_annotations). Read-only. Use to answer questions like 'what's the mean intensity of my nuclei?'.",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -603,6 +603,147 @@
           "description": "Annotation filter (same fields as list_annotations' query): only summarize values for matching annotations."
         }
       },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "get_property_histogram",
+    "description": "Get a binned histogram (min, max, count per bucket) for one numeric property value path across annotations, optionally restricted by a query (same shape as list_annotations). Use this to inspect the distribution shape (skew, modality, outliers) of a property before deciding what to plot or conclude. Read-only.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "propertyPath": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Property value path segments, as returned by get_property_values' propertyPath."
+        },
+        "buckets": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200,
+          "description": "Number of buckets (default 50, max 200)."
+        },
+        "query": {
+          "type": "object",
+          "description": "Annotation filter (same fields as list_annotations' query)."
+        }
+      },
+      "required": ["propertyPath"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "get_sample_values",
+    "description": "Get up to n sample rows (annotation id, tags, plus the value for each requested property path) so you can eyeball raw data before drawing conclusions. Rows are sampled evenly across the dataset, not the first n. Read-only; default 20 rows, max 100.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "propertyPaths": {
+          "type": "array",
+          "items": { "type": "array", "items": { "type": "string" } },
+          "description": "Property value paths (each an array of segments)."
+        },
+        "n": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "query": {
+          "type": "object",
+          "description": "Annotation filter (same fields as list_annotations' query)."
+        }
+      },
+      "required": ["propertyPaths"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "create_scatter_plot",
+    "description": "Create an interactive scatter plot of one property against another, rendered inline in the panel. Annotations missing a numeric value on either axis are dropped. Optionally color points by each annotation's first tag, and/or restrict annotations with a query (same shape as list_annotations). The raw points are never sent back to you — they render directly for the user; you receive only a plotId and point count. Refer to the plot by its title in your reply.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "xPropertyPath": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Property value path for the x axis (from get_property_values' propertyPath)."
+        },
+        "yPropertyPath": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Property value path for the y axis (from get_property_values' propertyPath)."
+        },
+        "title": { "type": "string" },
+        "xLabel": {
+          "type": "string",
+          "description": "Optional x-axis label; defaults to the property's full name."
+        },
+        "yLabel": {
+          "type": "string",
+          "description": "Optional y-axis label; defaults to the property's full name."
+        },
+        "colorByTag": {
+          "type": "boolean",
+          "description": "One trace per first-tag (untagged grouped together)."
+        },
+        "query": {
+          "type": "object",
+          "description": "Annotation filter (same fields as list_annotations' query)."
+        }
+      },
+      "required": ["xPropertyPath", "yPropertyPath", "title"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "create_histogram_plot",
+    "description": "Create an interactive histogram of one numeric property value path, rendered inline in the panel as a bar chart, optionally restricted by a query (same shape as list_annotations). The binned data renders directly for the user and is never sent back to you; you receive only a plotId and bucket count. Refer to the plot by its title in your reply.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "propertyPath": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Property value path segments, as returned by get_property_values' propertyPath."
+        },
+        "title": { "type": "string" },
+        "buckets": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200,
+          "description": "Number of buckets (default 50, max 200)."
+        },
+        "xLabel": {
+          "type": "string",
+          "description": "Optional x-axis label; defaults to the property's full name."
+        },
+        "query": {
+          "type": "object",
+          "description": "Annotation filter (same fields as list_annotations' query)."
+        }
+      },
+      "required": ["propertyPath", "title"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "create_box_plot",
+    "description": "Create an interactive box plot of one or more numeric property value paths, rendered inline in the panel, optionally restricted by a query (same shape as list_annotations). With groupByTag (valid only for a single path) it draws one box per annotation first-tag; otherwise one box per property path. The raw values render directly for the user and are never sent back to you; you receive only a plotId and trace count. Refer to the plot by its title in your reply.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "propertyPaths": {
+          "type": "array",
+          "items": { "type": "array", "items": { "type": "string" } },
+          "description": "Property value paths (each an array of segments, from get_property_values' propertyPath)."
+        },
+        "title": { "type": "string" },
+        "groupByTag": {
+          "type": "boolean",
+          "description": "One box per annotation first-tag; requires exactly one propertyPath."
+        },
+        "query": {
+          "type": "object",
+          "description": "Annotation filter (same fields as list_annotations' query)."
+        }
+      },
+      "required": ["propertyPaths", "title"],
       "additionalProperties": false
     }
   },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "p-limit": "^7.1.1",
     "p-retry": "^7.0.0",
     "papaparse": "^5.4.1",
+    "plotly.js-dist-min": "^3.6.0",
     "polygon-clipping": "^0.15.7",
     "qs": "^6.15.2",
     "rbush": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       papaparse:
         specifier: ^5.4.1
         version: 5.4.1
+      plotly.js-dist-min:
+        specifier: ^3.6.0
+        version: 3.7.0
       polygon-clipping:
         specifier: ^0.15.7
         version: 0.15.7
@@ -3772,6 +3775,9 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  plotly.js-dist-min@3.7.0:
+    resolution: {integrity: sha512-IRWNnBJZmKss3URDnicBK2nvt/VTSi/MD1GnUscAYFjwSuN6g/CTde5R1UC0RYtblehj8rkT4BL8r05e/c8j5Q==}
 
   polygon-clipping@0.15.7:
     resolution: {integrity: sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==}
@@ -8693,6 +8699,8 @@ snapshots:
   pinkie@2.0.4: {}
 
   platform@1.3.6: {}
+
+  plotly.js-dist-min@3.7.0: {}
 
   polygon-clipping@0.15.7:
     dependencies:

--- a/src/agent/analysis.test.ts
+++ b/src/agent/analysis.test.ts
@@ -4,6 +4,7 @@ import {
   downsample,
   resolvePathValue,
   computeStats,
+  computeBoxStats,
   uniformHistogram,
   SIGNIFICANT_DIGITS,
 } from "./analysis";
@@ -120,6 +121,25 @@ describe("computeStats", () => {
     expect(stats.median).toBe(7);
     expect(stats.p25).toBe(7);
     expect(stats.p75).toBe(7);
+  });
+});
+
+describe("computeBoxStats", () => {
+  it("clamps whisker endpoints to the Tukey (1.5*IQR) fences", () => {
+    // [1,2,3,4,5,1000]: q1=2.25, q3=4.75, IQR=2.5, upper bound=8.5 -> the 1000
+    // is an outlier, so the upper whisker ends at 5, not 1000.
+    const box = computeBoxStats([1, 2, 3, 4, 5, 1000]);
+    expect(box.q1).toBe(2.25);
+    expect(box.median).toBe(3.5);
+    expect(box.q3).toBe(4.75);
+    expect(box.lowerFence).toBe(1);
+    expect(box.upperFence).toBe(5);
+  });
+
+  it("extends whiskers to the extremes when there are no outliers", () => {
+    const box = computeBoxStats([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(box.lowerFence).toBe(1);
+    expect(box.upperFence).toBe(10);
   });
 });
 

--- a/src/agent/analysis.test.ts
+++ b/src/agent/analysis.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  roundSignificant,
+  downsample,
+  resolvePathValue,
+  computeStats,
+  uniformHistogram,
+  SIGNIFICANT_DIGITS,
+} from "./analysis";
+
+describe("roundSignificant", () => {
+  it("rounds to 6 significant digits", () => {
+    expect(SIGNIFICANT_DIGITS).toBe(6);
+    expect(roundSignificant(1.23456789)).toBe(1.23457);
+    expect(roundSignificant(123456789)).toBe(123457000);
+  });
+
+  it("passes through 0, null, and negatives", () => {
+    expect(roundSignificant(0)).toBe(0);
+    expect(roundSignificant(null)).toBeNull();
+    expect(roundSignificant(-1.23456789)).toBe(-1.23457);
+  });
+
+  it("handles very small and very large magnitudes", () => {
+    expect(roundSignificant(0.000123456789)).toBe(0.000123457);
+    expect(roundSignificant(1.23456789e21)).toBe(1.23457e21);
+  });
+
+  it("passes non-finite values through unchanged", () => {
+    expect(roundSignificant(Infinity)).toBe(Infinity);
+    expect(roundSignificant(-Infinity)).toBe(-Infinity);
+    expect(roundSignificant(NaN)).toBeNaN();
+  });
+});
+
+describe("downsample", () => {
+  it("returns the same array and false when n <= limit", () => {
+    const items = [1, 2, 3];
+    const [sampled, wasDownsampled] = downsample(items, 3);
+    expect(sampled).toBe(items);
+    expect(wasDownsampled).toBe(false);
+  });
+
+  it("takes every k-th item, preserving the first, when n > limit", () => {
+    const items = Array.from({ length: 10 }, (_, i) => i);
+    const [sampled, wasDownsampled] = downsample(items, 4);
+    // step = ceil(10 / 4) = 3 → indices 0, 3, 6, 9
+    expect(sampled).toEqual([0, 3, 6, 9]);
+    expect(sampled.length).toBeLessThanOrEqual(4);
+    expect(sampled[0]).toBe(0);
+    expect(wasDownsampled).toBe(true);
+  });
+
+  it("is deterministic and never exceeds the limit", () => {
+    const items = Array.from({ length: 101 }, (_, i) => i);
+    const [a] = downsample(items, 50);
+    const [b] = downsample(items, 50);
+    expect(a).toEqual(b);
+    expect(a.length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe("resolvePathValue", () => {
+  const values = {
+    propA: { sub1: 5, sub2: "text" },
+    propB: 42,
+    propC: { sub1: NaN },
+  };
+
+  it("resolves a nested numeric leaf", () => {
+    expect(resolvePathValue(values, ["propA", "sub1"])).toBe(5);
+    expect(resolvePathValue(values, ["propB"])).toBe(42);
+  });
+
+  it("returns null for a missing segment", () => {
+    expect(resolvePathValue(values, ["propA", "missing"])).toBeNull();
+    expect(resolvePathValue(values, ["missing", "sub"])).toBeNull();
+  });
+
+  it("returns null for a non-numeric leaf", () => {
+    expect(resolvePathValue(values, ["propA", "sub2"])).toBeNull();
+    // Descending into a number is not an object → null
+    expect(resolvePathValue(values, ["propB", "sub"])).toBeNull();
+  });
+
+  it("returns null for a NaN leaf", () => {
+    expect(resolvePathValue(values, ["propC", "sub1"])).toBeNull();
+  });
+});
+
+describe("computeStats", () => {
+  it("matches hand-computed values for [1,2,3,4]", () => {
+    const stats = computeStats([1, 2, 3, 4]);
+    expect(stats.count).toBe(4);
+    expect(stats.mean).toBe(2.5);
+    expect(stats.std).toBeCloseTo(1.29099, 5);
+    expect(stats.min).toBe(1);
+    expect(stats.max).toBe(4);
+    expect(stats.median).toBe(2.5);
+    expect(stats.p25).toBe(1.75);
+    expect(stats.p75).toBe(3.25);
+  });
+
+  it("sorts unordered input before computing percentiles", () => {
+    const stats = computeStats([4, 1, 3, 2]);
+    expect(stats.median).toBe(2.5);
+    expect(stats.p25).toBe(1.75);
+    expect(stats.p75).toBe(3.25);
+    expect(stats.min).toBe(1);
+    expect(stats.max).toBe(4);
+  });
+
+  it("handles count === 1 (std 0, all percentiles equal the value)", () => {
+    const stats = computeStats([7]);
+    expect(stats.count).toBe(1);
+    expect(stats.mean).toBe(7);
+    expect(stats.std).toBe(0);
+    expect(stats.min).toBe(7);
+    expect(stats.max).toBe(7);
+    expect(stats.median).toBe(7);
+    expect(stats.p25).toBe(7);
+    expect(stats.p75).toBe(7);
+  });
+});
+
+describe("uniformHistogram", () => {
+  it("keeps counts summing to input length with the max in the last bucket", () => {
+    const values = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const buckets = uniformHistogram(values, 5);
+    expect(buckets).toHaveLength(5);
+    const total = buckets.reduce((sum, b) => sum + b.count, 0);
+    expect(total).toBe(values.length);
+    // 10 is the max value and belongs to the last bucket
+    expect(buckets[buckets.length - 1].count).toBeGreaterThan(0);
+  });
+
+  it("has contiguous bucket bounds and keeps zero-count buckets", () => {
+    // A gap at the middle leaves interior buckets empty but present.
+    const buckets = uniformHistogram([0, 0, 10, 10], 5);
+    expect(buckets).toHaveLength(5);
+    for (let i = 0; i < buckets.length - 1; i++) {
+      expect(buckets[i + 1].min).toBe(buckets[i].max);
+    }
+    expect(buckets.some((b) => b.count === 0)).toBe(true);
+    expect(buckets.reduce((sum, b) => sum + b.count, 0)).toBe(4);
+  });
+
+  it("collapses constant data to a single bucket", () => {
+    const buckets = uniformHistogram([3, 3, 3], 10);
+    expect(buckets).toEqual([{ min: 3, max: 3, count: 3 }]);
+  });
+
+  it("collapses to a single bucket when buckets <= 1", () => {
+    const buckets = uniformHistogram([1, 2, 3, 4], 1);
+    expect(buckets).toEqual([{ min: 1, max: 4, count: 4 }]);
+  });
+});

--- a/src/agent/analysis.ts
+++ b/src/agent/analysis.ts
@@ -25,6 +25,28 @@ export interface IPathStats {
   p75: number;
 }
 
+export interface IBoxStats {
+  q1: number;
+  median: number;
+  q3: number;
+  // Whisker endpoints: the most extreme data values still within 1.5*IQR of
+  // the quartiles (Tukey), matching how Plotly draws whiskers from raw points.
+  lowerFence: number;
+  upperFence: number;
+  mean: number;
+}
+
+// Linear-interpolation percentile on an already-sorted, non-empty array,
+// matching Python statistics.quantiles(method="inclusive").
+function percentileOfSorted(sorted: number[], q: number): number {
+  const count = sorted.length;
+  const pos = (count - 1) * q;
+  const lower = Math.floor(pos);
+  const lowerValue = sorted[lower];
+  const upperValue = lower + 1 < count ? sorted[lower + 1] : lowerValue;
+  return lowerValue + (pos - lower) * (upperValue - lowerValue);
+}
+
 // Round to SIGNIFICANT_DIGITS significant digits. null passes through as null;
 // non-finite values (Infinity/NaN) pass through unchanged.
 export function roundSignificant(value: number | null): number | null {
@@ -80,22 +102,52 @@ export function computeStats(values: number[]): IPathStats {
           values.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
             (count - 1),
         );
-  const percentile = (q: number): number => {
-    const pos = (count - 1) * q;
-    const lower = Math.floor(pos);
-    const lowerValue = sorted[lower];
-    const upperValue = lower + 1 < count ? sorted[lower + 1] : lowerValue;
-    return lowerValue + (pos - lower) * (upperValue - lowerValue);
-  };
   return {
     count,
     mean,
     std,
     min: sorted[0],
     max: sorted[count - 1],
-    median: percentile(0.5),
-    p25: percentile(0.25),
-    p75: percentile(0.75),
+    median: percentileOfSorted(sorted, 0.5),
+    p25: percentileOfSorted(sorted, 0.25),
+    p75: percentileOfSorted(sorted, 0.75),
+  };
+}
+
+// Box-plot statistics over a non-empty numeric array: quartiles plus Tukey
+// whisker endpoints (the most extreme data values within 1.5*IQR of the
+// quartiles). Used to render an exact box for datasets too large to ship every
+// point; individual outlier markers are omitted, but the box and whiskers match
+// what Plotly would draw from the raw points.
+export function computeBoxStats(values: number[]): IBoxStats {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const count = sorted.length;
+  const q1 = percentileOfSorted(sorted, 0.25);
+  const q3 = percentileOfSorted(sorted, 0.75);
+  const iqr = q3 - q1;
+  const lowerBound = q1 - 1.5 * iqr;
+  const upperBound = q3 + 1.5 * iqr;
+  let lowerFence = sorted[0];
+  for (const value of sorted) {
+    if (value >= lowerBound) {
+      lowerFence = value;
+      break;
+    }
+  }
+  let upperFence = sorted[count - 1];
+  for (let i = count - 1; i >= 0; i--) {
+    if (sorted[i] <= upperBound) {
+      upperFence = sorted[i];
+      break;
+    }
+  }
+  return {
+    q1,
+    median: percentileOfSorted(sorted, 0.5),
+    q3,
+    lowerFence,
+    upperFence,
+    mean: sorted.reduce((sum, value) => sum + value, 0) / count,
   };
 }
 

--- a/src/agent/analysis.ts
+++ b/src/agent/analysis.ts
@@ -1,0 +1,135 @@
+// Pure, store-free helpers for the AI-panel data-analysis tools (ports of PR
+// #1221's Python helpers). Everything here is unit-testable without the Vuex
+// store; the executors that need store data live in executors.ts.
+
+export const MAX_PLOT_POINTS = 50000;
+export const MAX_BOX_POINTS = 20000;
+export const MAX_HISTOGRAM_BUCKETS = 200;
+export const MAX_SAMPLE_ROWS = 100;
+export const SIGNIFICANT_DIGITS = 6;
+
+export interface IHistogramBucket {
+  min: number;
+  max: number;
+  count: number;
+}
+
+export interface IPathStats {
+  count: number;
+  mean: number;
+  std: number;
+  min: number;
+  max: number;
+  median: number;
+  p25: number;
+  p75: number;
+}
+
+// Round to SIGNIFICANT_DIGITS significant digits. null passes through as null;
+// non-finite values (Infinity/NaN) pass through unchanged.
+export function roundSignificant(value: number | null): number | null {
+  if (value === null || !Number.isFinite(value)) {
+    return value;
+  }
+  return Number(value.toPrecision(SIGNIFICANT_DIGITS));
+}
+
+// Deterministic every-k-th downsample preserving order. Returns
+// [sampled, wasDownsampled]; the original array is returned untouched when it
+// already fits within the limit.
+export function downsample<T>(items: T[], limit: number): [T[], boolean] {
+  if (items.length <= limit) {
+    return [items, false];
+  }
+  const step = Math.ceil(items.length / limit);
+  const sampled: T[] = [];
+  for (let i = 0; i < items.length; i += step) {
+    sampled.push(items[i]);
+  }
+  return [sampled, true];
+}
+
+// Walk path segments through a nested values object (objects keyed by segment).
+// Returns the leaf only when it is a finite number, else null.
+export function resolvePathValue(values: any, path: string[]): number | null {
+  let current = values;
+  for (const segment of path) {
+    if (current == null || typeof current !== "object") {
+      return null;
+    }
+    current = current[segment];
+  }
+  return typeof current === "number" && Number.isFinite(current)
+    ? current
+    : null;
+}
+
+// Statistics over a non-empty numeric array (caller guarantees non-empty).
+// Unrounded — callers round. std is the sample standard deviation (n-1
+// divisor), 0 for count === 1. median/p25/p75 are linear-interpolation
+// percentiles on the sorted array, matching Python
+// statistics.quantiles(method="inclusive").
+export function computeStats(values: number[]): IPathStats {
+  const count = values.length;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mean = values.reduce((sum, value) => sum + value, 0) / count;
+  const std =
+    count === 1
+      ? 0
+      : Math.sqrt(
+          values.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
+            (count - 1),
+        );
+  const percentile = (q: number): number => {
+    const pos = (count - 1) * q;
+    const lower = Math.floor(pos);
+    const lowerValue = sorted[lower];
+    const upperValue = lower + 1 < count ? sorted[lower + 1] : lowerValue;
+    return lowerValue + (pos - lower) * (upperValue - lowerValue);
+  };
+  return {
+    count,
+    mean,
+    std,
+    min: sorted[0],
+    max: sorted[count - 1],
+    median: percentile(0.5),
+    p25: percentile(0.25),
+    p75: percentile(0.75),
+  };
+}
+
+// Uniform bins over [min, max] of the values. Constant data (min === max) or
+// buckets <= 1 collapses to a single bucket spanning [min, max] with the full
+// count. Otherwise bucket i spans [min + i*w, min + (i+1)*w] with
+// w = (max-min)/buckets; the max value lands in the last bucket (index
+// clamped). Zero-count buckets are kept for contiguous coverage. Bounds are
+// unrounded.
+export function uniformHistogram(
+  values: number[],
+  buckets: number,
+): IHistogramBucket[] {
+  let min = values[0];
+  let max = values[0];
+  for (const value of values) {
+    if (value < min) {
+      min = value;
+    }
+    if (value > max) {
+      max = value;
+    }
+  }
+  if (min === max || buckets <= 1) {
+    return [{ min, max, count: values.length }];
+  }
+  const width = (max - min) / buckets;
+  const result: IHistogramBucket[] = [];
+  for (let i = 0; i < buckets; i++) {
+    result.push({ min: min + i * width, max: min + (i + 1) * width, count: 0 });
+  }
+  for (const value of values) {
+    const index = Math.min(buckets - 1, Math.floor((value - min) / width));
+    result[index].count++;
+  }
+  return result;
+}

--- a/src/agent/conversationStore.test.ts
+++ b/src/agent/conversationStore.test.ts
@@ -4,7 +4,12 @@ import {
   loadStoredConversation,
   saveStoredConversation,
   clearStoredConversation,
+  selectPlotsForStorage,
+  MAX_STORED_PLOTS,
+  MAX_STORED_PLOT_CHARS,
 } from "./conversationStore";
+import type { IAgentPlot } from "./plotRegistry";
+import type { IAgentPanelItem } from "@/store/aiPanel";
 
 beforeEach(async () => {
   await clearStoredConversation();
@@ -39,5 +44,58 @@ describe("conversationStore", () => {
     await saveStoredConversation(record);
     await clearStoredConversation();
     expect(await loadStoredConversation()).toBeNull();
+  });
+});
+
+function makePlot(id: string, data: unknown[] = [{ x: [1] }]): IAgentPlot {
+  return { id, title: `Plot ${id}`, data, layout: {} };
+}
+
+function plotItem(plotId: string): IAgentPanelItem {
+  return { kind: "plot", plotId, text: plotId };
+}
+
+describe("selectPlotsForStorage", () => {
+  it("returns an empty array when no items reference a plot", () => {
+    expect(
+      selectPlotsForStorage(
+        [{ kind: "user", text: "hi" }],
+        [makePlot("plot-1")],
+      ),
+    ).toEqual([]);
+    expect(selectPlotsForStorage([], [makePlot("plot-1")])).toEqual([]);
+  });
+
+  it("drops plots not referenced by any transcript item", () => {
+    const plots = [makePlot("plot-1"), makePlot("plot-2"), makePlot("plot-3")];
+    expect(
+      selectPlotsForStorage(
+        [plotItem("plot-2"), { kind: "assistant", text: "done" }],
+        plots,
+      ),
+    ).toEqual([plots[1]]);
+  });
+
+  it("keeps only the newest MAX_STORED_PLOTS in insertion order", () => {
+    const plots = Array.from({ length: MAX_STORED_PLOTS + 3 }, (_, i) =>
+      makePlot(`plot-${i + 1}`),
+    );
+    const items = plots.map((plot) => plotItem(plot.id));
+    const kept = selectPlotsForStorage(items, plots);
+    expect(kept).toHaveLength(MAX_STORED_PLOTS);
+    // Registry insertion order is chronological: the LAST 12 survive,
+    // still in insertion order.
+    expect(kept).toEqual(plots.slice(3));
+  });
+
+  it("skips any single plot whose serialized size exceeds the cap", () => {
+    const oversize = makePlot("plot-2", ["x".repeat(MAX_STORED_PLOT_CHARS)]);
+    const plots = [makePlot("plot-1"), oversize, makePlot("plot-3")];
+    expect(
+      selectPlotsForStorage(
+        [plotItem("plot-1"), plotItem("plot-2"), plotItem("plot-3")],
+        plots,
+      ),
+    ).toEqual([plots[0], plots[2]]);
   });
 });

--- a/src/agent/conversationStore.ts
+++ b/src/agent/conversationStore.ts
@@ -1,5 +1,6 @@
 import type { IAgentPanelItem } from "@/store/aiPanel";
 import type { IAgentWireMessage } from "@/store/AgentAPI";
+import type { IAgentPlot } from "./plotRegistry";
 import { logError } from "@/utils/log";
 
 // Browser-local persistence for the AI-panel conversation. A single stored
@@ -20,7 +21,33 @@ export interface IStoredAgentConversation {
   userId: string;
   items: IAgentPanelItem[];
   wireMessages: IAgentWireMessage[];
+  plots?: IAgentPlot[];
   updatedAt: number;
+}
+
+export const MAX_STORED_PLOTS = 12;
+export const MAX_STORED_PLOT_CHARS = 3_000_000;
+
+// Plots worth persisting: those referenced by a current transcript item,
+// newest-first capped at MAX_STORED_PLOTS, skipping any single plot whose
+// serialized size exceeds MAX_STORED_PLOT_CHARS. Returned in original
+// (insertion) order so restorePlots keeps ids monotonic.
+export function selectPlotsForStorage(
+  items: IAgentPanelItem[],
+  plots: IAgentPlot[],
+): IAgentPlot[] {
+  const referencedIds = new Set(
+    items
+      .filter((item) => item.kind === "plot" && item.plotId)
+      .map((item) => item.plotId),
+  );
+  return plots
+    .filter(
+      (plot) =>
+        referencedIds.has(plot.id) &&
+        JSON.stringify(plot).length <= MAX_STORED_PLOT_CHARS,
+    )
+    .slice(-MAX_STORED_PLOTS);
 }
 
 function openDatabase(): Promise<IDBDatabase> {

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -166,6 +166,9 @@ vi.mock("@/store/properties", () => ({
     propertyValues: {} as any,
     computedPropertyPaths: [] as string[][],
     propertyStatuses: {} as any,
+    // Real store: a getter returning (path) => "Prop / sub" | null. Default to
+    // null here so propertyPathLabel falls back to the dotted path.
+    getFullNameFromPath: () => null as string | null,
     fetchPropertyValues: vi.fn(),
     createProperty: vi.fn(),
     computeProperty: vi.fn(),
@@ -201,6 +204,8 @@ import {
   ToolExecutionError,
   viewIdentityChangedSince,
 } from "./executors";
+import { MAX_PLOT_POINTS, MAX_SAMPLE_ROWS } from "./analysis";
+import { clearPlots, getPlot } from "./plotRegistry";
 
 const mockMain = main as any;
 const mockAnnotations = annotationStore as any;
@@ -248,8 +253,10 @@ beforeEach(() => {
   mockMain.scalebarColor = "#ffffff";
   mockMain.backgroundColor = "black";
   mockMain.drawAnnotationConnections = true;
+  mockProperties.getFullNameFromPath = () => null;
   mockVolumeView.viewMode = "2d";
   mockFilters.propertyFilters = [];
+  clearPlots();
 });
 
 describe("describeAgentToolCall", () => {
@@ -289,6 +296,11 @@ describe("describeAgentToolCall", () => {
     "create_property",
     "compute_property",
     "get_property_values",
+    "get_property_histogram",
+    "get_sample_values",
+    "create_scatter_plot",
+    "create_histogram_plot",
+    "create_box_plot",
     "read_help_topic",
     "run_worker",
     "unknown_tool",
@@ -1229,13 +1241,49 @@ describe("property tools", () => {
     );
     expect(mockProperties.fetchPropertyValues).toHaveBeenCalled();
     expect(result.stats).toHaveLength(1);
+    // Hand-computed over [10, 20, 30]: sample std sqrt(200/2)=10; inclusive
+    // quantiles p25=15, median=20, p75=25.
     expect(result.stats[0]).toMatchObject({
       propertyId: "prop1",
       property: "Intensity",
       count: 3,
       mean: 20,
+      std: 10,
       min: 10,
       max: 30,
+      median: 20,
+      p25: 15,
+      p75: 25,
+    });
+  });
+
+  it("get_property_values rounds stats to 6 significant digits", async () => {
+    mockProperties.properties = [{ id: "prop1", name: "Intensity" }];
+    mockAnnotations.annotations = [
+      makeAnnotation({ id: "a1" }),
+      makeAnnotation({ id: "a2" }),
+    ];
+    mockProperties.propertyValues = {
+      a1: { prop1: { mean: 1 } },
+      a2: { prop1: { mean: 2 } },
+    };
+    mockProperties.computedPropertyPaths = [["prop1", "mean"]];
+
+    const { result } = await executeAgentTool(
+      "get_property_values",
+      {},
+      context,
+    );
+    // Sample std of [1, 2] = sqrt(0.5) = 0.70710678… -> 6 sig digits.
+    expect(result.stats[0]).toMatchObject({
+      count: 2,
+      mean: 1.5,
+      std: 0.707107,
+      min: 1,
+      max: 2,
+      median: 1.5,
+      p25: 1.25,
+      p75: 1.75,
     });
   });
 
@@ -1285,6 +1333,377 @@ describe("property tools", () => {
       min: 0,
       max: count - 1,
       mean: (count - 1) / 2,
+    });
+  });
+});
+
+describe("data analysis tools", () => {
+  // Point a1..aN each at prop1.mean = its supplied value; tag them as given.
+  function seedValues(values: { [id: string]: number }, tags: string[] = []) {
+    mockAnnotations.annotations = Object.keys(values).map((id) =>
+      makeAnnotation({ id, tags }),
+    );
+    mockProperties.propertyValues = Object.fromEntries(
+      Object.entries(values).map(([id, v]) => [id, { prop1: { mean: v } }]),
+    );
+  }
+
+  describe("get_property_histogram", () => {
+    it("bins values so bucket counts sum to the value count", async () => {
+      seedValues({
+        a0: 0,
+        a1: 1,
+        a2: 2,
+        a3: 3,
+        a4: 4,
+        a5: 5,
+        a6: 6,
+        a7: 7,
+        a8: 8,
+        a9: 9,
+      });
+      const { result } = await executeAgentTool(
+        "get_property_histogram",
+        { propertyPath: ["prop1", "mean"], buckets: 5 },
+        context,
+      );
+      expect(result.buckets).toHaveLength(5);
+      expect(result.totalCount).toBe(10);
+      const summed = result.buckets.reduce(
+        (sum: number, b: any) => sum + b.count,
+        0,
+      );
+      expect(summed).toBe(10);
+    });
+
+    it("restricts the histogram to a query", async () => {
+      // a1/a2 tagged keep, a3/a4 untagged; the query keeps only the tagged two.
+      mockAnnotations.annotations = [
+        makeAnnotation({ id: "a1", tags: ["keep"] }),
+        makeAnnotation({ id: "a2", tags: ["keep"] }),
+        makeAnnotation({ id: "a3", tags: [] }),
+        makeAnnotation({ id: "a4", tags: [] }),
+      ];
+      mockProperties.propertyValues = {
+        a1: { prop1: { mean: 1 } },
+        a2: { prop1: { mean: 2 } },
+        a3: { prop1: { mean: 3 } },
+        a4: { prop1: { mean: 4 } },
+      };
+      const all = await executeAgentTool(
+        "get_property_histogram",
+        { propertyPath: ["prop1", "mean"] },
+        context,
+      );
+      expect(all.result.totalCount).toBe(4);
+      const restricted = await executeAgentTool(
+        "get_property_histogram",
+        { propertyPath: ["prop1", "mean"], query: { tags: ["keep"] } },
+        context,
+      );
+      expect(restricted.result.totalCount).toBe(2);
+    });
+
+    it("errors helpfully on a path with no numeric values", async () => {
+      seedValues({ a1: 1, a2: 2 });
+      await expect(
+        executeAgentTool(
+          "get_property_histogram",
+          { propertyPath: ["prop1", "missing"] },
+          context,
+        ),
+      ).rejects.toThrow(/prop1\.missing.*get_property_values/s);
+    });
+
+    it("clamps buckets above the maximum", async () => {
+      seedValues({
+        a0: 0,
+        a1: 1,
+        a2: 2,
+        a3: 3,
+        a4: 4,
+        a5: 5,
+        a6: 6,
+        a7: 7,
+        a8: 8,
+        a9: 9,
+      });
+      const { result } = await executeAgentTool(
+        "get_property_histogram",
+        { propertyPath: ["prop1", "mean"], buckets: 1000 },
+        context,
+      );
+      // MAX_HISTOGRAM_BUCKETS is 200.
+      expect(result.buckets).toHaveLength(200);
+    });
+  });
+
+  describe("get_sample_values", () => {
+    it("returns rows of id, tags and requested path values (null if missing)", async () => {
+      mockAnnotations.annotations = [
+        makeAnnotation({ id: "a1", tags: ["nucleus"] }),
+        makeAnnotation({ id: "a2", tags: [] }),
+        makeAnnotation({ id: "a3", tags: ["spot"] }),
+      ];
+      mockProperties.propertyValues = {
+        a1: { prop1: { mean: 10 } },
+        a2: { prop1: { mean: 20 } },
+        a3: {},
+      };
+      const { result } = await executeAgentTool(
+        "get_sample_values",
+        { propertyPaths: [["prop1", "mean"]] },
+        context,
+      );
+      expect(result.totalMatching).toBe(3);
+      expect(result.rows).toHaveLength(3);
+      const byId = Object.fromEntries(
+        result.rows.map((row: any) => [row.annotationId, row]),
+      );
+      expect(byId.a1).toMatchObject({
+        tags: ["nucleus"],
+        "prop1.mean": 10,
+      });
+      // a3 has no value on the path -> null, not dropped.
+      expect(byId.a3["prop1.mean"]).toBeNull();
+    });
+
+    it("clamps n to MAX_SAMPLE_ROWS", async () => {
+      const values: { [id: string]: any } = {};
+      const annotations: any[] = [];
+      for (let i = 0; i < 300; i++) {
+        annotations.push(makeAnnotation({ id: `a${i}` }));
+        values[`a${i}`] = { prop1: { mean: i } };
+      }
+      mockAnnotations.annotations = annotations;
+      mockProperties.propertyValues = values;
+      const { result } = await executeAgentTool(
+        "get_sample_values",
+        { propertyPaths: [["prop1", "mean"]], n: 1000 },
+        context,
+      );
+      expect(result.rows).toHaveLength(MAX_SAMPLE_ROWS);
+      expect(result.totalMatching).toBe(300);
+    });
+
+    it("rejects an empty propertyPaths array", async () => {
+      seedValues({ a1: 1 });
+      await expect(
+        executeAgentTool("get_sample_values", { propertyPaths: [] }, context),
+      ).rejects.toBeInstanceOf(ToolExecutionError);
+    });
+  });
+
+  describe("create_scatter_plot", () => {
+    it("plots only annotations with a numeric value on both axes", async () => {
+      mockAnnotations.annotations = [
+        makeAnnotation({ id: "a1" }),
+        makeAnnotation({ id: "a2" }),
+        makeAnnotation({ id: "a3" }),
+      ];
+      mockProperties.propertyValues = {
+        a1: { px: { v: 1 }, py: { v: 2 } },
+        a2: { px: { v: 3 } }, // no y -> dropped
+        a3: { py: { v: 4 } }, // no x -> dropped
+      };
+      const { result, plots } = await executeAgentTool(
+        "create_scatter_plot",
+        {
+          xPropertyPath: ["px", "v"],
+          yPropertyPath: ["py", "v"],
+          title: "x vs y",
+        },
+        context,
+      );
+      expect(result.pointCount).toBe(1);
+      expect(result.downsampled).toBe(false);
+      expect(plots).toHaveLength(1);
+      // The plot is registered and retrievable, with full-precision points.
+      const plot = getPlot(result.plotId);
+      expect(plot).toBeDefined();
+      const trace = (plot!.data as any[])[0];
+      expect(trace.type).toBe("scattergl");
+      expect(trace.x).toEqual([1]);
+      expect(trace.y).toEqual([2]);
+    });
+
+    it("colors by first tag with one trace per tag plus untagged", async () => {
+      mockAnnotations.annotations = [
+        makeAnnotation({ id: "a1", tags: ["nucleus"] }),
+        makeAnnotation({ id: "a2", tags: [] }),
+        makeAnnotation({ id: "a3", tags: ["nucleus"] }),
+      ];
+      mockProperties.propertyValues = {
+        a1: { px: { v: 1 }, py: { v: 1 } },
+        a2: { px: { v: 2 }, py: { v: 2 } },
+        a3: { px: { v: 3 }, py: { v: 3 } },
+      };
+      const { result } = await executeAgentTool(
+        "create_scatter_plot",
+        {
+          xPropertyPath: ["px", "v"],
+          yPropertyPath: ["py", "v"],
+          title: "colored",
+          colorByTag: true,
+        },
+        context,
+      );
+      const plot = getPlot(result.plotId)!;
+      const names = (plot.data as any[]).map((trace) => trace.name);
+      expect(names).toContain("nucleus");
+      expect(names).toContain("untagged");
+      expect(plot.data).toHaveLength(2);
+    });
+
+    it("errors with both axis counts when nothing overlaps", async () => {
+      mockAnnotations.annotations = [
+        makeAnnotation({ id: "a1" }),
+        makeAnnotation({ id: "a2" }),
+      ];
+      mockProperties.propertyValues = {
+        a1: { px: { v: 1 } },
+        a2: { py: { v: 2 } },
+      };
+      await expect(
+        executeAgentTool(
+          "create_scatter_plot",
+          {
+            xPropertyPath: ["px", "v"],
+            yPropertyPath: ["py", "v"],
+            title: "empty",
+          },
+          context,
+        ),
+      ).rejects.toThrow(/px\.v.*py\.v/s);
+    });
+
+    it("requires a non-empty title", async () => {
+      seedValues({ a1: 1 });
+      await expect(
+        executeAgentTool(
+          "create_scatter_plot",
+          {
+            xPropertyPath: ["prop1", "mean"],
+            yPropertyPath: ["prop1", "mean"],
+            title: "",
+          },
+          context,
+        ),
+      ).rejects.toBeInstanceOf(ToolExecutionError);
+    });
+
+    it("downsamples beyond MAX_PLOT_POINTS and flags the title", async () => {
+      const annotations: any[] = [];
+      const propertyValues: { [id: string]: any } = {};
+      const total = MAX_PLOT_POINTS + 10000;
+      for (let i = 0; i < total; i++) {
+        const id = `a${i}`;
+        annotations.push(makeAnnotation({ id }));
+        propertyValues[id] = { px: { v: i }, py: { v: i } };
+      }
+      mockAnnotations.annotations = annotations;
+      mockProperties.propertyValues = propertyValues;
+      const { result } = await executeAgentTool(
+        "create_scatter_plot",
+        {
+          xPropertyPath: ["px", "v"],
+          yPropertyPath: ["py", "v"],
+          title: "big",
+        },
+        context,
+      );
+      expect(result.downsampled).toBe(true);
+      expect(result.pointCount).toBeLessThanOrEqual(MAX_PLOT_POINTS);
+      expect(result.title.endsWith("(downsampled)")).toBe(true);
+    });
+  });
+
+  describe("create_histogram_plot", () => {
+    it("builds a bar trace with matching x/width/y lengths", async () => {
+      seedValues({
+        a0: 0,
+        a1: 1,
+        a2: 2,
+        a3: 3,
+        a4: 4,
+        a5: 5,
+        a6: 6,
+        a7: 7,
+        a8: 8,
+        a9: 9,
+      });
+      const { result, plots } = await executeAgentTool(
+        "create_histogram_plot",
+        { propertyPath: ["prop1", "mean"], title: "dist", buckets: 5 },
+        context,
+      );
+      expect(result.bucketCount).toBe(5);
+      expect(plots).toHaveLength(1);
+      const trace = (getPlot(result.plotId)!.data as any[])[0];
+      expect(trace.type).toBe("bar");
+      expect(trace.x).toHaveLength(5);
+      expect(trace.width).toHaveLength(5);
+      expect(trace.y).toHaveLength(5);
+    });
+  });
+
+  describe("create_box_plot", () => {
+    it("names one trace per property path", async () => {
+      seedValues({ a1: 1, a2: 2, a3: 3 });
+      const { result } = await executeAgentTool(
+        "create_box_plot",
+        { propertyPaths: [["prop1", "mean"]], title: "spread" },
+        context,
+      );
+      expect(result.traceCount).toBe(1);
+      const trace = (getPlot(result.plotId)!.data as any[])[0];
+      expect(trace.type).toBe("box");
+      // getFullNameFromPath returns null -> dotted-path fallback.
+      expect(trace.name).toBe("prop1.mean");
+      expect(trace.y).toEqual([1, 2, 3]);
+    });
+
+    it("rejects groupByTag with more than one path", async () => {
+      seedValues({ a1: 1 });
+      await expect(
+        executeAgentTool(
+          "create_box_plot",
+          {
+            propertyPaths: [
+              ["prop1", "mean"],
+              ["prop2", "mean"],
+            ],
+            title: "bad",
+            groupByTag: true,
+          },
+          context,
+        ),
+      ).rejects.toBeInstanceOf(ToolExecutionError);
+    });
+
+    it("groups one box per first tag when groupByTag is set", async () => {
+      mockAnnotations.annotations = [
+        makeAnnotation({ id: "a1", tags: ["nucleus"] }),
+        makeAnnotation({ id: "a2", tags: ["spot"] }),
+        makeAnnotation({ id: "a3", tags: ["nucleus"] }),
+      ];
+      mockProperties.propertyValues = {
+        a1: { prop1: { mean: 1 } },
+        a2: { prop1: { mean: 2 } },
+        a3: { prop1: { mean: 3 } },
+      };
+      const { result } = await executeAgentTool(
+        "create_box_plot",
+        {
+          propertyPaths: [["prop1", "mean"]],
+          title: "by tag",
+          groupByTag: true,
+        },
+        context,
+      );
+      const names = (getPlot(result.plotId)!.data as any[]).map((t) => t.name);
+      expect(names).toContain("nucleus");
+      expect(names).toContain("spot");
     });
   });
 });

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -1680,6 +1680,20 @@ describe("data analysis tools", () => {
       expect(trace.width).toHaveLength(5);
       expect(trace.y).toHaveLength(5);
     });
+
+    it("omits bar width for constant data so the single bar is visible", async () => {
+      // All values equal -> one zero-width bucket; an explicit width of 0 would
+      // render an invisible bar, so width must be omitted (Plotly auto-sizes).
+      seedValues({ a1: 5, a2: 5, a3: 5 });
+      const { result } = await executeAgentTool(
+        "create_histogram_plot",
+        { propertyPath: ["prop1", "mean"], title: "const" },
+        context,
+      );
+      const trace = (getPlot(result.plotId)!.data as any[])[0];
+      expect(trace.y).toEqual([3]);
+      expect(trace.width).toBeUndefined();
+    });
   });
 
   describe("create_box_plot", () => {
@@ -1735,8 +1749,29 @@ describe("data analysis tools", () => {
       expect(trace.q1).toEqual([5000]);
       expect(trace.median).toEqual([10000]);
       expect(trace.q3).toEqual([15000]);
+      // Uniform data has no outliers, so whiskers reach the extremes.
       expect(trace.lowerfence).toEqual([0]);
       expect(trace.upperfence).toEqual([MAX_BOX_POINTS]);
+    });
+
+    it("clamps precomputed whiskers to the Tukey fence above the cap", async () => {
+      // Over-cap: a tight cluster plus one extreme value. The whisker must end
+      // at the cluster (the outlier stays outside), not at the extreme.
+      const values: { [id: string]: number } = {};
+      for (let i = 0; i < MAX_BOX_POINTS; i++) {
+        values[`a${i}`] = 10;
+      }
+      values.outlier = 1_000_000;
+      seedValues(values);
+      const { result } = await executeAgentTool(
+        "create_box_plot",
+        { propertyPaths: [["prop1", "mean"]], title: "outlier" },
+        context,
+      );
+      const trace = (getPlot(result.plotId)!.data as any[])[0];
+      expect(trace.y).toBeUndefined();
+      expect(trace.upperfence).toEqual([10]);
+      expect(trace.lowerfence).toEqual([10]);
     });
 
     it("groups one box per first tag when groupByTag is set", async () => {

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -1415,6 +1415,27 @@ describe("data analysis tools", () => {
       ).rejects.toThrow(/prop1\.missing.*get_property_values/s);
     });
 
+    it("excludes property values orphaned by deleted annotations", async () => {
+      // Two live annotations, but propertyValues also carries a value for
+      // "ghost" — an annotation that was deleted (the backend leaves such
+      // values behind). Analysis must count only the live pair, not the ghost.
+      mockAnnotations.annotations = [
+        makeAnnotation({ id: "a1" }),
+        makeAnnotation({ id: "a2" }),
+      ];
+      mockProperties.propertyValues = {
+        a1: { prop1: { mean: 1 } },
+        a2: { prop1: { mean: 2 } },
+        ghost: { prop1: { mean: 999 } },
+      };
+      const { result } = await executeAgentTool(
+        "get_property_histogram",
+        { propertyPath: ["prop1", "mean"] },
+        context,
+      );
+      expect(result.totalCount).toBe(2);
+    });
+
     it("clamps buckets above the maximum", async () => {
       seedValues({
         a0: 0,

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -204,7 +204,7 @@ import {
   ToolExecutionError,
   viewIdentityChangedSince,
 } from "./executors";
-import { MAX_PLOT_POINTS, MAX_SAMPLE_ROWS } from "./analysis";
+import { MAX_BOX_POINTS, MAX_PLOT_POINTS, MAX_SAMPLE_ROWS } from "./analysis";
 import { clearPlots, getPlot } from "./plotRegistry";
 
 const mockMain = main as any;
@@ -1415,6 +1415,20 @@ describe("data analysis tools", () => {
       ).rejects.toThrow(/prop1\.missing.*get_property_values/s);
     });
 
+    it("aborts if the dataset changed during the property-value fetch", async () => {
+      seedValues({ a1: 1, a2: 2 });
+      // The user navigated to a different dataset while fetchPropertyValues
+      // was in flight; the tool must not analyze the now-current dataset.
+      const changedContext = { ...context, hasViewIdentityChanged: () => true };
+      await expect(
+        executeAgentTool(
+          "get_property_histogram",
+          { propertyPath: ["prop1", "mean"] },
+          changedContext,
+        ),
+      ).rejects.toThrow(/active dataset changed/);
+    });
+
     it("excludes property values orphaned by deleted annotations", async () => {
       // Two live annotations, but propertyValues also carries a value for
       // "ghost" — an annotation that was deleted (the backend leaves such
@@ -1700,6 +1714,29 @@ describe("data analysis tools", () => {
           context,
         ),
       ).rejects.toBeInstanceOf(ToolExecutionError);
+    });
+
+    it("uses exact precomputed stats above the point cap, not a downsample", async () => {
+      // 0..MAX_BOX_POINTS inclusive => MAX_BOX_POINTS+1 values, over the cap.
+      const values: { [id: string]: number } = {};
+      for (let i = 0; i <= MAX_BOX_POINTS; i++) {
+        values[`a${i}`] = i;
+      }
+      seedValues(values);
+      const { result } = await executeAgentTool(
+        "create_box_plot",
+        { propertyPaths: [["prop1", "mean"]], title: "big" },
+        context,
+      );
+      const trace = (getPlot(result.plotId)!.data as any[])[0];
+      // No raw y array (that path would have been downsampled); exact quartiles
+      // computed from the full data instead.
+      expect(trace.y).toBeUndefined();
+      expect(trace.q1).toEqual([5000]);
+      expect(trace.median).toEqual([10000]);
+      expect(trace.q3).toEqual([15000]);
+      expect(trace.lowerfence).toEqual([0]);
+      expect(trace.upperfence).toEqual([MAX_BOX_POINTS]);
     });
 
     it("groups one box per first tag when groupByTag is set", async () => {

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -26,6 +26,7 @@ import {
   captureViewportScreenshot,
 } from "@/utils/interfaceCapture";
 import { getDefault } from "@/utils/workerInterface";
+import type { IAgentPlot } from "./plotRegistry";
 import {
   MANUAL_CATALOG,
   buildCatalog,
@@ -58,6 +59,9 @@ export interface IToolExecutionResult {
   result: any;
   // Optional images sent back as image blocks (screenshots)
   images?: IChatImage[];
+  // Plots registered by this tool for inline rendering in the transcript
+  // (the model only ever sees {plotId, ...} in `result`).
+  plots?: IAgentPlot[];
 }
 
 // Above this many matching annotations, list_annotations returns a hint

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -248,6 +248,20 @@ function liveAnnotationIdSet(): Set<string> {
   );
 }
 
+// Analysis executors await fetchPropertyValues before reading the global
+// annotation/property stores. If the user switched datasets during that await,
+// the fetch resolves for the old dataset and the stores now hold the new one —
+// so re-check identity afterward and abort before producing a stat or plot for
+// a dataset the request didn't target (mirrors run_worker's post-await check).
+function assertDatasetUnchanged(context: IAgentToolContext) {
+  if (context.hasViewIdentityChanged?.()) {
+    throw new ToolExecutionError(
+      "Aborted: the active dataset changed while loading property values; " +
+        "not analyzing a different dataset than the request targeted.",
+    );
+  }
+}
+
 // Collect [annotationId, value] pairs for one property value path. Iterates the
 // query's matches when a query was given (queryAnnotations already restricts to
 // live annotations), else every live annotation — never the raw propertyValues
@@ -1540,8 +1554,12 @@ const registry: { [name: string]: IAgentToolEntry } = {
   },
 
   get_property_values: {
-    execute: async (input: { propertyId?: string; query?: unknown }) => {
+    execute: async (
+      input: { propertyId?: string; query?: unknown },
+      context: IAgentToolContext,
+    ) => {
       await propertyStore.fetchPropertyValues();
+      assertDatasetUnchanged(context);
       const allowedIds = resolveQueryToIdSet(input.query);
       const nameOf = (id: string) =>
         propertyStore.properties.find((p) => p.id === id)?.name ?? id;
@@ -1581,13 +1599,17 @@ const registry: { [name: string]: IAgentToolEntry } = {
   },
 
   get_property_histogram: {
-    execute: async (input: {
-      propertyPath?: unknown;
-      buckets?: number;
-      query?: unknown;
-    }) => {
+    execute: async (
+      input: {
+        propertyPath?: unknown;
+        buckets?: number;
+        query?: unknown;
+      },
+      context: IAgentToolContext,
+    ) => {
       requireDataset();
       await propertyStore.fetchPropertyValues();
+      assertDatasetUnchanged(context);
       const path = validatePropertyPath(input.propertyPath, "propertyPath");
       const allowedIds = resolveQueryToIdSet(input.query);
       const values = collectPathValues(path, allowedIds).map(([, v]) => v);
@@ -1610,13 +1632,17 @@ const registry: { [name: string]: IAgentToolEntry } = {
   },
 
   get_sample_values: {
-    execute: async (input: {
-      propertyPaths?: unknown;
-      n?: number;
-      query?: unknown;
-    }) => {
+    execute: async (
+      input: {
+        propertyPaths?: unknown;
+        n?: number;
+        query?: unknown;
+      },
+      context: IAgentToolContext,
+    ) => {
       requireDataset();
       await propertyStore.fetchPropertyValues();
+      assertDatasetUnchanged(context);
       if (
         !Array.isArray(input.propertyPaths) ||
         input.propertyPaths.length === 0
@@ -1659,17 +1685,21 @@ const registry: { [name: string]: IAgentToolEntry } = {
   },
 
   create_scatter_plot: {
-    execute: async (input: {
-      xPropertyPath?: unknown;
-      yPropertyPath?: unknown;
-      title?: unknown;
-      xLabel?: string;
-      yLabel?: string;
-      colorByTag?: boolean;
-      query?: unknown;
-    }) => {
+    execute: async (
+      input: {
+        xPropertyPath?: unknown;
+        yPropertyPath?: unknown;
+        title?: unknown;
+        xLabel?: string;
+        yLabel?: string;
+        colorByTag?: boolean;
+        query?: unknown;
+      },
+      context: IAgentToolContext,
+    ) => {
       requireDataset();
       await propertyStore.fetchPropertyValues();
+      assertDatasetUnchanged(context);
       const xPath = validatePropertyPath(input.xPropertyPath, "xPropertyPath");
       const yPath = validatePropertyPath(input.yPropertyPath, "yPropertyPath");
       const title = requirePlotTitle(input.title);
@@ -1740,15 +1770,19 @@ const registry: { [name: string]: IAgentToolEntry } = {
   },
 
   create_histogram_plot: {
-    execute: async (input: {
-      propertyPath?: unknown;
-      title?: unknown;
-      buckets?: number;
-      xLabel?: string;
-      query?: unknown;
-    }) => {
+    execute: async (
+      input: {
+        propertyPath?: unknown;
+        title?: unknown;
+        buckets?: number;
+        xLabel?: string;
+        query?: unknown;
+      },
+      context: IAgentToolContext,
+    ) => {
       requireDataset();
       await propertyStore.fetchPropertyValues();
+      assertDatasetUnchanged(context);
       const path = validatePropertyPath(input.propertyPath, "propertyPath");
       const title = requirePlotTitle(input.title);
       const allowedIds = resolveQueryToIdSet(input.query);
@@ -1786,14 +1820,18 @@ const registry: { [name: string]: IAgentToolEntry } = {
   },
 
   create_box_plot: {
-    execute: async (input: {
-      propertyPaths?: unknown;
-      title?: unknown;
-      groupByTag?: boolean;
-      query?: unknown;
-    }) => {
+    execute: async (
+      input: {
+        propertyPaths?: unknown;
+        title?: unknown;
+        groupByTag?: boolean;
+        query?: unknown;
+      },
+      context: IAgentToolContext,
+    ) => {
       requireDataset();
       await propertyStore.fetchPropertyValues();
+      assertDatasetUnchanged(context);
       if (
         !Array.isArray(input.propertyPaths) ||
         input.propertyPaths.length === 0
@@ -1807,11 +1845,28 @@ const registry: { [name: string]: IAgentToolEntry } = {
       );
       const title = requirePlotTitle(input.title);
       const allowedIds = resolveQueryToIdSet(input.query);
-      const boxTrace = (name: string, values: number[]) => ({
-        type: "box",
-        name,
-        y: downsample(values, MAX_BOX_POINTS)[0],
-      });
+      // At/below the cap: hand Plotly the raw points so it draws exact
+      // quartiles and individual outliers. Above it: shipping every point is
+      // wasteful and an every-kth downsample silently shifts the box's
+      // quartiles/outliers, so pass EXACT precomputed statistics from the full
+      // data instead — the box stays accurate (individual outlier dots are
+      // omitted), never a silent approximation.
+      const boxTrace = (name: string, values: number[]) => {
+        if (values.length <= MAX_BOX_POINTS) {
+          return { type: "box", name, y: values };
+        }
+        const s = computeStats(values);
+        return {
+          type: "box",
+          name,
+          q1: [s.p25],
+          median: [s.median],
+          q3: [s.p75],
+          lowerfence: [s.min],
+          upperfence: [s.max],
+          mean: [s.mean],
+        };
+      };
       let data: unknown[];
       if (input.groupByTag) {
         if (paths.length !== 1) {

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -26,7 +26,18 @@ import {
   captureViewportScreenshot,
 } from "@/utils/interfaceCapture";
 import { getDefault } from "@/utils/workerInterface";
-import type { IAgentPlot } from "./plotRegistry";
+import { registerPlot, type IAgentPlot } from "./plotRegistry";
+import {
+  MAX_BOX_POINTS,
+  MAX_HISTOGRAM_BUCKETS,
+  MAX_PLOT_POINTS,
+  MAX_SAMPLE_ROWS,
+  computeStats,
+  downsample,
+  resolvePathValue,
+  roundSignificant,
+  uniformHistogram,
+} from "./analysis";
 import {
   MANUAL_CATALOG,
   buildCatalog,
@@ -209,6 +220,101 @@ function resolveAnnotationTargetIds(target: unknown): string[] {
   }
   validateAnnotationQuery(target as { [key: string]: unknown });
   return queryAnnotations(target as IAnnotationQuery).map((a) => a.id);
+}
+
+// Resolve a (model-supplied, unvalidated) `query` to the set of annotation ids
+// it matches, or null when no query was given (meaning "all annotations").
+// Shared by every property/analysis tool that accepts the list_annotations
+// query shape.
+function resolveQueryToIdSet(query: unknown): Set<string> | null {
+  if (query === undefined) {
+    return null;
+  }
+  if (query === null || typeof query !== "object" || Array.isArray(query)) {
+    throw new ToolExecutionError("query must be a query object");
+  }
+  validateAnnotationQuery(query as { [key: string]: unknown });
+  return new Set(queryAnnotations(query as IAnnotationQuery).map((a) => a.id));
+}
+
+// Collect [annotationId, value] pairs for one property value path from the
+// in-memory propertyValues map, restricted to allowedIds when non-null. Only
+// finite-numeric leaves are kept (resolvePathValue drops the rest).
+function collectPathValues(
+  path: string[],
+  allowedIds: Set<string> | null,
+): [string, number][] {
+  const pairs: [string, number][] = [];
+  for (const annotationId in propertyStore.propertyValues) {
+    if (allowedIds && !allowedIds.has(annotationId)) {
+      continue;
+    }
+    const value = resolvePathValue(
+      propertyStore.propertyValues[annotationId],
+      path,
+    );
+    if (value !== null) {
+      pairs.push([annotationId, value]);
+    }
+  }
+  return pairs;
+}
+
+// Validate a model-supplied property value path: a non-empty array of strings,
+// the same currency get_property_values returns as `propertyPath`.
+function validatePropertyPath(value: unknown, field: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.some((segment) => typeof segment !== "string")
+  ) {
+    throw new ToolExecutionError(
+      `${field} must be a non-empty array of strings (a propertyPath as ` +
+        "returned by get_property_values)",
+    );
+  }
+  return value as string[];
+}
+
+// The human-facing name for a property value path (what users see elsewhere in
+// the app), falling back to the dotted path when the property is unnamed.
+function propertyPathLabel(path: string[]): string {
+  return propertyStore.getFullNameFromPath(path) ?? path.join(".");
+}
+
+// A model-supplied plot title must be a non-empty string.
+function requirePlotTitle(value: unknown): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new ToolExecutionError("title is required (a non-empty string)");
+  }
+  return value;
+}
+
+// Bucket count for the histogram tools: default 50, floored, clamped to
+// [1, MAX_HISTOGRAM_BUCKETS].
+function clampHistogramBuckets(value: unknown): number {
+  const requested =
+    typeof value === "number" && value > 0 ? Math.floor(value) : 50;
+  return Math.min(Math.max(1, requested), MAX_HISTOGRAM_BUCKETS);
+}
+
+// Map each annotation id to its first tag (or "untagged") for tag-grouped
+// plots. Built once per plot call rather than searching annotations per point.
+function buildFirstTagMap(): Map<string, string> {
+  const firstTags = new Map<string, string>();
+  for (const annotation of annotationStore.annotations) {
+    firstTags.set(annotation.id, annotation.tags?.[0] ?? "untagged");
+  }
+  return firstTags;
+}
+
+// Map each annotation id to its full tag list, for sample rows.
+function buildTagsMap(): Map<string, string[]> {
+  const tags = new Map<string, string[]>();
+  for (const annotation of annotationStore.annotations) {
+    tags.set(annotation.id, annotation.tags ?? []);
+  }
+  return tags;
 }
 
 // Resolve the parameter values for a worker image: fetch its interface, reject
@@ -1426,20 +1532,7 @@ const registry: { [name: string]: IAgentToolEntry } = {
   get_property_values: {
     execute: async (input: { propertyId?: string; query?: unknown }) => {
       await propertyStore.fetchPropertyValues();
-      let allowedIds: Set<string> | null = null;
-      if (input.query !== undefined) {
-        if (
-          input.query === null ||
-          typeof input.query !== "object" ||
-          Array.isArray(input.query)
-        ) {
-          throw new ToolExecutionError("query must be a query object");
-        }
-        validateAnnotationQuery(input.query as { [key: string]: unknown });
-        allowedIds = new Set(
-          queryAnnotations(input.query as IAnnotationQuery).map((a) => a.id),
-        );
-      }
+      const allowedIds = resolveQueryToIdSet(input.query);
       const nameOf = (id: string) =>
         propertyStore.properties.find((p) => p.id === id)?.name ?? id;
       const stats = [];
@@ -1448,51 +1541,316 @@ const registry: { [name: string]: IAgentToolEntry } = {
         if (input.propertyId && propertyId !== input.propertyId) {
           continue;
         }
-        const values: number[] = [];
-        for (const annotationId in propertyStore.propertyValues) {
-          if (allowedIds && !allowedIds.has(annotationId)) {
-            continue;
-          }
-          let value: any = propertyStore.propertyValues[annotationId];
-          for (const key of path) {
-            value = value?.[key];
-          }
-          if (typeof value === "number" && !Number.isNaN(value)) {
-            values.push(value);
-          }
-        }
+        const values = collectPathValues(path, allowedIds).map(([, v]) => v);
         if (values.length === 0) {
           continue;
         }
-        // Single pass rather than sum-reduce + Math.min(...values): `values`
-        // has one entry per matching annotation and is uncapped, so spreading
-        // it into Math.min/max throws RangeError past the engine's argument
-        // limit (~65k) — reachable on the large datasets this tool targets.
-        let sum = 0;
-        let min = Infinity;
-        let max = -Infinity;
-        for (const value of values) {
-          sum += value;
-          if (value < min) {
-            min = value;
-          }
-          if (value > max) {
-            max = value;
-          }
-        }
+        // computeStats loops internally (sort + reductions), never spreading
+        // `values` into Math.min/max — that would throw RangeError past the
+        // engine's ~65k argument limit on the large datasets this tool targets.
+        const s = computeStats(values);
         stats.push({
           propertyId,
           property: nameOf(propertyId),
           path: path.slice(1).join(".") || nameOf(propertyId),
-          // Full path (incl. propertyId) to pass to set_annotation_filter.
+          // Full path (incl. propertyId) to pass to set_annotation_filter and
+          // the analysis/plot tools.
           propertyPath: path,
-          count: values.length,
-          mean: sum / values.length,
-          min,
-          max,
+          count: s.count,
+          mean: roundSignificant(s.mean),
+          std: roundSignificant(s.std),
+          min: roundSignificant(s.min),
+          max: roundSignificant(s.max),
+          median: roundSignificant(s.median),
+          p25: roundSignificant(s.p25),
+          p75: roundSignificant(s.p75),
         });
       }
       return { result: { stats } };
+    },
+  },
+
+  get_property_histogram: {
+    execute: async (input: {
+      propertyPath?: unknown;
+      buckets?: number;
+      query?: unknown;
+    }) => {
+      requireDataset();
+      await propertyStore.fetchPropertyValues();
+      const path = validatePropertyPath(input.propertyPath, "propertyPath");
+      const allowedIds = resolveQueryToIdSet(input.query);
+      const values = collectPathValues(path, allowedIds).map(([, v]) => v);
+      if (values.length === 0) {
+        throw new ToolExecutionError(
+          `No numeric values for property value path "${path.join(".")}"; ` +
+            "call get_property_values to see the available propertyPaths.",
+        );
+      }
+      const buckets = uniformHistogram(
+        values,
+        clampHistogramBuckets(input.buckets),
+      ).map((bucket) => ({
+        min: roundSignificant(bucket.min),
+        max: roundSignificant(bucket.max),
+        count: bucket.count,
+      }));
+      return { result: { buckets, totalCount: values.length } };
+    },
+  },
+
+  get_sample_values: {
+    execute: async (input: {
+      propertyPaths?: unknown;
+      n?: number;
+      query?: unknown;
+    }) => {
+      requireDataset();
+      await propertyStore.fetchPropertyValues();
+      if (
+        !Array.isArray(input.propertyPaths) ||
+        input.propertyPaths.length === 0
+      ) {
+        throw new ToolExecutionError(
+          "propertyPaths must be a non-empty array of property value paths",
+        );
+      }
+      const paths = input.propertyPaths.map((path) =>
+        validatePropertyPath(path, "propertyPaths[]"),
+      );
+      const allowedIds = resolveQueryToIdSet(input.query);
+      const matchingIds: string[] = [];
+      for (const annotationId in propertyStore.propertyValues) {
+        if (allowedIds && !allowedIds.has(annotationId)) {
+          continue;
+        }
+        matchingIds.push(annotationId);
+      }
+      const requestedN =
+        typeof input.n === "number" && input.n > 0 ? Math.floor(input.n) : 20;
+      const n = Math.min(Math.max(1, requestedN), MAX_SAMPLE_ROWS);
+      const [sampledIds] = downsample(matchingIds, n);
+      const tagsById = buildTagsMap();
+      const rows = sampledIds.map((annotationId) => {
+        const row: { [key: string]: unknown } = {
+          annotationId,
+          tags: tagsById.get(annotationId) ?? [],
+        };
+        for (const path of paths) {
+          row[path.join(".")] = roundSignificant(
+            resolvePathValue(propertyStore.propertyValues[annotationId], path),
+          );
+        }
+        return row;
+      });
+      return { result: { rows, totalMatching: matchingIds.length } };
+    },
+  },
+
+  create_scatter_plot: {
+    execute: async (input: {
+      xPropertyPath?: unknown;
+      yPropertyPath?: unknown;
+      title?: unknown;
+      xLabel?: string;
+      yLabel?: string;
+      colorByTag?: boolean;
+      query?: unknown;
+    }) => {
+      requireDataset();
+      await propertyStore.fetchPropertyValues();
+      const xPath = validatePropertyPath(input.xPropertyPath, "xPropertyPath");
+      const yPath = validatePropertyPath(input.yPropertyPath, "yPropertyPath");
+      const title = requirePlotTitle(input.title);
+      const allowedIds = resolveQueryToIdSet(input.query);
+      const xValues = new Map(collectPathValues(xPath, allowedIds));
+      const yValues = new Map(collectPathValues(yPath, allowedIds));
+      const sharedIds: string[] = [];
+      for (const id of xValues.keys()) {
+        if (yValues.has(id)) {
+          sharedIds.push(id);
+        }
+      }
+      if (sharedIds.length === 0) {
+        throw new ToolExecutionError(
+          `No annotations have a numeric value on both "${xPath.join(".")}" (${
+            xValues.size
+          } values) and "${yPath.join(".")}" (${yValues.size} values).`,
+        );
+      }
+      const [ids, downsampled] = downsample(sharedIds, MAX_PLOT_POINTS);
+      const plotTitle = downsampled ? `${title} (downsampled)` : title;
+      // Full precision here (unlike the model-visible tool result): plot traces
+      // render for the user and are never sent back to the model.
+      const makeTrace = (name: string, traceIds: string[]) => ({
+        type: "scattergl",
+        mode: "markers",
+        name,
+        x: traceIds.map((id) => xValues.get(id)),
+        y: traceIds.map((id) => yValues.get(id)),
+        marker: { size: 5, opacity: 0.7 },
+      });
+      let data: unknown[];
+      if (input.colorByTag) {
+        const firstTags = buildFirstTagMap();
+        const groups = new Map<string, string[]>();
+        for (const id of ids) {
+          const tag = firstTags.get(id) ?? "untagged";
+          const group = groups.get(tag);
+          if (group) {
+            group.push(id);
+          } else {
+            groups.set(tag, [id]);
+          }
+        }
+        data = Array.from(groups.entries()).map(([tag, tagIds]) =>
+          makeTrace(tag, tagIds),
+        );
+      } else {
+        data = [makeTrace(title, ids)];
+      }
+      const layout = {
+        title: plotTitle,
+        xaxis: { title: input.xLabel ?? propertyPathLabel(xPath) },
+        yaxis: { title: input.yLabel ?? propertyPathLabel(yPath) },
+        hovermode: "closest",
+      };
+      const plot = registerPlot({ title: plotTitle, data, layout });
+      return {
+        result: {
+          plotId: plot.id,
+          title: plotTitle,
+          pointCount: ids.length,
+          downsampled,
+        },
+        plots: [plot],
+      };
+    },
+  },
+
+  create_histogram_plot: {
+    execute: async (input: {
+      propertyPath?: unknown;
+      title?: unknown;
+      buckets?: number;
+      xLabel?: string;
+      query?: unknown;
+    }) => {
+      requireDataset();
+      await propertyStore.fetchPropertyValues();
+      const path = validatePropertyPath(input.propertyPath, "propertyPath");
+      const title = requirePlotTitle(input.title);
+      const allowedIds = resolveQueryToIdSet(input.query);
+      const values = collectPathValues(path, allowedIds).map(([, v]) => v);
+      if (values.length === 0) {
+        throw new ToolExecutionError(
+          `No numeric values for property value path "${path.join(".")}"; ` +
+            "call get_property_values to see the available propertyPaths.",
+        );
+      }
+      const histogram = uniformHistogram(
+        values,
+        clampHistogramBuckets(input.buckets),
+      );
+      const trace = {
+        type: "bar",
+        name: title,
+        x: histogram.map((bucket) => (bucket.min + bucket.max) / 2),
+        y: histogram.map((bucket) => bucket.count),
+        width: histogram.map((bucket) => bucket.max - bucket.min),
+      };
+      const layout = {
+        title,
+        xaxis: { title: input.xLabel ?? propertyPathLabel(path) },
+        yaxis: { title: "count" },
+        hovermode: "closest",
+        bargap: 0,
+      };
+      const plot = registerPlot({ title, data: [trace], layout });
+      return {
+        result: { plotId: plot.id, title, bucketCount: histogram.length },
+        plots: [plot],
+      };
+    },
+  },
+
+  create_box_plot: {
+    execute: async (input: {
+      propertyPaths?: unknown;
+      title?: unknown;
+      groupByTag?: boolean;
+      query?: unknown;
+    }) => {
+      requireDataset();
+      await propertyStore.fetchPropertyValues();
+      if (
+        !Array.isArray(input.propertyPaths) ||
+        input.propertyPaths.length === 0
+      ) {
+        throw new ToolExecutionError(
+          "propertyPaths must be a non-empty array of property value paths",
+        );
+      }
+      const paths = input.propertyPaths.map((path) =>
+        validatePropertyPath(path, "propertyPaths[]"),
+      );
+      const title = requirePlotTitle(input.title);
+      const allowedIds = resolveQueryToIdSet(input.query);
+      const boxTrace = (name: string, values: number[]) => ({
+        type: "box",
+        name,
+        y: downsample(values, MAX_BOX_POINTS)[0],
+      });
+      let data: unknown[];
+      if (input.groupByTag) {
+        if (paths.length !== 1) {
+          throw new ToolExecutionError(
+            "groupByTag requires exactly one propertyPath (one box per tag)",
+          );
+        }
+        const path = paths[0];
+        const firstTags = buildFirstTagMap();
+        const groups = new Map<string, number[]>();
+        for (const [id, value] of collectPathValues(path, allowedIds)) {
+          const tag = firstTags.get(id) ?? "untagged";
+          const group = groups.get(tag);
+          if (group) {
+            group.push(value);
+          } else {
+            groups.set(tag, [value]);
+          }
+        }
+        if (groups.size === 0) {
+          throw new ToolExecutionError(
+            `No numeric values for property value path "${path.join(".")}"; ` +
+              "call get_property_values to see the available propertyPaths.",
+          );
+        }
+        data = Array.from(groups.entries()).map(([tag, values]) =>
+          boxTrace(tag, values),
+        );
+      } else {
+        data = [];
+        for (const path of paths) {
+          const values = collectPathValues(path, allowedIds).map(([, v]) => v);
+          if (values.length === 0) {
+            continue;
+          }
+          data.push(boxTrace(propertyPathLabel(path), values));
+        }
+        if (data.length === 0) {
+          throw new ToolExecutionError(
+            "None of the given property value paths have numeric values; " +
+              "call get_property_values to see the available propertyPaths.",
+          );
+        }
+      }
+      const layout = { title, hovermode: "closest" };
+      const plot = registerPlot({ title, data, layout });
+      return {
+        result: { plotId: plot.id, title, traceCount: data.length },
+        plots: [plot],
+      };
     },
   },
 
@@ -1675,6 +2033,29 @@ export function describeAgentToolCall(name: string, input: any): string {
     }
     case "get_property_values":
       return "Summarize computed property values";
+    case "get_property_histogram": {
+      const path = Array.isArray(input?.propertyPath)
+        ? input.propertyPath.join(".")
+        : "";
+      return `Read histogram of ${path}`;
+    }
+    case "get_sample_values": {
+      const n =
+        typeof input?.n === "number" && input.n > 0 ? Math.floor(input.n) : 20;
+      return `Read up to ${n} sample values`;
+    }
+    case "create_scatter_plot":
+      return `Create scatter plot "${
+        typeof input?.title === "string" ? input.title : ""
+      }"`;
+    case "create_histogram_plot":
+      return `Create histogram plot "${
+        typeof input?.title === "string" ? input.title : ""
+      }"`;
+    case "create_box_plot":
+      return `Create box plot "${
+        typeof input?.title === "string" ? input.title : ""
+      }"`;
     case "undo":
       return "Undo the last annotation change";
     case "redo":

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -32,6 +32,7 @@ import {
   MAX_HISTOGRAM_BUCKETS,
   MAX_PLOT_POINTS,
   MAX_SAMPLE_ROWS,
+  computeBoxStats,
   computeStats,
   downsample,
   resolvePathValue,
@@ -1797,13 +1798,20 @@ const registry: { [name: string]: IAgentToolEntry } = {
         values,
         clampHistogramBuckets(input.buckets),
       );
-      const trace = {
+      const widths = histogram.map((bucket) => bucket.max - bucket.min);
+      const trace: { [key: string]: unknown } = {
         type: "bar",
         name: title,
         x: histogram.map((bucket) => (bucket.min + bucket.max) / 2),
         y: histogram.map((bucket) => bucket.count),
-        width: histogram.map((bucket) => bucket.max - bucket.min),
       };
+      // Constant data collapses to a single zero-width bucket; an explicit
+      // width of 0 renders an invisible bar. Only set bar widths when they are
+      // all positive (the normal multi-bucket case); otherwise let Plotly
+      // auto-size the single bar.
+      if (widths.every((width) => width > 0)) {
+        trace.width = widths;
+      }
       const layout = {
         title,
         xaxis: { title: input.xLabel ?? propertyPathLabel(path) },
@@ -1855,15 +1863,19 @@ const registry: { [name: string]: IAgentToolEntry } = {
         if (values.length <= MAX_BOX_POINTS) {
           return { type: "box", name, y: values };
         }
-        const s = computeStats(values);
+        // Exact quartiles + Tukey (1.5*IQR) whisker endpoints from the full
+        // data, so the box matches what Plotly draws from raw points below the
+        // cap — extreme values stay outside the whiskers instead of being
+        // pulled in to the min/max. Individual outlier dots are omitted.
+        const s = computeBoxStats(values);
         return {
           type: "box",
           name,
-          q1: [s.p25],
+          q1: [s.q1],
           median: [s.median],
-          q3: [s.p75],
-          lowerfence: [s.min],
-          upperfence: [s.max],
+          q3: [s.q3],
+          lowerfence: [s.lowerFence],
+          upperfence: [s.upperFence],
           mean: [s.mean],
         };
       };

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -237,18 +237,28 @@ function resolveQueryToIdSet(query: unknown): Set<string> | null {
   return new Set(queryAnnotations(query as IAnnotationQuery).map((a) => a.id));
 }
 
-// Collect [annotationId, value] pairs for one property value path from the
-// in-memory propertyValues map, restricted to allowedIds when non-null. Only
+// Ids of the annotations that currently exist for this dataset (the frontend
+// holds them all in memory). Property-value documents can outlive their
+// annotation — a backend cleanup gap leaves values orphaned after deletion
+// (see AI_PANEL_DATA_ANALYSIS_SPEC.md §9) — so analysis intersects with this
+// live set to keep stats and plots to real objects instead of ghost data.
+function liveAnnotationIdSet(): Set<string> {
+  return new Set(
+    annotationStore.annotations.map((annotation) => annotation.id),
+  );
+}
+
+// Collect [annotationId, value] pairs for one property value path. Iterates the
+// query's matches when a query was given (queryAnnotations already restricts to
+// live annotations), else every live annotation — never the raw propertyValues
+// keys, which can include values orphaned by deleted annotations. Only
 // finite-numeric leaves are kept (resolvePathValue drops the rest).
 function collectPathValues(
   path: string[],
   allowedIds: Set<string> | null,
 ): [string, number][] {
   const pairs: [string, number][] = [];
-  for (const annotationId in propertyStore.propertyValues) {
-    if (allowedIds && !allowedIds.has(annotationId)) {
-      continue;
-    }
+  for (const annotationId of allowedIds ?? liveAnnotationIdSet()) {
     const value = resolvePathValue(
       propertyStore.propertyValues[annotationId],
       path,
@@ -1619,12 +1629,13 @@ const registry: { [name: string]: IAgentToolEntry } = {
         validatePropertyPath(path, "propertyPaths[]"),
       );
       const allowedIds = resolveQueryToIdSet(input.query);
+      // Only live annotations that actually have a property-value document —
+      // skips values orphaned by deleted annotations, matching collectPathValues.
       const matchingIds: string[] = [];
-      for (const annotationId in propertyStore.propertyValues) {
-        if (allowedIds && !allowedIds.has(annotationId)) {
-          continue;
+      for (const annotationId of allowedIds ?? liveAnnotationIdSet()) {
+        if (propertyStore.propertyValues[annotationId] !== undefined) {
+          matchingIds.push(annotationId);
         }
-        matchingIds.push(annotationId);
       }
       const requestedN =
         typeof input.n === "number" && input.n > 0 ? Math.floor(input.n) : 20;

--- a/src/agent/plotRegistry.test.ts
+++ b/src/agent/plotRegistry.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  registerPlot,
+  getPlot,
+  listPlots,
+  restorePlots,
+  clearPlots,
+  IAgentPlot,
+} from "./plotRegistry";
+
+// The registry's id counter is module-global and never resets (clearPlots only
+// empties the map), so assertions compare ids relative to each other rather
+// than against absolute values.
+beforeEach(() => {
+  clearPlots();
+});
+
+const samplePlot = (title = "t"): Omit<IAgentPlot, "id"> => ({
+  title,
+  data: [],
+  layout: {},
+});
+
+const idNumber = (id: string) => Number(id.replace("plot-", ""));
+
+describe("plotRegistry", () => {
+  it("assigns sequential plot-<n> ids", () => {
+    const first = registerPlot(samplePlot());
+    const second = registerPlot(samplePlot());
+    expect(first.id).toMatch(/^plot-\d+$/);
+    expect(idNumber(second.id)).toBe(idNumber(first.id) + 1);
+  });
+
+  it("gets by id and lists in insertion order", () => {
+    const a = registerPlot(samplePlot("first"));
+    const b = registerPlot(samplePlot("second"));
+    expect(getPlot(a.id)).toBe(a);
+    expect(getPlot(b.id)).toBe(b);
+    expect(getPlot("plot-does-not-exist")).toBeUndefined();
+    expect(listPlots().map((p) => p.title)).toEqual(["first", "second"]);
+  });
+
+  it("clears the registry", () => {
+    registerPlot(samplePlot());
+    clearPlots();
+    expect(listPlots()).toEqual([]);
+  });
+
+  it("restorePlots replaces contents and advances the counter past ids", () => {
+    registerPlot(samplePlot());
+    restorePlots([{ id: "plot-40", title: "restored", data: [], layout: {} }]);
+    expect(listPlots().map((p) => p.id)).toEqual(["plot-40"]);
+
+    const next = registerPlot(samplePlot());
+    expect(idNumber(next.id)).toBeGreaterThan(40);
+    expect(getPlot(next.id)).toBe(next);
+    expect(getPlot("plot-40")).toBeDefined();
+  });
+});

--- a/src/agent/plotRegistry.ts
+++ b/src/agent/plotRegistry.ts
@@ -1,0 +1,47 @@
+// Panel-local registry for AI-panel plots. Plot data (large Plotly trace
+// arrays) must live OUTSIDE Vuex — no reactivity is wanted, same reasoning as
+// wireMessages — and this module is imported by both executors.ts and the
+// aiPanel store, so it must not import either (circular import).
+
+export interface IAgentPlot {
+  id: string; // "plot-<n>"
+  title: string;
+  data: unknown[]; // Plotly traces
+  layout: Record<string, unknown>; // titles/axis labels only; theming at render
+}
+
+const plots = new Map<string, IAgentPlot>();
+let nextId = 1;
+
+export function registerPlot(plot: Omit<IAgentPlot, "id">): IAgentPlot {
+  const registered: IAgentPlot = { ...plot, id: `plot-${nextId++}` };
+  plots.set(registered.id, registered);
+  return registered;
+}
+
+export function getPlot(id: string): IAgentPlot | undefined {
+  return plots.get(id);
+}
+
+export function listPlots(): IAgentPlot[] {
+  return Array.from(plots.values());
+}
+
+// Replace the registry contents with restored plots (hydration), advancing the
+// id counter past the highest numeric "plot-<n>" suffix so freshly registered
+// plots never collide with restored ids.
+export function restorePlots(restored: IAgentPlot[]): void {
+  plots.clear();
+  for (const plot of restored) {
+    plots.set(plot.id, plot);
+    const suffix = Number(plot.id.replace(/^plot-/, ""));
+    if (Number.isFinite(suffix) && suffix >= nextId) {
+      nextId = suffix + 1;
+    }
+  }
+}
+
+// Empty the registry without resetting the id counter.
+export function clearPlots(): void {
+  plots.clear();
+}

--- a/src/agent/plotRegistry.ts
+++ b/src/agent/plotRegistry.ts
@@ -41,6 +41,12 @@ export function restorePlots(restored: IAgentPlot[]): void {
   }
 }
 
+// Remove a single plot. Used when a tool's conversation is cleared/switched
+// before it finishes, so its plot must not linger in the next conversation.
+export function removePlot(id: string): void {
+  plots.delete(id);
+}
+
 // Empty the registry without resetting the id counter.
 export function clearPlots(): void {
   plots.clear();

--- a/src/components/AiPanel.vue
+++ b/src/components/AiPanel.vue
@@ -39,7 +39,13 @@
             Ask me to drive the interface: move to a location, recolor layers or
             annotations, filter annotations, run workers…
           </div>
-          <template v-for="(item, index) in reversedItems" :key="index">
+          <!-- Plot items key by plotId so appends (which shift indices in
+               the reversed array) don't remount — and re-render — every
+               chart. -->
+          <template
+            v-for="(item, index) in reversedItems"
+            :key="item.plotId ?? index"
+          >
             <div
               v-if="item.kind === 'user' || item.kind === 'assistant'"
               :class="item.kind"
@@ -89,6 +95,11 @@
                 </v-btn>
               </span>
             </div>
+            <ai-panel-plot
+              v-else-if="item.kind === 'plot' && item.plotId"
+              :plot-id="item.plotId"
+              class="plot-item"
+            />
             <div v-else :class="item.kind">{{ item.text }}</div>
           </template>
         </div>
@@ -158,6 +169,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import AiPanelPlot from "./AiPanelPlot.vue";
 import { renderAssistantMarkdown } from "@/utils/renderMarkdown";
 import aiPanelStore, {
   IAgentPanelItem,
@@ -382,6 +394,11 @@ onBeforeUnmount(() => {
 
 .tool-detail {
   opacity: 0.7;
+}
+
+.plot-item {
+  align-self: stretch;
+  width: 100%;
 }
 
 .tool-approval-actions {

--- a/src/components/AiPanelPlot.vue
+++ b/src/components/AiPanelPlot.vue
@@ -1,0 +1,85 @@
+<template>
+  <div v-if="plot && !renderFailed" ref="plotEl" class="plot-container"></div>
+  <div v-else class="plot-missing">
+    This plot wasn't saved — ask the assistant to recreate it.
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from "vue";
+import { useTheme } from "vuetify";
+import { getPlot } from "@/agent/plotRegistry";
+import { logError } from "@/utils/log";
+
+const props = defineProps<{
+  plotId: string;
+}>();
+
+const theme = useTheme();
+const plotEl = ref<HTMLElement>();
+const renderFailed = ref(false);
+
+// Registry entries are immutable, so a single lookup suffices: the plot is
+// rendered once on mount and never re-rendered. A missing entry (pruned from
+// persistence) falls through to the placeholder.
+const plot = getPlot(props.plotId);
+
+// Loaded lazily so plotly.js-dist-min never lands in the main bundle.
+let PlotlyModule: any = null;
+
+onMounted(async () => {
+  if (!plot || !plotEl.value) {
+    return;
+  }
+  try {
+    const module = await import("plotly.js-dist-min");
+    PlotlyModule = module.default ?? module; // CJS interop
+    await PlotlyModule.newPlot(
+      plotEl.value,
+      plot.data,
+      {
+        autosize: true,
+        height: 300,
+        margin: { l: 56, r: 16, t: 36, b: 44 },
+        paper_bgcolor: "transparent",
+        plot_bgcolor: "transparent",
+        font: {
+          color: theme.current.value.colors["on-surface"],
+          size: 11,
+        },
+        ...plot.layout,
+      },
+      { responsive: true, displaylogo: false },
+    );
+  } catch (error) {
+    // A broken plot must never crash the transcript; show the placeholder.
+    logError("Failed to render AI panel plot:", error);
+    renderFailed.value = true;
+  }
+});
+
+onBeforeUnmount(() => {
+  if (PlotlyModule && plotEl.value) {
+    PlotlyModule.purge(plotEl.value);
+  }
+});
+</script>
+
+<style scoped>
+.plot-container {
+  width: 100%;
+  height: 300px;
+}
+
+/* Same muted look as AiPanel.vue's .info items */
+.plot-missing {
+  text-align: center;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.65);
+  background-color: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 6px 12px;
+  margin: 2px 0;
+}
+</style>

--- a/src/plotly-dist-min.d.ts
+++ b/src/plotly-dist-min.d.ts
@@ -1,0 +1,1 @@
+declare module "plotly.js-dist-min";

--- a/src/store/aiPanel.test.ts
+++ b/src/store/aiPanel.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/agent/conversationStore", () => ({
   loadStoredConversation: vi.fn(async () => null),
   saveStoredConversation: vi.fn(async () => {}),
   clearStoredConversation: vi.fn(async () => {}),
+  selectPlotsForStorage: vi.fn(() => []),
 }));
 
 // Mocked relative to the module under test, same directory, so it resolves to
@@ -400,5 +401,29 @@ describe("AI panel persistence", () => {
     await aiPanel.sendUserMessage("now it works");
     expect(postAgentMessage).toHaveBeenCalled();
     expect(lastSentPayload()).toContain("now it works");
+  });
+
+  it("releases the hydration guard when cleared mid-load", async () => {
+    // A plain clearConversation during the hydration await bumps
+    // conversationGeneration. The guard release keys off a dedicated hydration
+    // counter, not conversationGeneration -- otherwise this in-flight hydration
+    // mistakes the clear for a newer hydration, skips releasing `hydrating`,
+    // and strands it true so every later send is silently swallowed.
+    let resolveLoad: (value: any) => void = () => {};
+    mockLoad.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+
+    const change = aiPanel.handleAuthenticatedUserChange("userCleared");
+    aiPanel.clearConversation(); // bumps conversationGeneration mid-hydration
+    resolveLoad(null);
+    await change;
+
+    // The guard must be released, so a subsequent send is not swallowed.
+    await aiPanel.sendUserMessage("after the clear");
+    expect(postAgentMessage).toHaveBeenCalled();
+    expect(lastSentPayload()).toContain("after the clear");
   });
 });

--- a/src/store/aiPanel.test.ts
+++ b/src/store/aiPanel.test.ts
@@ -403,6 +403,34 @@ describe("AI panel persistence", () => {
     expect(lastSentPayload()).toContain("now it works");
   });
 
+  it("discards a plot from a tool whose conversation was cleared mid-run", async () => {
+    await aiPanel.handleAuthenticatedUserChange("userA");
+    postAgentMessage.mockResolvedValueOnce(
+      toolUseResponse("create_scatter_plot"),
+    );
+
+    // The plot tool resolves only after the conversation is cleared (e.g. an
+    // account change mid-analysis). Its plot must not leak into the now-current
+    // conversation's transcript.
+    let resolveTool: (value: any) => void = () => {};
+    mockExecuteAgentTool.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveTool = resolve;
+      }),
+    );
+    const turn = aiPanel.sendUserMessage("plot it");
+    await waitFor(() => mockExecuteAgentTool.mock.calls.length > 0);
+
+    aiPanel.clearConversation(true); // bumps the generation mid-tool
+    resolveTool({
+      result: { plotId: "plot-leak" },
+      plots: [{ id: "plot-leak", title: "leaked plot" }],
+    });
+    await turn;
+
+    expect(aiPanel.items.some((i) => i.kind === "plot")).toBe(false);
+  });
+
   it("releases the hydration guard when cleared mid-load", async () => {
     // A plain clearConversation during the hydration await bumps
     // conversationGeneration. The guard release keys off a dedicated hydration

--- a/src/store/aiPanel.ts
+++ b/src/store/aiPanel.ts
@@ -32,7 +32,9 @@ import {
   clearStoredConversation,
   loadStoredConversation,
   saveStoredConversation,
+  selectPlotsForStorage,
 } from "@/agent/conversationStore";
+import { clearPlots, listPlots, restorePlots } from "@/agent/plotRegistry";
 import { dataUrlToBase64 } from "@/utils/interfaceCapture";
 
 // AI panel: conversational agent that drives the interface through the tool
@@ -49,13 +51,15 @@ export type TAgentToolStatus =
   | "declined";
 
 export interface IAgentPanelItem {
-  kind: "user" | "assistant" | "tool" | "info" | "error";
+  kind: "user" | "assistant" | "tool" | "info" | "error" | "plot";
   // Message text; for tool items, a human-readable action description
   text: string;
   toolName?: string;
   status?: TAgentToolStatus;
   // Short outcome note for tool items (e.g. "42 annotations affected")
   detail?: string;
+  // For plot items: id into the plot registry (src/agent/plotRegistry.ts)
+  plotId?: string;
 }
 
 // Upper bound on model round-trips per user message; the backend has a
@@ -135,6 +139,9 @@ function toolResultDetail(result: any): string | undefined {
   }
   if (typeof result.filteredCount === "number") {
     return `${result.filteredCount} annotations pass the filter`;
+  }
+  if (typeof result.pointCount === "number") {
+    return `${result.pointCount.toLocaleString()} points`;
   }
   if (result.jobId) {
     return "job started";
@@ -263,6 +270,7 @@ export class AiPanel extends VuexModule {
     }
     wireMessages = [];
     turnSnapshot = null;
+    clearPlots();
     conversationGeneration++;
     this.clearItemsImpl();
     this.setCanRevert(false);
@@ -330,6 +338,7 @@ export class AiPanel extends VuexModule {
       if (stored && stored.userId === userId) {
         // Same user (e.g. a page reload): rehydrate the conversation.
         wireMessages = stored.wireMessages;
+        restorePlots(stored.plots ?? []);
         this.setItems(stored.items);
       } else {
         // A different user's conversation must never surface here.
@@ -508,6 +517,7 @@ export class AiPanel extends VuexModule {
           userId: lastKnownUserId,
           items: [...this.items],
           wireMessages,
+          plots: selectPlotsForStorage(this.items, listPlots()),
           updatedAt: Date.now(),
         });
       }
@@ -602,7 +612,7 @@ export class AiPanel extends VuexModule {
       // Late notifications (e.g. worker completion) reference this
       // conversation; drop them if it has been cleared in the meantime.
       const generation = conversationGeneration;
-      const { result, images } = await executeAgentTool(
+      const { result, images, plots } = await executeAgentTool(
         toolUse.name,
         toolUse.input,
         {
@@ -622,6 +632,11 @@ export class AiPanel extends VuexModule {
         index: itemIndex,
         changes: { status: "done", detail: toolResultDetail(result) },
       });
+      // Each created plot gets its own transcript item, rendered by
+      // AiPanelPlot from the plot registry.
+      for (const plot of plots ?? []) {
+        this.addItemImpl({ kind: "plot", plotId: plot.id, text: plot.title });
+      }
       if (VIEW_STATE_TOOLS.has(toolUse.name)) {
         this.setCanRevert(true);
       }

--- a/src/store/aiPanel.ts
+++ b/src/store/aiPanel.ts
@@ -34,7 +34,12 @@ import {
   saveStoredConversation,
   selectPlotsForStorage,
 } from "@/agent/conversationStore";
-import { clearPlots, listPlots, restorePlots } from "@/agent/plotRegistry";
+import {
+  clearPlots,
+  listPlots,
+  removePlot,
+  restorePlots,
+} from "@/agent/plotRegistry";
 import { dataUrlToBase64 } from "@/utils/interfaceCapture";
 
 // AI panel: conversational agent that drives the interface through the tool
@@ -618,10 +623,12 @@ export class AiPanel extends VuexModule {
       }
     }
 
+    // Captured before the await so both the success and error paths can tell
+    // whether the conversation was cleared or switched to another user (e.g. a
+    // mid-analysis account change) while this tool ran. Late notifications
+    // (e.g. worker completion) reference this conversation too.
+    const generation = conversationGeneration;
     try {
-      // Late notifications (e.g. worker completion) reference this
-      // conversation; drop them if it has been cleared in the meantime.
-      const generation = conversationGeneration;
       const { result, images, plots } = await executeAgentTool(
         toolUse.name,
         toolUse.input,
@@ -638,6 +645,25 @@ export class AiPanel extends VuexModule {
             turnSnapshot != null && viewIdentityChangedSince(turnSnapshot),
         },
       );
+      if (generation !== conversationGeneration) {
+        // The conversation was cleared or switched to another user while this
+        // tool was awaiting. Its plots and transcript items must not leak into
+        // the now-current conversation: unregister the plots it created (they
+        // were added to the global registry inside the executor) and skip every
+        // transcript update. The outer loop drops the returned tool_result via
+        // the same generation check.
+        for (const plot of plots ?? []) {
+          removePlot(plot.id);
+        }
+        return {
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: toResultContent({
+            discarded: true,
+            reason: "The conversation was cleared before this action finished.",
+          }),
+        };
+      }
       this.updateItemImpl({
         index: itemIndex,
         changes: { status: "done", detail: toolResultDetail(result) },
@@ -657,6 +683,18 @@ export class AiPanel extends VuexModule {
       };
     } catch (error: any) {
       const message = error?.message ?? "Tool execution failed";
+      if (generation !== conversationGeneration) {
+        // Cleared/switched mid-tool; don't touch the now-current transcript.
+        return {
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: toResultContent({
+            discarded: true,
+            reason: "The conversation was cleared before this action finished.",
+          }),
+          is_error: true,
+        };
+      }
       this.updateItemImpl({
         index: itemIndex,
         changes: { status: "error", detail: message },

--- a/src/store/aiPanel.ts
+++ b/src/store/aiPanel.ts
@@ -93,6 +93,13 @@ let panelElement: HTMLElement | null = null;
 // job finishing minutes after its conversation was cleared) are dropped
 // instead of landing in an unrelated conversation.
 let conversationGeneration = 0;
+// Bumped once per hydration attempt, by handleAuthenticatedUserChange only, to
+// decide which invocation owns releasing the `hydrating` guard. Kept separate
+// from conversationGeneration (which clearConversation also bumps): a plain
+// clear during an in-flight hydration must not make that hydration mistake the
+// bump for a newer hydration and skip releasing the guard — that would strand
+// `hydrating` true and block every future send.
+let hydrationGeneration = 0;
 // Identity of the last authenticated user the conversation belonged to, so a
 // login/logout (client-side, no page reload) clears the prior user's history.
 // `undefined` until the first check runs.
@@ -322,6 +329,7 @@ export class AiPanel extends VuexModule {
     // generation now so we can tell, after the await, whether a newer change
     // superseded this one.
     const generationAtChange = conversationGeneration;
+    const hydrationAtChange = ++hydrationGeneration;
     hydrating = true;
     try {
       const stored = await loadStoredConversation();
@@ -345,9 +353,11 @@ export class AiPanel extends VuexModule {
         await clearStoredConversation();
       }
     } finally {
-      // Only release the guard if we're still the current change; a newer
-      // in-flight change owns it until it settles.
-      if (conversationGeneration === generationAtChange) {
+      // Release the guard unless a newer hydration started while we awaited —
+      // that newer one owns it and its own finally will release it. Gated on
+      // hydrationGeneration, not conversationGeneration, so a plain clear (which
+      // bumps only conversationGeneration) can't leave `hydrating` stuck true.
+      if (hydrationGeneration === hydrationAtChange) {
         hydrating = false;
       }
     }


### PR DESCRIPTION
## Agentic data analysis in the AI panel

Builds the agentic property-value analysis of #1221 **on top of the AI panel
(#1231)** instead of as a separate server-side agent loop. This PR is based on
the #1231 branch so the diff shows only the data-analysis work; it should be
retargeted to `master` (or merged after) once #1231 lands. **Supersedes #1221**
— that PR can be closed.

Full design + verification: `codebaseDocumentation/AI_PANEL_DATA_ANALYSIS_SPEC.md`.

### Approach
The AI-panel agent loop already runs in the browser and the frontend already
holds every property value in memory, so the analysis tools are **frontend
executors on the existing `/claude_agent` surface** — **no backend Python code
changes** (only the plugin's tool-definition JSON + system-prompt data files).
The #1221 invariant is preserved: plots build their Plotly traces client-side,
park them in a panel-local registry, and return only `{plotId, title, count}`
to the model, so raw per-annotation data never enters the model context.

### What's added
- **Six tools**: `get_property_values` extended with std/median/p25/p75, plus
  new `get_property_histogram`, `get_sample_values`, `create_scatter_plot`,
  `create_histogram_plot`, `create_box_plot` (all read-only, ungated).
- `src/agent/analysis.ts` (pure stat helpers) and `src/agent/plotRegistry.ts`
  (plot data lives outside Vuex; avoids a circular import).
- `kind:"plot"` transcript items rendered by `AiPanelPlot.vue`, which
  **lazy-loads `plotly.js-dist-min`** — the production build code-splits it into
  its own ~4.6 MB chunk, never the main bundle.
- Plots persist to IndexedDB (≤12, size-capped) and re-render across reload.

### Analysis reflects live annotations
`collectPathValues`/`get_sample_values` intersect with the live annotation set
rather than iterating raw `propertyValues` keys, so deleted annotations' values
don't inflate stats or add a spurious "untagged" group to tag-grouped plots.
The underlying backend cleanup gap is filed separately as #1243.

### Also in this PR
- Fixes a **pre-existing race** in `aiPanel.ts` (from #1231): clearing the
  conversation during the post-reload IndexedDB hydration could strand the
  `hydrating` send-guard and silently block all sends. Fixed with a dedicated
  `hydrationGeneration` counter + regression test. (This also repaired the
  `aiPanel.test.ts` conversationStore mock, which #1231 phase 3 had broken —
  only `src/agent` had been run in CI-equivalent checks.)

### Verification
- `pnpm tsc`, `pnpm lint:ci` clean; **189 `src/agent` + `src/store` tests pass**.
- Production build confirms Plotly is a separate lazy chunk.
- **Live-tested** against a real dataset (2,618 nuclei with computed intensity +
  morphology): histogram / scatter-by-tag / box-by-tag / query restriction all
  render inline; reported stats match MongoDB ground truth (Area mean 367.9,
  std 106.6, range 25–975); the raw-data invariant holds on the wire (plot
  tool_results ~23 KB, no value arrays); conversation + plots persist and
  re-render across reload; a mixed analysis→`set_annotation_filter` turn reverts
  cleanly; and the live-set fix drops the unrestricted scatter from 5,237 to
  the 2,618 real nuclei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
