### PR TITLE
Reset annotation filters when switching datasets

### DIFF
--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyFilterHistogram.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyFilterHistogram.vue
@@ -375,6 +375,12 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  // Disabling on unmount is load-bearing: when a filter is removed
+  // (removeFilter drops its path from filterPaths but leaves the entry in
+  // propertyFilters), this is what stops the orphaned entry from continuing
+  // to filter. Do not remove it. Side effect: on a dataset switch,
+  // resetFilterState clears propertyFilters first, then this re-adds one
+  // disabled (inert) orphan — see filters.ts resetFilterStateImpl.
   if (propertyFilter.value.enabled) {
     filterStore.updatePropertyFilter({
       ...propertyFilter.value,

--- a/src/store/filters.test.ts
+++ b/src/store/filters.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression test for the property-filter leak across dataset switches.
+ *
+ * Bug: switching datasets left the previous dataset's property filters (and
+ * ROI / tag / selection / id filters) in the global `filters` module. In the
+ * next dataset those chips referenced property IDs that no longer resolved, so
+ * they rendered as broken, uneditable filters the user had to delete by hand.
+ *
+ * Fix: `setSelectedDataset` now dispatches `resetFilterState` alongside the
+ * existing annotation/property resets. This test pins the reset behavior:
+ * every dataset-scoped field is cleared, while the generic `onlyCurrentFrame`
+ * view toggle is preserved.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The filters module only touches these dependencies inside getters/actions
+// that this test does not exercise, but they must be importable so the module
+// evaluates. Mock them to avoid pulling in the full store/geojs graph.
+vi.mock("./index", () => ({
+  default: { xy: 0, z: 0, time: 0, dataset: null },
+}));
+vi.mock("./annotation", () => ({
+  default: { annotations: [], selectedAnnotationIds: ["a", "b"] },
+}));
+vi.mock("./properties", () => ({
+  default: {
+    propertyValues: {},
+    propertiesAPI: { getPropertyHistogram: () => Promise.resolve([]) },
+  },
+}));
+vi.mock("geojs", () => ({
+  default: { util: { pointInPolygon: () => false } },
+}));
+vi.mock("@/utils/annotation", () => ({
+  tagCloudFilterFunction: () => true,
+}));
+
+import filters from "./filters";
+import { PropertyFilterMode } from "./model";
+
+function populateEveryFilter() {
+  filters.setTagFilter({
+    id: "tagFilter",
+    exclusive: true,
+    enabled: true,
+    tags: ["nucleus", "red blob"],
+  });
+  filters.togglePropertyPathFiltering(["prop-id-from-dataset-A", "Area"]);
+  filters.updatePropertyFilter({
+    range: { min: 400, max: 975 },
+    id: "filter-A",
+    propertyPath: ["prop-id-from-dataset-A", "Area"],
+    exclusive: false,
+    enabled: true,
+    valuesOrRange: PropertyFilterMode.Range,
+  });
+  filters.newROIFilter();
+  filters.validateNewROIFilter([{ x: 0, y: 0 }] as any);
+  filters.newROIFilter(); // leaves an in-progress emptyROIFilter set
+  filters.newAnnotationIdFilter(["ann-1", "ann-2"]);
+  filters.addSelectionAsFilter(); // reads annotation.selectedAnnotationIds
+  filters.setPropertyHistograms({ "prop-id-from-dataset-A###Area": [] as any });
+}
+
+describe("filters.resetFilterState", () => {
+  beforeEach(() => {
+    filters.resetFilterState();
+    filters.setOnlyCurrentFrame(false);
+  });
+
+  it("clears every dataset-scoped filter so nothing leaks into the next dataset", () => {
+    populateEveryFilter();
+
+    // Sanity: state is actually populated before the reset.
+    expect(filters.propertyFilters.length).toBe(1);
+    expect(filters.filterPaths.length).toBe(1);
+    expect(filters.roiFilters.length).toBe(1);
+    expect(filters.emptyROIFilter).not.toBeNull();
+    expect(filters.annotationIdFilters.length).toBe(1);
+    expect(filters.tagFilter.tags.length).toBe(2);
+    expect(filters.selectionFilter.enabled).toBe(true);
+    expect(Object.keys(filters.histograms).length).toBe(1);
+
+    filters.resetFilterState();
+
+    expect(filters.propertyFilters).toEqual([]);
+    expect(filters.filterPaths).toEqual([]);
+    expect(filters.roiFilters).toEqual([]);
+    expect(filters.emptyROIFilter).toBeNull();
+    expect(filters.annotationIdFilters).toEqual([]);
+    expect(filters.histograms).toEqual({});
+    expect(filters.tagFilter.enabled).toBe(false);
+    expect(filters.tagFilter.tags).toEqual([]);
+    expect(filters.selectionFilter.enabled).toBe(false);
+    expect(filters.selectionFilter.annotationIds).toEqual([]);
+  });
+
+  it("preserves the generic onlyCurrentFrame view toggle across a reset", () => {
+    filters.setOnlyCurrentFrame(true);
+
+    filters.resetFilterState();
+
+    expect(filters.onlyCurrentFrame).toBe(true);
+  });
+});

--- a/src/store/filters.test.ts
+++ b/src/store/filters.test.ts
@@ -36,7 +36,11 @@ vi.mock("@/utils/annotation", () => ({
 }));
 
 import filters from "./filters";
-import { PropertyFilterMode } from "./model";
+import {
+  IGeoJSPosition,
+  PropertyFilterMode,
+  TPropertyHistogram,
+} from "./model";
 
 function populateEveryFilter() {
   filters.setTagFilter({
@@ -55,11 +59,13 @@ function populateEveryFilter() {
     valuesOrRange: PropertyFilterMode.Range,
   });
   filters.newROIFilter();
-  filters.validateNewROIFilter([{ x: 0, y: 0 }] as any);
+  const roi: IGeoJSPosition[] = [{ x: 0, y: 0 }];
+  filters.validateNewROIFilter(roi);
   filters.newROIFilter(); // leaves an in-progress emptyROIFilter set
   filters.newAnnotationIdFilter(["ann-1", "ann-2"]);
   filters.addSelectionAsFilter(); // reads annotation.selectedAnnotationIds
-  filters.setPropertyHistograms({ "prop-id-from-dataset-A###Area": [] as any });
+  const histogram: TPropertyHistogram = [];
+  filters.setPropertyHistograms({ "prop-id-from-dataset-A###Area": histogram });
 }
 
 describe("filters.resetFilterState", () => {

--- a/src/store/filters.ts
+++ b/src/store/filters.ts
@@ -67,6 +67,43 @@ export class Filters extends VuexModule {
   annotationIdFilters: IIdAnnotationFilter[] = [];
 
   @Mutation
+  protected resetFilterStateImpl() {
+    // Every field below is scoped to a single dataset: property filters and
+    // filterPaths reference the previous dataset's property IDs, ROI filters
+    // hold coordinates from the previous image, and selection/id filters and
+    // histograms reference the previous dataset's annotations. Left in place,
+    // they render as broken, uneditable filter chips in the next dataset (the
+    // paths no longer resolve to any property). onlyCurrentFrame is a generic
+    // view toggle rather than stale data, so it is intentionally preserved.
+    this.tagFilter = {
+      id: "tagFilter",
+      exclusive: false,
+      enabled: false,
+      tags: [],
+    };
+    this.propertyFilters = [];
+    this.roiFilters = [];
+    this.emptyROIFilter = null;
+    this.selectionFilter = {
+      enabled: false,
+      exclusive: true,
+      id: "selection",
+      annotationIds: [],
+    };
+    this.filterPaths = [];
+    this.histograms = {};
+    this.annotationIdFilters = [];
+  }
+
+  // Clear per-dataset filter state. Call when switching datasets so stale
+  // filters (whose property paths / annotation IDs belong to the previous
+  // dataset) don't leak into the next one as broken, uneditable chips.
+  @Action
+  public resetFilterState() {
+    this.resetFilterStateImpl();
+  }
+
+  @Mutation
   togglePropertyPathFiltering(path: string[]) {
     const pathIdx = findIndexOfPath(path, this.filterPaths);
     if (pathIdx < 0) {

--- a/src/store/filters.ts
+++ b/src/store/filters.ts
@@ -75,6 +75,14 @@ export class Filters extends VuexModule {
     // they render as broken, uneditable filter chips in the next dataset (the
     // paths no longer resolve to any property). onlyCurrentFrame is a generic
     // view toggle rather than stale data, so it is intentionally preserved.
+    //
+    // Known limitation: clearing filterPaths unmounts the old dataset's
+    // PropertyFilterHistogram components, and their onBeforeUnmount re-adds a
+    // single *disabled* propertyFilter after this reset runs. That orphan is
+    // inert — it is excluded from filteredAnnotations (enabled === false) and
+    // never rendered (the panel iterates filterPaths, now empty) — and the
+    // next dataset switch clears it. See PropertyFilterHistogram.vue's
+    // onBeforeUnmount for why that disable step must stay.
     this.tagFilter = {
       id: "tagFilter",
       exclusive: false,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1431,10 +1431,21 @@ export class Main extends VuexModule {
   @Action
   async setSelectedDataset(id: string | null) {
     memDiag.autoSnapshot(`setSelectedDataset:enter id=${id ?? "null"}`);
+    // this.dataset still holds the previously selected dataset here (setDataset
+    // runs later), so this detects a genuine switch vs. a same-dataset refresh.
+    const datasetChanged = id !== this.dataset?.id;
     this.api.flushCaches();
     this.context.dispatch("resetAnnotationState");
     this.context.dispatch("resetPropertyState");
-    this.context.dispatch("resetFilterState");
+    // Filters hold unrecoverable user state (tag/property/ROI/ID filters), so
+    // only reset them on an actual dataset change. refreshDataset() re-runs
+    // setSelectedDataset with the same id (e.g. NavigatorPanel unroll toggles);
+    // wiping filters there would discard the user's active filters. The
+    // annotation/property resets above are safe to run every time because they
+    // are repopulated by the reload that follows.
+    if (datasetChanged) {
+      this.context.dispatch("resetFilterState");
+    }
     if (!id) {
       this.setDataset({ id, data: null });
       memDiag.autoSnapshot("setSelectedDataset:exit (null)");

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1434,6 +1434,7 @@ export class Main extends VuexModule {
     this.api.flushCaches();
     this.context.dispatch("resetAnnotationState");
     this.context.dispatch("resetPropertyState");
+    this.context.dispatch("resetFilterState");
     if (!id) {
       this.setDataset({ id, data: null });
       memDiag.autoSnapshot("setSelectedDataset:exit (null)");


### PR DESCRIPTION
## Problem

Applying a property filter in one dataset, closing it, and opening another dataset caused the first dataset's property filters to appear in the second one. Because property filters are keyed by the **previous** dataset's property IDs, the carried-over chips can't resolve to any property in the new dataset, so they render as broken, uneditable filters the user has to delete by hand. The same leak also affected ROI, tag, selection, and annotation-ID filters.

## Root cause

`setSelectedDataset` (`src/store/index.ts`) resets the two sibling per-dataset Vuex modules — `resetAnnotationState` and `resetPropertyState` — but the `filters` module was never reset, so its state survived across dataset switches.

## Fix

- Add a `resetFilterState` action + `resetFilterStateImpl` mutation to `src/store/filters.ts`, mirroring the existing reset pattern in `annotation.ts` / `properties.ts`. It clears every dataset-scoped field: `propertyFilters`, `filterPaths`, `roiFilters`, `emptyROIFilter`, `selectionFilter`, `annotationIdFilters`, `tagFilter`, and `histograms`.
- Dispatch it from `setSelectedDataset` next to the existing resets (same non-namespaced string-dispatch pattern, which avoids a circular import since `filters.ts` imports `./index`).
- `onlyCurrentFrame` is a generic view toggle rather than stale per-dataset data, so it is intentionally preserved.

## Verification

Reproduced and verified in the live app (localhost:5173) across two datasets:

- **Before:** switching from a dataset with an active `Area` property filter to another dataset showed the same broken chip (filtering out everything, `0` matches).
- **After:** the target dataset shows no leaked chip, `0` enabled filters, and zero filtering effect (`nFiltered === nAll`). The round-trip back is fully clean, and each dataset's tag filter correctly auto-populates with its own tags.

Added `src/store/filters.test.ts` (2 tests) pinning the reset behavior — confirmed to fail without the fix (`resetFilterState is not a function`) and pass with it.

`pnpm tsc`, `pnpm lint`, and the new test are all green.

## Known limitation (non-blocking)

During the transition, `PropertyFilterHistogram.vue`'s `onBeforeUnmount` re-adds a single **disabled** property filter after the reset runs. It is invisible (the panel renders chips from `filterPaths`, now empty), inert (filtering only uses enabled filters), bounded, and cleared on the next switch. The `onBeforeUnmount` disable is load-bearing for the normal "remove filter" flow, so it's deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)