### PR TITLE
fix(annotations): restore click-to-navigate/highlight in the annotation list

### DIFF
--- a/codebaseDocumentation/ANNOTATION-LIST-CLICK-NAV-REVIEW.md
+++ b/codebaseDocumentation/ANNOTATION-LIST-CLICK-NAV-REVIEW.md
@@ -1,0 +1,86 @@
+# Review Findings: stub-mode click-to-list navigation (anchorId)
+
+Branch: `claude/annotation-click-navigation-3ikbfj` — Codex fix reviewed by Claude
+(/branch-review) on 2026-07-17. Feature: clicking an annotation in the image
+viewer navigates the server-mode (stub) annotation list to the page containing
+that annotation, via a new `anchorId` option on `POST /upenn_annotation/list`.
+
+## Finding 1: `?? query.offset` fallback masks a stale backend
+
+- **Severity:** Medium — Frontend compensating for backend
+- **Location:** `src/store/AnnotationsAPI.ts` (`fetchAnnotationListPage` offset mapping)
+- **Problem:** The `?? query.offset` branch only fires against a backend that
+  doesn't return `offset` (an outdated one). Against a stale backend an anchor
+  request would resolve `offset: 0` and navigate to page 1 — recreating the
+  original bug instead of no-op'ing.
+- **Fix:** `offset: response.data.offset` with no fallback.
+- **Status:** fixed (working tree, 2026-07-17)
+
+## Finding 2: non-`_id` sorts pay a full filtered-set window walk per click
+
+- **Severity:** Low — Performance
+- **Location:** `server/models/annotation.py` (`listPosition` window path)
+- **Problem:** `$setWindowFields` sorts the entire filtered set (lookup join
+  included for property sorts) on every click for field/property-sorted lists —
+  on exactly the 100K+ datasets that trigger stub mode.
+- **Fix:** Fetch the anchor's normalized sort value inside the filtered set,
+  then count rows sorting strictly before it with a single `$expr` match
+  (no sort, no window, no disk spill). `$ifNull` normalization keeps
+  missing==null equivalence identical to `$sort` semantics; property sorts
+  compare `(_hasSortValue, _sortValue, _id)` explicitly.
+- **Equivalence guard:** `assertAnchorPagesSelfConsistent` test helper — for
+  every annotation, the anchor page must be page-aligned, contain the anchor,
+  and equal the plain offset-paged request at the returned offset. Exercised
+  over desc sorts, `_id` ties, missing `name` values, property sorts with and
+  without values, and property filters. All new tests were verified to pass
+  against the window implementation BEFORE the swap.
+- **Status:** fixed (working tree, 2026-07-17)
+
+## Finding 3: `fetchPageContaining` duplicates `fetchPage` scaffolding
+
+- **Severity:** Nit — Code duplication
+- **Location:** `src/store/annotationListServer.ts`
+- **Problem:** Both actions rebuild the same query object (filters, sort,
+  propertyPaths, limit).
+- **Fix:** Shared query-base getter spread by both actions.
+- **Status:** fixed (working tree, 2026-07-17)
+
+## Finding 4: user pagination clicks dropped while an anchor page mounts
+
+- **Severity:** Nit — UX / pattern
+- **Location:** `src/components/AnnotationBrowser/AnnotationList.vue`
+  (`suppressServerOptions` in `onServerOptions`)
+- **Problem:** While the boolean suppression is active (fetch + row-mount wait,
+  worst case ~1.5 s), a genuine user pagination click is silently swallowed —
+  the suppression can't tell it apart from Vuetify's stale options echo.
+- **Fix:** Snapshot the pre-navigation options when navigation starts. Drop
+  only an options event equal to the snapshot (the stale echo); any other
+  event is user intent — cancel the navigation and process it normally.
+  (Options matching the store state are still absorbed first, so a
+  post-navigation reconcile echo of the NEW options stays a no-op.)
+- **Status:** fixed (working tree, 2026-07-17)
+
+## Live verification (2026-07-17, Xenium 708,983-annotation dataset)
+
+Girder image rebuilt (not restarted — plugin is baked in). Verified in a
+foreground browser tab against stub mode (`stubOnlyMode: true`, total 708983):
+
+- **Backend anchor resolution:** `_id`-sort anchor at true offset 500000 →
+  returned offset 500000 in 0.27 s; `location.XY`-sort anchor at true offset
+  400000 → returned offset 400000, page-aligned, contains anchor, 1.9 s (range
+  count, no full-set sort). Cross-checked the anchor page equals the plain
+  offset-paged request.
+- **Injected-hover navigation (Finding 1/2/3 path):** setting
+  `hoveredAnnotationId` to the offset-500000 anchor moved the list page 1 →
+  50001; DOM footer read "500001-500010 of 708983"; anchor row highlighted and
+  scrolled to top.
+- **Real click (full chain):** clicking an annotation dot set
+  `hoveredAnnotationId` and navigated the list page 1 → 29335; anchor present in
+  rendered rows (position 0) with a `tr.is-hovered` highlight in the DOM.
+- **Normal pagination (Finding 4 regression):** real-click "next" advanced
+  50001 → 50002; clearing the hover did not spuriously navigate.
+
+Gates: flake8 clean; 305 backend tests pass; 2651 frontend tests pass; `pnpm
+tsc` and `pnpm lint:ci` clean.
+
+**Not committed** — awaiting user sign-off.

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -593,7 +593,7 @@ class Annotation(Resource):
     @describeRoute(
         Description("List annotations (paged), stub-shaped + property values")
         .param("body", "JSON: {datasetId, filters, sort, propertyPaths, "
-                       "offset, limit}", paramType="body")
+                       "offset, limit, anchorId?}", paramType="body")
         .errorResponse()
         .errorResponse("Read access denied.", 403)
     )
@@ -607,6 +607,11 @@ class Annotation(Resource):
         filters = bodyJson.get("filters") or {}
         sort = bodyJson.get("sort")
         propertyPaths = bodyJson.get("propertyPaths") or []
+        anchorIdValue = bodyJson.get("anchorId")
+        anchorId = (
+            requireObjectId(anchorIdValue, "anchorId")
+            if anchorIdValue is not None else None
+        )
         # Parse-or-400 at the boundary, then clamp: a non-integer
         # offset/limit would otherwise raise an uncaught int() error -> 500 on
         # this public endpoint. The limit is clamped to MAX_LIST_LIMIT so a
@@ -625,14 +630,34 @@ class Annotation(Resource):
         # field (ValueError -> 400) before the expensive count aggregation
         # runs, so a bad sort key doesn't pay for a full count.
         try:
-            cursor = self._annotationModel.listPage(
-                datasetId, filters, sort, propertyPaths, offset, limit
+            resolvedOffset = offset
+            if anchorId is not None:
+                position = self._annotationModel.listPosition(
+                    datasetId, filters, sort, anchorId
+                )
+                resolvedOffset = (
+                    (position // limit) * limit
+                    if position is not None else None
+                )
+            cursor = (
+                self._annotationModel.listPage(
+                    datasetId, filters, sort, propertyPaths,
+                    resolvedOffset, limit
+                )
+                if resolvedOffset is not None else []
             )
         except ValueError as e:
             raise RestException(str(e), code=400)
         total = self._annotationModel.listCount(datasetId, filters)
 
-        prefix = b'{"total":' + str(total).encode() + b',"rows":['
+        encodedOffset = (
+            b"null" if resolvedOffset is None
+            else str(resolvedOffset).encode()
+        )
+        prefix = (
+            b'{"total":' + str(total).encode()
+            + b',"offset":' + encodedOffset + b',"rows":['
+        )
         setResponseHeader("Content-Type", "application/json")
         return _streamJsonArray(
             cursor, prefix=prefix, suffix=b"]}", default=orJsonDefaults

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
@@ -366,10 +366,7 @@ class Annotation(AccessControlMixin, ProxiedModel):
             cursor = self._aggregate(self._pvModel.collection, pipeline)
             return [str(doc["annotationId"]) for doc in cursor]
 
-        pipeline = self._buildListMatchStages(datasetId, filters)
-        if filters.get("propertyFilters"):
-            pipeline += self._lookupStages()
-            pipeline += self._propertyFilterStages(filters)
+        pipeline = self._annotationDrivenStages(datasetId, filters)
         pipeline.append({"$project": {"_id": 1}})
         cursor = self._aggregate(self.collection, pipeline)
         return [str(doc["_id"]) for doc in cursor]
@@ -627,10 +624,7 @@ class Annotation(AccessControlMixin, ProxiedModel):
             result = list(self._aggregate(self._pvModel.collection, pipeline))
             return result[0]["n"] if result else 0
 
-        pipeline = self._buildListMatchStages(datasetId, filters)
-        if filters.get("propertyFilters"):
-            pipeline += self._lookupStages()
-            pipeline += self._propertyFilterStages(filters)
+        pipeline = self._annotationDrivenStages(datasetId, filters)
         pipeline.append({"$count": "n"})
         result = list(self._aggregate(self.collection, pipeline))
         return result[0]["n"] if result else 0
@@ -644,12 +638,7 @@ class Annotation(AccessControlMixin, ProxiedModel):
         transfer of the full matching id set to the browser.
         """
         def basePipeline():
-            pipeline = self._buildListMatchStages(datasetId, filters)
-            if self._needsPropertyBeforePage(filters, sort):
-                pipeline += self._lookupStages()
-                pipeline += self._propertyFilterStages(filters)
-                pipeline += self._propertySortAddFields(sort)
-            return pipeline
+            return self._annotationDrivenStages(datasetId, filters, sort)
 
         # The default list order is _id ascending, and explicit _id sorting
         # is also common. Resolve that position with an indexed range count
@@ -687,7 +676,8 @@ class Annotation(AccessControlMixin, ProxiedModel):
         # replicates the page order (_hasSortValue desc, value asc/desc, _id
         # asc) as an expression. $ifNull maps a missing field to null exactly
         # like $sort does, so missing and null order identically here and in
-        # listPage.
+        # listPage. `sort` is never None here: the isIdSort branch above
+        # returns for a missing sort.
         descending = sort.get("order") == "desc"
         if sort.get("type") == "property":
             valueRef = {"$ifNull": ["$_sortValue", None]}
@@ -849,6 +839,21 @@ class Annotation(AccessControlMixin, ProxiedModel):
             return True
         return bool(filters.get("propertyFilters"))
 
+    def _annotationDrivenStages(self, datasetId, filters, sort=None):
+        """Annotation-driven pipeline prefix shared by the list queries.
+
+        Match stages over annotation-document fields, plus -- only when a
+        property filter (or property sort) requires the values before
+        pagination -- the property-value join, property filters, and the
+        property sort fields.
+        """
+        pipeline = self._buildListMatchStages(datasetId, filters)
+        if self._needsPropertyBeforePage(filters, sort):
+            pipeline += self._lookupStages()
+            pipeline += self._propertyFilterStages(filters)
+            pipeline += self._propertySortAddFields(sort)
+        return pipeline
+
     def listPage(self, datasetId, filters, sort, propertyPaths,
                  offset, limit):
         skip = max(0, offset)
@@ -880,10 +885,7 @@ class Annotation(AccessControlMixin, ProxiedModel):
         # sort/filter (the PV docs don't carry those fields), or a field sort
         # accompanies a property filter. Join, filter, sort, then paginate on
         # the annotation collection.
-        pipeline = self._buildListMatchStages(datasetId, filters)
-        pipeline += self._lookupStages()
-        pipeline += self._propertyFilterStages(filters)
-        pipeline += self._propertySortAddFields(sort)
+        pipeline = self._annotationDrivenStages(datasetId, filters, sort)
         pipeline.append(self._sortStage(sort))
         pipeline.append({"$skip": skip})
         pipeline.append({"$limit": limit})

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/annotation.py
@@ -635,6 +635,118 @@ class Annotation(AccessControlMixin, ProxiedModel):
         result = list(self._aggregate(self.collection, pipeline))
         return result[0]["n"] if result else 0
 
+    def listPosition(self, datasetId, filters, sort, annotationId):
+        """Zero-based position of an annotation in a filtered/sorted list.
+
+        This intentionally uses the annotation-driven form for every query.
+        It has the same filter and ordering semantics as listPage, including
+        property filters/sorts and the stable _id tie-break, while avoiding
+        transfer of the full matching id set to the browser.
+        """
+        def basePipeline():
+            pipeline = self._buildListMatchStages(datasetId, filters)
+            if self._needsPropertyBeforePage(filters, sort):
+                pipeline += self._lookupStages()
+                pipeline += self._propertyFilterStages(filters)
+                pipeline += self._propertySortAddFields(sort)
+            return pipeline
+
+        # The default list order is _id ascending, and explicit _id sorting
+        # is also common. Resolve that position with an indexed range count
+        # on _id directly (no sort-value fetch needed).
+        isIdSort = not sort or (
+            sort.get("type") == "field" and sort.get("key") == "_id"
+        )
+        if isIdSort:
+            targetPipeline = basePipeline()
+            targetPipeline += [
+                {"$match": {"_id": annotationId}},
+                {"$limit": 1},
+                {"$project": {"_id": 1}},
+            ]
+            if next(iter(self._aggregate(
+                    self.collection, targetPipeline)), None) is None:
+                return None
+
+            comparison = "$gt" if (
+                sort and sort.get("order") == "desc"
+            ) else "$lt"
+            countPipeline = basePipeline()
+            countPipeline += [
+                {"$match": {"_id": {comparison: annotationId}}},
+                {"$count": "position"},
+            ]
+            result = next(iter(self._aggregate(
+                self.collection, countPipeline
+            )), None)
+            return result["position"] if result else 0
+
+        # Non-_id sorts: fetch the anchor's sort value inside the filtered
+        # set, then COUNT the rows that sort strictly before it -- the same
+        # match/lookup stages, but no full-set $sort or window walk. "Before"
+        # replicates the page order (_hasSortValue desc, value asc/desc, _id
+        # asc) as an expression. $ifNull maps a missing field to null exactly
+        # like $sort does, so missing and null order identically here and in
+        # listPage.
+        descending = sort.get("order") == "desc"
+        if sort.get("type") == "property":
+            valueRef = {"$ifNull": ["$_sortValue", None]}
+            hasValueRef = "$_hasSortValue"
+        else:
+            key = sort.get("key")
+            if key not in self._SORTABLE_FIELDS:
+                raise ValueError("Invalid sort field: %s" % key)
+            valueRef = {"$ifNull": ["$" + key, None]}
+            hasValueRef = None
+
+        anchorPipeline = basePipeline()
+        anchorPipeline += [
+            {"$match": {"_id": annotationId}},
+            {"$limit": 1},
+            {"$project": {
+                "_id": 0,
+                "value": valueRef,
+                "hasValue": hasValueRef or {"$literal": 1},
+            }},
+        ]
+        anchor = next(iter(self._aggregate(
+            self.collection, anchorPipeline)), None)
+        if anchor is None:
+            return None
+
+        idBefore = {"$lt": ["$_id", annotationId]}
+        if hasValueRef is not None and not anchor["hasValue"]:
+            # The anchor lacks a value for the property sort key, so every
+            # row WITH a value precedes it (_hasSortValue sorts descending
+            # first regardless of direction); among no-value rows the order
+            # is _id ascending.
+            before = {"$or": [
+                {"$eq": [hasValueRef, 1]},
+                {"$and": [{"$eq": [hasValueRef, 0]}, idBefore]},
+            ]}
+        else:
+            valueCmp = "$gt" if descending else "$lt"
+            strictlyBefore = {valueCmp: [valueRef, anchor["value"]]}
+            tieBefore = {"$and": [
+                {"$eq": [valueRef, anchor["value"]]}, idBefore,
+            ]}
+            before = {"$or": [strictlyBefore, tieBefore]}
+            if hasValueRef is not None:
+                # The anchor has a value: only value-bearing rows can
+                # precede it (no-value rows always sort after them).
+                before = {"$and": [
+                    {"$eq": [hasValueRef, 1]}, before,
+                ]}
+
+        countPipeline = basePipeline()
+        countPipeline += [
+            {"$match": {"$expr": before}},
+            {"$count": "position"},
+        ]
+        result = next(iter(self._aggregate(
+            self.collection, countPipeline)), None)
+        return result["position"] if result else 0
+
     def _propertyComputeMatch(self, shape, tagSpec):
         """Match expression for the annotations a property CAN be computed on.
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_server_list.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_server_list.py
@@ -39,6 +39,37 @@ def postList(server, user, path, body):
     )
 
 
+def assertAnchorPagesSelfConsistent(server, admin, datasetId, annotationIds,
+                                    sort, limit, filters=None,
+                                    propertyPaths=None):
+    """For every annotation: the anchor page must be page-aligned, contain
+    the anchor, and be byte-identical to the plain offset-paged request at
+    the returned offset — i.e. listPosition agrees with listPage ordering."""
+    base = {
+        "datasetId": str(datasetId),
+        "filters": filters or {},
+        "sort": sort,
+        "propertyPaths": propertyPaths or [],
+        "limit": limit,
+    }
+    for annotationId in annotationIds:
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            **base, "offset": 0, "anchorId": str(annotationId),
+        })
+        assertStatusOk(resp)
+        anchored = parseStreaming(resp)
+        assert anchored["offset"] is not None
+        assert anchored["offset"] % limit == 0
+        anchoredIds = [str(r["_id"]) for r in anchored["rows"]]
+        assert str(annotationId) in anchoredIds
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            **base, "offset": anchored["offset"],
+        })
+        assertStatusOk(resp)
+        paged = [str(r["_id"]) for r in parseStreaming(resp)["rows"]]
+        assert anchoredIds == paged
+
+
 @pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
 @pytest.mark.plugin("upenncontrast_annotation")
 class TestServerListIds:
@@ -133,6 +164,129 @@ class TestServerListPage:
         xys = [r["location"]["XY"] for r in result["rows"]]
         assert xys == [2, 1, 0]
 
+    def testListAnchorReturnsContainingPage(self, admin, server):
+        folder = utilities.createFolder(
+            admin, "ds", upenn_utilities.datasetMetadata
+        )
+        annotations = []
+        for i in range(5):
+            annotations.append(makeAnnotation(
+                folder["_id"], location={"XY": i, "Z": 0, "Time": 0}
+            ))
+
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {},
+            "sort": {"type": "field", "key": "location.XY",
+                     "order": "asc"},
+            "propertyPaths": [], "offset": 0, "limit": 2,
+            "anchorId": str(annotations[3]["_id"]),
+        })
+        assertStatusOk(resp)
+        result = parseStreaming(resp)
+        assert result["offset"] == 2
+        assert [r["location"]["XY"] for r in result["rows"]] == [2, 3]
+
+    def testListAnchorOutsideFiltersReturnsNoPage(self, admin, server):
+        folder = utilities.createFolder(
+            admin, "ds", upenn_utilities.datasetMetadata
+        )
+        target = makeAnnotation(folder["_id"], tags=["excluded"])
+        makeAnnotation(folder["_id"], tags=["included"])
+
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {"tags": {
+                "values": ["included"], "exclusive": False,
+            }},
+            "sort": None, "propertyPaths": [], "offset": 0, "limit": 10,
+            "anchorId": str(target["_id"]),
+        })
+        assertStatusOk(resp)
+        result = parseStreaming(resp)
+        assert result["total"] == 1
+        assert result["offset"] is None
+        assert result["rows"] == []
+
+    def testListAnchorFieldSortDescending(self, admin, server):
+        folder = utilities.createFolder(
+            admin, "ds", upenn_utilities.datasetMetadata
+        )
+        annotations = [
+            makeAnnotation(folder["_id"], location={"XY": i, "Z": 0,
+                                                    "Time": 0})
+            for i in range(5)
+        ]
+
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {},
+            "sort": {"type": "field", "key": "location.XY",
+                     "order": "desc"},
+            "propertyPaths": [], "offset": 0, "limit": 2,
+            # Descending order is 4,3,2,1,0 so XY=1 is at position 3.
+            "anchorId": str(annotations[1]["_id"]),
+        })
+        assertStatusOk(resp)
+        result = parseStreaming(resp)
+        assert result["offset"] == 2
+        assert [r["location"]["XY"] for r in result["rows"]] == [2, 1]
+
+    def testListAnchorEqualSortValuesTieBrokenById(self, admin, server):
+        folder = utilities.createFolder(
+            admin, "ds", upenn_utilities.datasetMetadata
+        )
+        annotations = [
+            makeAnnotation(folder["_id"], location={"XY": 7, "Z": 0,
+                                                    "Time": 0})
+            for _ in range(3)
+        ]
+
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {},
+            "sort": {"type": "field", "key": "location.XY", "order": "asc"},
+            "propertyPaths": [], "offset": 0, "limit": 1,
+            # All XY equal: order falls back to _id asc (creation order).
+            "anchorId": str(annotations[1]["_id"]),
+        })
+        assertStatusOk(resp)
+        result = parseStreaming(resp)
+        assert result["offset"] == 1
+        assert str(result["rows"][0]["_id"]) == str(annotations[1]["_id"])
+
+    def testListAnchorNameSortWithMissingNames(self, admin, server):
+        # `name` is a nullable sort field: a missing name must order
+        # identically in the anchor position query and in the page sort
+        # (both treat missing as null).
+        folder = utilities.createFolder(
+            admin, "ds", upenn_utilities.datasetMetadata
+        )
+        annotations = [makeAnnotation(folder["_id"]) for _ in range(6)]
+        for unnamed in annotations[::2]:
+            Annotation().collection.update_one(
+                {"_id": unnamed["_id"]}, {"$unset": {"name": ""}}
+            )
+
+        for order in ("asc", "desc"):
+            assertAnchorPagesSelfConsistent(
+                server, admin, folder["_id"],
+                [a["_id"] for a in annotations],
+                {"type": "field", "key": "name", "order": order},
+                limit=2,
+            )
+
+    def testListRejectsInvalidAnchorId(self, admin, server):
+        folder = utilities.createFolder(
+            admin, "ds", upenn_utilities.datasetMetadata
+        )
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {}, "offset": 0, "limit": 10,
+            "anchorId": "not-an-object-id",
+        })
+        assertStatus(resp, 400)
+
     def testInvalidFieldSortReturns400(self, admin, server):
         folder = utilities.createFolder(
             admin, "ds", upenn_utilities.datasetMetadata
@@ -219,6 +373,71 @@ class TestServerListProperties:
         vals = [r["values"]["p"]["Area"] for r in result["rows"][:3]]
         assert vals == [30, 20, 10]
         assert str(result["rows"][-1]["_id"]) == str(noval["_id"])
+
+    def testPropertySortAnchorReturnsContainingPage(self, admin, server):
+        folder, anns, noval = self._setup(admin)
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {},
+            "sort": {"type": "property", "key": ["p", "Area"],
+                     "order": "asc"},
+            "propertyPaths": [["p", "Area"]],
+            "offset": 0, "limit": 2,
+            # anns[0] has Area=30, at position 2 after 10 and 20.
+            "anchorId": str(anns[0]["_id"]),
+        })
+        assertStatusOk(resp)
+        result = parseStreaming(resp)
+        assert result["offset"] == 2
+        assert str(result["rows"][0]["_id"]) == str(anns[0]["_id"])
+        assert str(result["rows"][1]["_id"]) == str(noval["_id"])
+
+    def testPropertySortAnchorWithoutValueLandsOnTailPage(
+            self, admin, server):
+        folder, anns, noval = self._setup(admin)
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {},
+            "sort": {"type": "property", "key": ["p", "Area"],
+                     "order": "asc"},
+            "propertyPaths": [["p", "Area"]],
+            "offset": 0, "limit": 2,
+            # noval has no Area value, so it sorts last: position 3.
+            "anchorId": str(noval["_id"]),
+        })
+        assertStatusOk(resp)
+        result = parseStreaming(resp)
+        assert result["offset"] == 2
+        assert str(result["rows"][1]["_id"]) == str(noval["_id"])
+
+    def testPropertySortDescAnchorsSelfConsistent(self, admin, server):
+        folder, anns, noval = self._setup(admin)
+        assertAnchorPagesSelfConsistent(
+            server, admin, folder["_id"],
+            [a["_id"] for a in anns] + [noval["_id"]],
+            {"type": "property", "key": ["p", "Area"], "order": "desc"},
+            limit=2, propertyPaths=[["p", "Area"]],
+        )
+
+    def testPropertyFilterWithAnchor(self, admin, server):
+        folder, anns, noval = self._setup(admin)
+        propertyFilters = [{
+            "path": ["p", "Area"], "mode": "range", "min": 15,
+        }]
+        resp = postList(server, admin, "/upenn_annotation/list", {
+            "datasetId": str(folder["_id"]),
+            "filters": {"propertyFilters": propertyFilters},
+            "sort": {"type": "property", "key": ["p", "Area"],
+                     "order": "asc"},
+            "propertyPaths": [["p", "Area"]],
+            "offset": 0, "limit": 1,
+            # Filtered set is Area 20, 30 (asc): anns[0] (30) is position 1.
+            "anchorId": str(anns[0]["_id"]),
+        })
+        assertStatusOk(resp)
+        result = parseStreaming(resp)
+        assert result["offset"] == 1
+        assert str(result["rows"][0]["_id"]) == str(anns[0]["_id"])
 
     def testPureSortNoDuplicateWhenPvDocLacksSortKey(self, admin, server):
         # Regression (Codex finding #4): on a pure property sort, an annotation

--- a/src/components/AnnotationBrowser/AnnotationList.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationList.test.ts
@@ -101,6 +101,10 @@ vi.mock("@/store/filters", () => ({
 }));
 
 const mockFetchPage = vi.fn();
+const mockFetchPageContaining = vi.fn<
+  (annotationId: string) => Promise<boolean>
+>(async () => true);
+const mockCancelPendingNavigation = vi.fn();
 const mockSetOptions = vi.fn();
 const mockSetIdSubstring = vi.fn();
 vi.mock("@/store/annotationListServer", () => ({
@@ -113,6 +117,9 @@ vi.mock("@/store/annotationListServer", () => ({
     sort: null,
     setOptions: (...a: any[]) => mockSetOptions(...a),
     fetchPage: (...a: any[]) => mockFetchPage(...a),
+    fetchPageContaining: (annotationId: string) =>
+      mockFetchPageContaining(annotationId),
+    cancelPendingNavigation: (...a: any[]) => mockCancelPendingNavigation(...a),
     fetchMatchingIds: vi.fn(async () => []),
     setIdSubstring: (...a: any[]) => mockSetIdSubstring(...a),
   },
@@ -236,6 +243,9 @@ describe("AnnotationList", () => {
     // inline module-mock implementation.
     (annotationListServer as any).fetchMatchingIds = vi.fn(async () => []);
     mockFetchPage.mockClear();
+    mockFetchPageContaining.mockClear();
+    mockFetchPageContaining.mockResolvedValue(true);
+    mockCancelPendingNavigation.mockClear();
     mockSetOptions.mockClear();
     mockSetIdSubstring.mockClear();
 
@@ -856,6 +866,29 @@ describe("AnnotationList", () => {
       const vm = wrapper.vm as any;
       expect(vm.getPageFromItemId("ann1")).toBe(1);
     });
+
+    it("waits for and scrolls to a row after changing the client page", async () => {
+      (filterStore as any).filteredAnnotations = Array.from(
+        { length: 15 },
+        (_, index) => makeAnnotation({ id: `ann${index + 1}` }),
+      );
+      (annotationStore as any).hoveredAnnotationId = "ann14";
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      const scrollIntoView = vi.fn();
+
+      const navigation = vm.onHoveredIdOrItemsPerPageChanged();
+      await Promise.resolve();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      vm.setAnnotationRef("ann14", { scrollIntoView });
+      await navigation;
+
+      expect(vm.page).toBe(2);
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    });
   });
 
   describe("hoveredId", () => {
@@ -933,7 +966,7 @@ describe("AnnotationList", () => {
       expect(vm.serverRowItems[0].index).toBe(100);
     });
 
-    it("does not invoke filterStore.filteredAnnotations in server mode", () => {
+    it("does not invoke filterStore.filteredAnnotations in server mode", async () => {
       // A throwing getter proves server mode never reads the client set.
       Object.defineProperty(filterStore, "filteredAnnotations", {
         configurable: true,
@@ -954,15 +987,107 @@ describe("AnnotationList", () => {
       expect(vm.serverItemsLength).toBe(7);
       // The hover watch must also stay off the client set: simulate an external
       // hover (e.g. from the image viewer) and let the watcher run.
+      vm.setAnnotationRef("srv1", { scrollIntoView: vi.fn() });
       (annotationStore as any).hoveredAnnotationId = "srv1";
       vm.itemsPerPage = 200;
-      expect(() => wrapper.vm.$nextTick()).not.toThrow();
+      await expect(wrapper.vm.$nextTick()).resolves.toBeUndefined();
       // Restore a plain data property so later tests aren't affected.
       Object.defineProperty(filterStore, "filteredAnnotations", {
         configurable: true,
         writable: true,
         value: [],
       });
+    });
+
+    it("loads the page containing an externally hovered off-page row", async () => {
+      (annotationStore as any).stubOnlyMode = true;
+      (annotationStore as any).hoveredAnnotationId = "off-page";
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      const scrollIntoView = vi.fn();
+      mockFetchPageContaining.mockClear();
+
+      const navigation = vm.onHoveredIdOrItemsPerPageChanged();
+      await Promise.resolve();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      vm.setAnnotationRef("off-page", { scrollIntoView });
+      await navigation;
+
+      expect(mockFetchPageContaining).toHaveBeenCalledWith("off-page");
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    });
+
+    it("drops Vuetify's stale options echo while an anchor page is mounting", async () => {
+      (annotationStore as any).stubOnlyMode = true;
+      (annotationStore as any).hoveredAnnotationId = "off-page";
+      let finishPageLookup!: (loaded: boolean) => void;
+      mockFetchPageContaining.mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            finishPageLookup = resolve;
+          }),
+      );
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      const scrollIntoView = vi.fn();
+      mockSetOptions.mockClear();
+      mockFetchPage.mockClear();
+
+      const navigation = vm.onHoveredIdOrItemsPerPageChanged();
+      // The anchor result lands and moves the store to the target page...
+      finishPageLookup(true);
+      (annotationListServer as any).page = 5;
+      await Promise.resolve();
+      // ...then Vuetify re-emits the PRE-navigation options while reconciling.
+      // That stale echo must be dropped, and must not cancel the navigation.
+      vm.onServerOptions({ page: 1, itemsPerPage: 50, sortBy: [] });
+
+      expect(mockSetOptions).not.toHaveBeenCalled();
+      expect(mockFetchPage).not.toHaveBeenCalled();
+
+      vm.setAnnotationRef("off-page", { scrollIntoView });
+      await navigation;
+      expect(scrollIntoView).toHaveBeenCalled();
+      (annotationListServer as any).page = 1;
+    });
+
+    it("lets a user pagination click cancel an anchor navigation", async () => {
+      (annotationStore as any).stubOnlyMode = true;
+      (annotationStore as any).hoveredAnnotationId = "off-page";
+      let finishPageLookup!: (loaded: boolean) => void;
+      mockFetchPageContaining.mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            finishPageLookup = resolve;
+          }),
+      );
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      const scrollIntoView = vi.fn();
+      mockSetOptions.mockClear();
+      mockFetchPage.mockClear();
+
+      const navigation = vm.onHoveredIdOrItemsPerPageChanged();
+      mockCancelPendingNavigation.mockClear();
+      // A genuine pagination click (differs from both the pre-navigation
+      // snapshot and the store state) wins over the pending navigation.
+      vm.onServerOptions({ page: 2, itemsPerPage: 50, sortBy: [] });
+
+      expect(mockCancelPendingNavigation).toHaveBeenCalled();
+      expect(mockSetOptions).toHaveBeenCalledWith({
+        page: 2,
+        pageSize: 50,
+        sort: null,
+      });
+      expect(mockFetchPage).toHaveBeenCalled();
+
+      finishPageLookup(true);
+      vm.setAnnotationRef("off-page", { scrollIntoView });
+      await navigation;
+      expect(scrollIntoView).not.toHaveBeenCalled();
     });
 
     it("selectAllValue uses server total + selectedAnnotationIds in server mode", () => {

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -315,7 +315,14 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import {
+  ref,
+  computed,
+  watch,
+  nextTick,
+  onMounted,
+  onBeforeUnmount,
+} from "vue";
 import { debounce } from "lodash";
 import store from "@/store";
 import annotationStore from "@/store/annotation";
@@ -385,14 +392,46 @@ const emit = defineEmits<{
 }>();
 
 const annotationRefMap = new Map<string, Element>();
+type AnnotationRefWaiter = (element: Element | null) => void;
+const annotationRefWaiters = new Map<string, Set<AnnotationRefWaiter>>();
+
 function setAnnotationRef(id: string, el: any) {
   if (el) {
     // In Vue 2, component refs resolve to the component instance; get the $el
     const element = el.$el || el;
     annotationRefMap.set(id, element);
+    const waiters = annotationRefWaiters.get(id);
+    if (waiters) {
+      annotationRefWaiters.delete(id);
+      waiters.forEach((resolve) => resolve(element));
+    }
   } else {
     annotationRefMap.delete(id);
   }
+}
+
+function waitForAnnotationRef(
+  id: string,
+  timeoutMs: number = 1500,
+): Promise<Element | null> {
+  const mounted = annotationRefMap.get(id);
+  if (mounted) {
+    return Promise.resolve(mounted);
+  }
+  return new Promise((resolve) => {
+    const waiters = annotationRefWaiters.get(id) ?? new Set();
+    annotationRefWaiters.set(id, waiters);
+    const finish: AnnotationRefWaiter = (element) => {
+      globalThis.clearTimeout(timeout);
+      waiters.delete(finish);
+      if (waiters.size === 0) {
+        annotationRefWaiters.delete(id);
+      }
+      resolve(element);
+    };
+    waiters.add(finish);
+    const timeout = globalThis.setTimeout(() => finish(null), timeoutMs);
+  });
 }
 
 // Template ref
@@ -409,6 +448,16 @@ const addOrRemove = ref<"add" | "remove">("add");
 // These are "from" or "to" v-data-table
 const page = ref(1);
 const itemsPerPage = ref(10);
+// While a click-to-row navigation is in flight, the server-mode options the
+// table showed when it started. Lets onServerOptions tell Vuetify's stale
+// options echo (equal to this snapshot → drop) apart from a genuine user
+// pagination action (anything else → cancel the navigation and honor it).
+let preNavigationOptions: {
+  page: number;
+  itemsPerPage: number;
+  sort: IAnnotationListSort | null;
+} | null = null;
+let serverNavigationSequence = 0;
 const groupBy = ref<string | string[]>([]);
 const sortBy = ref<{ key: string; order: "asc" | "desc" }[]>([]);
 
@@ -503,13 +552,32 @@ function onServerOptions(opts: {
   // Vuetify's options composable watches {immediate:true} and emits
   // update:options on mount, which would duplicate the onMounted fetchPage().
   // No-op when the incoming options already match the store state so the
-  // mount-time emit doesn't trigger a second identical request.
+  // mount-time emit doesn't trigger a second identical request. (This also
+  // absorbs a post-navigation reconcile echo carrying the NEW options.)
   if (
     opts.page === annotationListServer.page &&
     opts.itemsPerPage === annotationListServer.pageSize &&
     sortsEqual(newSort, annotationListServer.sort)
   ) {
     return;
+  }
+  // Programmatic click-to-row navigation changes page + rows together. Vuetify
+  // can emit its pre-navigation options while reconciling those props;
+  // treating that echo as a user pagination event immediately fetches the old
+  // page again (the brief flash reported on large lists). Drop ONLY that exact
+  // echo — any other options event is a genuine user action, which wins over
+  // the pending navigation.
+  if (preNavigationOptions) {
+    if (
+      opts.page === preNavigationOptions.page &&
+      opts.itemsPerPage === preNavigationOptions.itemsPerPage &&
+      sortsEqual(newSort, preNavigationOptions.sort)
+    ) {
+      return;
+    }
+    preNavigationOptions = null;
+    serverNavigationSequence += 1;
+    annotationListServer.cancelPendingNavigation();
   }
   annotationListServer.setOptions({
     page: opts.page,
@@ -793,27 +861,58 @@ const getPageFromItemId = computed(() => {
 // for external hovers (e.g., hovering an annotation in the image viewer).
 let hoverFromList = false;
 
-// Stacked @Watch("hoveredId") @Watch("itemsPerPage") → single watch
-watch([hoveredId, itemsPerPage], () => {
+async function onHoveredIdOrItemsPerPageChanged() {
+  const navigationSequence = ++serverNavigationSequence;
+  // Cancel an older off-page lookup even when this hover resolves to a row
+  // already mounted on the current page.
+  annotationListServer.cancelPendingNavigation();
   if (hoveredId.value === null) {
+    preNavigationOptions = null;
     hoverFromList = false;
     return;
   }
   if (hoverFromList) {
+    preNavigationOptions = null;
     hoverFromList = false;
     return;
   }
-  // Change page (only for external hovers, e.g., from image viewer). In
-  // server mode the page computation would read the client filtered set (via
-  // getPageFromItemId → dataTableItems → filteredItems), and the hovered row's
-  // server page isn't known client-side — so skip the page jump there but
-  // still scroll to the row when it's on the current server page.
-  if (!isServerMode.value) {
-    page.value = getPageFromItemId.value(hoveredId.value);
+  const targetId = hoveredId.value;
+  let annotationEl: Element | null | undefined;
+  if (isServerMode.value) {
+    preNavigationOptions = {
+      page: annotationListServer.page,
+      itemsPerPage: annotationListServer.pageSize,
+      sort: annotationListServer.sort,
+    };
+    try {
+      if (!annotationRefMap.has(targetId)) {
+        const loaded = await annotationListServer.fetchPageContaining(targetId);
+        // The user may have hovered/clicked something else while the server was
+        // locating this row. Never scroll to or retain a stale navigation.
+        if (!loaded || hoveredId.value !== targetId) {
+          return;
+        }
+      }
+      // VDataTableServer reconciles its internal pagination after Vue's first
+      // tick. Resolve from the actual row ref instead of guessing how many
+      // ticks that render will take.
+      annotationEl = await waitForAnnotationRef(targetId);
+    } finally {
+      if (navigationSequence === serverNavigationSequence) {
+        await nextTick();
+        preNavigationOptions = null;
+      }
+    }
+  } else {
+    preNavigationOptions = null;
+    page.value = getPageFromItemId.value(targetId);
+    annotationEl = await waitForAnnotationRef(targetId);
   }
-  // Get the tr element from the ref map if it exists
-  const annotationEl = annotationRefMap.get(hoveredId.value);
-  if (!annotationEl) {
+  if (
+    !annotationEl ||
+    hoveredId.value !== targetId ||
+    navigationSequence !== serverNavigationSequence
+  ) {
     return;
   }
   // Scroll to the element
@@ -821,7 +920,10 @@ watch([hoveredId, itemsPerPage], () => {
     behavior: "smooth",
     block: "nearest",
   });
-});
+}
+
+// Stacked @Watch("hoveredId") @Watch("itemsPerPage") → single watch
+watch([hoveredId, itemsPerPage], onHoveredIdOrItemsPerPageChanged);
 
 // --- Server-mode reactive refetch -----------------------------------------
 // Each watch body is a no-op in client mode (the client set is reactive on its
@@ -898,7 +1000,14 @@ watch(
 );
 
 onBeforeUnmount(() => {
+  serverNavigationSequence += 1;
+  preNavigationOptions = null;
+  annotationRefWaiters.forEach((waiters) =>
+    waiters.forEach((resolve) => resolve(null)),
+  );
+  annotationRefWaiters.clear();
   debouncedServerRefetch.cancel();
+  annotationListServer.cancelPendingNavigation();
 });
 
 onMounted(() => {
@@ -1010,6 +1119,8 @@ defineExpose({
   columnOptions,
   selectedColumns,
   tableItemClass,
+  setAnnotationRef,
+  waitForAnnotationRef,
   annotationFilteredDialog,
   localIdFilter,
   LIST_ITEM_LIMIT,
@@ -1035,6 +1146,7 @@ defineExpose({
   propertyHeaders,
   goToAnnotationIdLocation,
   hoveredId,
+  onHoveredIdOrItemsPerPageChanged,
   dataTableItems,
   sortBy,
   getPageFromItemId,
@@ -1178,5 +1290,15 @@ td span {
 }
 .compact-table tbody tr td {
   border-bottom: 1px solid var(--nimbus-border, rgba(255, 255, 255, 0.06));
+}
+
+/* The transparency rule above intentionally wins over Vuetify's table
+   surfaces, but it must not erase interactive row feedback. Apply the color
+   to cells (which cover the row background) with enough specificity to keep a
+   clicked annotation visibly highlighted after the pointer leaves it. */
+.compact-table tbody tr:hover > td,
+.compact-table tbody tr.is-hovered > td,
+.compact-table tbody tr.is-hovered:hover > td {
+  background-color: #616161 !important;
 }
 </style>

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -795,12 +795,6 @@ let hoverFromList = false;
 
 // Stacked @Watch("hoveredId") @Watch("itemsPerPage") → single watch
 watch([hoveredId, itemsPerPage], () => {
-  // In server mode the page/scroll-to-hovered logic would read the client
-  // filtered set (via getPageFromItemId → dataTableItems → filteredItems);
-  // skip it entirely so server mode never touches that getter.
-  if (isServerMode.value) {
-    return;
-  }
   if (hoveredId.value === null) {
     hoverFromList = false;
     return;
@@ -809,8 +803,14 @@ watch([hoveredId, itemsPerPage], () => {
     hoverFromList = false;
     return;
   }
-  // Change page (only for external hovers, e.g., from image viewer)
-  page.value = getPageFromItemId.value(hoveredId.value);
+  // Change page (only for external hovers, e.g., from image viewer). In
+  // server mode the page computation would read the client filtered set (via
+  // getPageFromItemId → dataTableItems → filteredItems), and the hovered row's
+  // server page isn't known client-side — so skip the page jump there but
+  // still scroll to the row when it's on the current server page.
+  if (!isServerMode.value) {
+    page.value = getPageFromItemId.value(hoveredId.value);
+  }
   // Get the tr element from the ref map if it exists
   const annotationEl = annotationRefMap.get(hoveredId.value);
   if (!annotationEl) {

--- a/src/components/AnnotationViewer.test.ts
+++ b/src/components/AnnotationViewer.test.ts
@@ -1646,6 +1646,81 @@ describe("AnnotationViewer", () => {
       });
     });
 
+    // --- shouldSelectStub ---
+    describe("shouldSelectStub", () => {
+      beforeEach(() => {
+        wrapper = mountComponent();
+        // Real Euclidean distance so the hit-test math is actually exercised.
+        (pointDistance as any).mockImplementation((a: any, b: any) =>
+          Math.hypot(a.x - b.x, a.y - b.y),
+        );
+      });
+
+      function makeStub(overrides: any = {}) {
+        return {
+          id: "stub1",
+          centroid: { x: 0, y: 0 },
+          location: { XY: 0, Z: 0, Time: 0 },
+          shape: "polygon",
+          channel: 0,
+          tags: [],
+          color: null,
+          estimatedRadius: 10,
+          ...overrides,
+        };
+      }
+
+      it("hit-tests the stub radius in world units (no unitsPerPixel scaling)", () => {
+        // The stub dot's style.radius is estimatedRadius in WORLD units. A click
+        // 8 world units away is inside the rendered radius (10), so it must hit
+        // regardless of the zoom-dependent unitsPerPixel.
+        const stub = makeStub();
+        const style = { radius: 10, strokeWidth: 0 };
+        const unitsPerPixel = 0.25; // zoomed in — the regression trigger
+        const result = (wrapper.vm as any).shouldSelectStub(
+          { x: 8, y: 0 },
+          stub,
+          style,
+          unitsPerPixel,
+        );
+        // Old (buggy) math: radius * unitsPerPixel = 2.5 → 8 > 2.5 → missed.
+        // Fixed math: radius = 10 → 8 < 10 → hit.
+        expect(result).toBe(true);
+      });
+
+      it("misses when the click is outside the world-unit radius", () => {
+        const stub = makeStub();
+        const style = { radius: 10, strokeWidth: 0 };
+        const result = (wrapper.vm as any).shouldSelectStub(
+          { x: 12, y: 0 },
+          stub,
+          style,
+          4, // zoomed out — old math would falsely hit (10*4=40)
+        );
+        expect(result).toBe(false);
+      });
+
+      it("converts only the stroke width by unitsPerPixel", () => {
+        // radius 10 (world) + strokeWidth 4 * unitsPerPixel 0.5 = 12 world units.
+        const stub = makeStub();
+        const style = { radius: 10, strokeWidth: 4 };
+        const inside = (wrapper.vm as any).shouldSelectStub(
+          { x: 11.5, y: 0 },
+          stub,
+          style,
+          0.5,
+        );
+        const outside = (wrapper.vm as any).shouldSelectStub(
+          { x: 12.5, y: 0 },
+          stub,
+          style,
+          0.5,
+        );
+        expect(inside).toBe(true);
+        expect(outside).toBe(false);
+      });
+    });
+
     // --- getSelectedAnnotationsFromAnnotation ---
     describe("getSelectedAnnotationsFromAnnotation", () => {
       it("iterates annotations and filters using shouldSelectAnnotation", () => {

--- a/src/components/AnnotationViewer.test.ts
+++ b/src/components/AnnotationViewer.test.ts
@@ -4060,6 +4060,134 @@ describe("AnnotationViewer", () => {
       });
     });
 
+    // Regression: clicking an annotation in the viewer (no tool selected)
+    // must set hoveredAnnotationId so the annotation list can page-jump,
+    // scroll to, and highlight the row.
+    describe("click-to-hover navigation", () => {
+      function fireAnnotationLayerMouseclicks(evt: any) {
+        const geoOnCalls = ((wrapper.vm as any).annotationLayer.geoOn as any)
+          .mock.calls;
+        const handlers = geoOnCalls
+          .filter((call: any[]) => call[0] === "geojs.mouseclick")
+          .map((call: any[]) => call[1]);
+        handlers.forEach((handler: any) => handler(evt));
+      }
+
+      it("clicking a point annotation sets hoveredAnnotationId", () => {
+        const ann = makeAnnotation(); // point at (10, 20)
+        mockedAnnotationStore.annotations = [ann];
+        wrapper = mountComponent();
+        (mockedAnnotationStore.getAnnotationFromId as any).mockImplementation(
+          (id: string) => (id === "ann1" ? ann : undefined),
+        );
+        (pointDistance as any).mockImplementation((a: any, b: any) =>
+          Math.hypot(a.x - b.x, a.y - b.y),
+        );
+        const geoAnn = mockGeoJSAnnotation("point");
+        geoAnn.options("girderId", "ann1");
+        (wrapper.vm as any).annotationLayer.addAnnotation(geoAnn);
+
+        fireAnnotationLayerMouseclicks({
+          geo: { x: 10, y: 20 },
+          buttonsDown: {},
+        });
+
+        expect(
+          mockedAnnotationStore.setHoveredAnnotationId,
+        ).toHaveBeenCalledWith("ann1");
+      });
+
+      it("clicking a stub-rendered (unhydrated) annotation sets hoveredAnnotationId", () => {
+        // Non-point stubs resolve to undefined via getAnnotationFromId; the
+        // hover hit-test must fall back to the stub and its rendered dot.
+        const stub = {
+          id: "stub1",
+          centroid: { x: 10, y: 20 },
+          location: { XY: 0, Z: 0, Time: 0 },
+          shape: "polygon",
+          channel: 0,
+          tags: [],
+          color: null,
+          estimatedRadius: 5,
+        };
+        wrapper = mountComponent();
+        (mockedAnnotationStore.getAnnotationFromId as any).mockReturnValue(
+          undefined,
+        );
+        (mockedAnnotationStore.getStub as any).mockImplementation(
+          (id: string) => (id === "stub1" ? stub : undefined),
+        );
+        (pointDistance as any).mockImplementation((a: any, b: any) =>
+          Math.hypot(a.x - b.x, a.y - b.y),
+        );
+        const geoAnn = mockGeoJSAnnotation("point");
+        geoAnn.options("girderId", "stub1");
+        geoAnn.options("isStub", true);
+        (wrapper.vm as any).annotationLayer.addAnnotation(geoAnn);
+
+        fireAnnotationLayerMouseclicks({
+          geo: { x: 10, y: 20 },
+          buttonsDown: {},
+        });
+
+        expect(
+          mockedAnnotationStore.setHoveredAnnotationId,
+        ).toHaveBeenCalledWith("stub1");
+      });
+
+      it("clicking empty space clears hoveredAnnotationId", () => {
+        const ann = makeAnnotation();
+        mockedAnnotationStore.annotations = [ann];
+        wrapper = mountComponent();
+        (mockedAnnotationStore.getAnnotationFromId as any).mockImplementation(
+          (id: string) => (id === "ann1" ? ann : undefined),
+        );
+        (pointDistance as any).mockImplementation((a: any, b: any) =>
+          Math.hypot(a.x - b.x, a.y - b.y),
+        );
+        const geoAnn = mockGeoJSAnnotation("point");
+        geoAnn.options("girderId", "ann1");
+        (wrapper.vm as any).annotationLayer.addAnnotation(geoAnn);
+
+        fireAnnotationLayerMouseclicks({
+          geo: { x: 500, y: 500 },
+          buttonsDown: {},
+        });
+
+        expect(
+          mockedAnnotationStore.setHoveredAnnotationId,
+        ).toHaveBeenCalledWith(null);
+      });
+
+      it("does not set hover when a tool is selected", () => {
+        const ann = makeAnnotation();
+        mockedAnnotationStore.annotations = [ann];
+        mockedStore.selectedTool = {
+          configuration: { type: "create", values: {} },
+          state: null,
+        } as any;
+        wrapper = mountComponent();
+        (mockedAnnotationStore.getAnnotationFromId as any).mockImplementation(
+          (id: string) => (id === "ann1" ? ann : undefined),
+        );
+        (pointDistance as any).mockImplementation((a: any, b: any) =>
+          Math.hypot(a.x - b.x, a.y - b.y),
+        );
+        const geoAnn = mockGeoJSAnnotation("point");
+        geoAnn.options("girderId", "ann1");
+        (wrapper.vm as any).annotationLayer.addAnnotation(geoAnn);
+
+        fireAnnotationLayerMouseclicks({
+          geo: { x: 10, y: 20 },
+          buttonsDown: {},
+        });
+
+        expect(
+          mockedAnnotationStore.setHoveredAnnotationId,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
     describe("bindTimelapseEvents", () => {
       it("registers mouseclick handler on timelapseLayer", () => {
         wrapper = mountComponent();

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -1926,13 +1926,18 @@ function shouldSelectStub(
   annotationStyle: IGeoJSPointFeatureStyle,
   unitsPerPixel: number,
 ): boolean {
-  return pointNearPoint(
-    clickPosition,
-    stub.centroid,
-    (annotationStyle.radius as number) ?? 0,
-    (annotationStyle.strokeWidth as number) ?? 0,
-    unitsPerPixel,
-  );
+  // Unlike a normal point feature (whose radius is in display pixels), the stub
+  // dot renders world-locked: its style.radius is estimatedRadius in world
+  // (image-pixel) units, via `scaled` (getStubStyleFromBaseStyle). clickPosition
+  // and stub.centroid are also world units, so compare directly — do NOT route
+  // through pointNearPoint, which multiplies the radius by unitsPerPixel and
+  // would shrink/expand the hit area relative to the rendered dot at any zoom
+  // where unitsPerPixel !== 1. Only strokeWidth is in display pixels, so convert
+  // just that term.
+  const radius = (annotationStyle.radius as number) ?? 0;
+  const strokeWidth = (annotationStyle.strokeWidth as number) ?? 0;
+  const hitRadius = radius + strokeWidth * unitsPerPixel;
+  return pointDistance(clickPosition, stub.centroid) < hitRadius;
 }
 
 function getSelectedAnnotationsFromAnnotation(
@@ -4567,6 +4572,7 @@ defineExpose({
   pointNearPoint,
   pointNearLine,
   shouldSelectAnnotation,
+  shouldSelectStub,
   getSelectedAnnotationsFromAnnotation,
   shouldSelectGeoJSAnnotation,
   getTimelapseAnnotationsFromAnnotation,

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -2961,27 +2961,37 @@ function handleInteractionModeChange(evt: any) {
 function setHoveredAnnotationFromCoordinates(gcsCoordinates: IGeoJSPosition) {
   const geoAnnotations: IGeoJSAnnotation[] =
     props.annotationLayer.annotations();
-  let annotationToToggle: IAnnotation | null = null;
+  let annotationToToggle: TAnnotationOrStub | null = null;
+  const unitsPerPixel = getMapUnitsPerPixel();
   for (let i = 0; i < geoAnnotations.length; ++i) {
     const geoAnnotation = geoAnnotations[i];
-    const id = geoAnnotation.options("girderId");
-    if (!id) {
+    const { girderId, isConnection } = geoAnnotation.options();
+    if (!girderId || isConnection) {
       continue;
     }
-    const annotation = getAnnotationFromId.value(id);
-    if (!annotation) {
+    // Mirror the point-click selection path: unhydrated annotations render as
+    // stub dots, so resolve to the stub and hit-test the dot — otherwise every
+    // stub-rendered annotation is silently unclickable.
+    const candidate = resolveSelectionCandidate(girderId);
+    if (!candidate) {
       continue;
     }
-    const unitsPerPixel = getMapUnitsPerPixel();
-    const shouldSelect = shouldSelectAnnotation(
-      AnnotationShape.Point,
-      [gcsCoordinates],
-      annotation,
-      geoAnnotation.style(),
-      unitsPerPixel,
-    );
-    if (shouldSelect) {
-      annotationToToggle = annotation;
+    const hit = isHydratedAnnotation(candidate)
+      ? shouldSelectAnnotation(
+          AnnotationShape.Point,
+          [gcsCoordinates],
+          candidate,
+          geoAnnotation.style(),
+          unitsPerPixel,
+        )
+      : shouldSelectStub(
+          gcsCoordinates,
+          candidate,
+          geoAnnotation.style(),
+          unitsPerPixel,
+        );
+    if (hit) {
+      annotationToToggle = candidate;
       break;
     }
   }

--- a/src/store/AnnotationsAPI.test.ts
+++ b/src/store/AnnotationsAPI.test.ts
@@ -19,6 +19,7 @@ describe("AnnotationsAPI.fetchAnnotationListPage", () => {
     const { api, client } = makeApi(async () => ({
       data: {
         total: 1,
+        offset: 0,
         rows: [
           {
             _id: "a1",
@@ -47,6 +48,7 @@ describe("AnnotationsAPI.fetchAnnotationListPage", () => {
       expect.objectContaining({ datasetId: "ds" }),
     );
     expect(page.total).toBe(1);
+    expect(page.offset).toBe(0);
     expect(page.rows[0].id).toBe("a1");
     expect(page.rows[0].name).toBe("Cell 1");
     expect((page.rows[0].values as any).p.Area).toBe(9);
@@ -78,6 +80,45 @@ describe("AnnotationsAPI.fetchAnnotationListPage", () => {
       limit: 50,
     });
     expect(page.rows[0].name).toBeNull();
+  });
+
+  it("posts anchorId and preserves a null offset when it is filtered out", async () => {
+    const { api, client } = makeApi(async () => ({
+      data: { total: 12, offset: null, rows: [] },
+    }));
+    const page = await api.fetchAnnotationListPage({
+      datasetId: "ds",
+      filters: {},
+      sort: null,
+      propertyPaths: [],
+      offset: 0,
+      limit: 10,
+      anchorId: "a12",
+    });
+    expect(client.post).toHaveBeenCalledWith(
+      "upenn_annotation/list",
+      expect.objectContaining({ anchorId: "a12" }),
+    );
+    expect(page.offset).toBeNull();
+    expect(page.rows).toEqual([]);
+  });
+
+  it("does not substitute the request offset when the response lacks one", async () => {
+    // A response without `offset` means an outdated backend that ignored
+    // anchorId; falling back to the request offset would navigate to page 1.
+    const { api } = makeApi(async () => ({
+      data: { total: 12, rows: [] },
+    }));
+    const page = await api.fetchAnnotationListPage({
+      datasetId: "ds",
+      filters: {},
+      sort: null,
+      propertyPaths: [],
+      offset: 0,
+      limit: 10,
+      anchorId: "a12",
+    });
+    expect(page.offset).toBeUndefined();
   });
 });
 

--- a/src/store/AnnotationsAPI.ts
+++ b/src/store/AnnotationsAPI.ts
@@ -126,6 +126,7 @@ export default class AnnotationsAPI {
     return {
       total: response.data.total,
       rows: (response.data.rows as any[]).map(this.toListRow),
+      offset: response.data.offset,
     };
   }
 

--- a/src/store/__tests__/annotationListServerFetch.test.ts
+++ b/src/store/__tests__/annotationListServerFetch.test.ts
@@ -51,6 +51,11 @@ describe("annotationListServer.fetchPage stale-response guard", () => {
     fetchAnnotationListPage.mockReset();
     (annotationListServer as any).setPageResult({ rows: [], total: 0 });
     (annotationListServer as any).setLoading(false);
+    (annotationListServer as any).setOptions({
+      page: 1,
+      pageSize: 10,
+      sort: null,
+    });
   });
 
   it("ignores an older response that resolves after a newer one", async () => {
@@ -84,6 +89,73 @@ describe("annotationListServer.fetchPage stale-response guard", () => {
     });
     await annotationListServer.fetchPage();
     expect(annotationListServer.total).toBe(5);
+    expect(annotationListServer.loading).toBe(false);
+  });
+
+  it("loads and applies the page containing an anchor annotation", async () => {
+    fetchAnnotationListPage.mockResolvedValueOnce({
+      total: 100,
+      offset: 40,
+      rows: [{ id: "target" }],
+    });
+
+    const found = await annotationListServer.fetchPageContaining("target");
+
+    expect(found).toBe(true);
+    expect(fetchAnnotationListPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anchorId: "target",
+        offset: 0,
+        limit: 10,
+      }),
+    );
+    expect(annotationListServer.page).toBe(5);
+    expect(annotationListServer.rows.map((r: any) => r.id)).toEqual(["target"]);
+    expect(annotationListServer.loading).toBe(false);
+  });
+
+  it("preserves the current page when the anchor is filtered out", async () => {
+    (annotationListServer as any).setPageResult({
+      rows: [{ id: "current" }],
+      total: 10,
+    });
+    fetchAnnotationListPage.mockResolvedValueOnce({
+      total: 10,
+      offset: null,
+      rows: [],
+    });
+
+    const found = await annotationListServer.fetchPageContaining("missing");
+
+    expect(found).toBe(false);
+    expect(annotationListServer.page).toBe(1);
+    expect(annotationListServer.rows.map((r: any) => r.id)).toEqual([
+      "current",
+    ]);
+    expect(annotationListServer.loading).toBe(false);
+  });
+
+  it("drops an anchor response canceled by a newer hover", async () => {
+    (annotationListServer as any).setPageResult({
+      rows: [{ id: "current" }],
+      total: 10,
+    });
+    const request = deferred<any>();
+    fetchAnnotationListPage.mockReturnValueOnce(request.promise);
+
+    const pending = annotationListServer.fetchPageContaining("old-target");
+    annotationListServer.cancelPendingNavigation();
+    request.resolve({
+      total: 100,
+      offset: 50,
+      rows: [{ id: "old-target" }],
+    });
+
+    expect(await pending).toBe(false);
+    expect(annotationListServer.page).toBe(1);
+    expect(annotationListServer.rows.map((r: any) => r.id)).toEqual([
+      "current",
+    ]);
     expect(annotationListServer.loading).toBe(false);
   });
 });

--- a/src/store/annotationListServer.ts
+++ b/src/store/annotationListServer.ts
@@ -31,6 +31,10 @@ import { createSequenceGuard } from "@/utils/sequenceGuard";
 // returning after a slow filtered request). Module-level (not Vuex state) since
 // it is an internal token never read by the UI.
 const pageRequestGuard = createSequenceGuard();
+// Navigation has its own guard so a later hover can cancel an in-flight
+// anchor lookup without interfering with an unrelated page request's loading
+// cleanup. Every ordinary page fetch also invalidates pending navigation.
+const navigationRequestGuard = createSequenceGuard();
 
 // Pure: translate the client filter store into backend list filters.
 export function buildListFilters(input: {
@@ -137,22 +141,31 @@ export class AnnotationListServer extends VuexModule {
     });
   }
 
+  // The query fields shared by every list fetch; each action adds its own
+  // offset (and anchorId for navigation) plus the datasetId it guarded on.
+  get listQueryBase() {
+    return {
+      filters: this.currentFilters,
+      sort: this.sort,
+      propertyPaths: properties.displayedPropertyPaths,
+      limit: this.pageSize,
+    };
+  }
+
   @Action
   async fetchPage() {
     const datasetId = main.dataset?.id;
     if (!datasetId) {
       return;
     }
+    navigationRequestGuard.next();
     const token = pageRequestGuard.next();
     this.setLoading(true);
     try {
       const page = await main.annotationsAPI.fetchAnnotationListPage({
         datasetId,
-        filters: this.currentFilters,
-        sort: this.sort,
-        propertyPaths: properties.displayedPropertyPaths,
+        ...this.listQueryBase,
         offset: (this.page - 1) * this.pageSize,
-        limit: this.pageSize,
       });
       // Drop the result if a newer fetchPage started while we were awaiting.
       if (pageRequestGuard.isCurrent(token)) {
@@ -160,6 +173,47 @@ export class AnnotationListServer extends VuexModule {
       }
     } finally {
       if (pageRequestGuard.isCurrent(token)) {
+        this.setLoading(false);
+      }
+    }
+  }
+
+  @Action
+  cancelPendingNavigation() {
+    navigationRequestGuard.next();
+  }
+
+  @Action
+  async fetchPageContaining(annotationId: string): Promise<boolean> {
+    const datasetId = main.dataset?.id;
+    if (!datasetId) {
+      return false;
+    }
+    const navigationToken = navigationRequestGuard.next();
+    const pageToken = pageRequestGuard.next();
+    this.setLoading(true);
+    try {
+      const page = await main.annotationsAPI.fetchAnnotationListPage({
+        datasetId,
+        ...this.listQueryBase,
+        offset: 0,
+        anchorId: annotationId,
+      });
+      if (
+        !navigationRequestGuard.isCurrent(navigationToken) ||
+        !pageRequestGuard.isCurrent(pageToken) ||
+        page.offset === null ||
+        page.offset === undefined
+      ) {
+        return false;
+      }
+      this.setOptions({ page: Math.floor(page.offset / this.pageSize) + 1 });
+      this.setPageResult(page);
+      return true;
+    } finally {
+      // A hover cancellation alone must still clear this request's loading
+      // state. A newer page request owns loading when the page token changed.
+      if (pageRequestGuard.isCurrent(pageToken)) {
         this.setLoading(false);
       }
     }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1555,6 +1555,10 @@ export interface IAnnotationListQuery {
   propertyPaths: string[][];
   offset: number;
   limit: number;
+  // When supplied, the server ignores `offset` and returns the page containing
+  // this annotation under the same filters and sort. `offset` in the response
+  // is null when the annotation is not part of the filtered result.
+  anchorId?: string;
 }
 
 // A server list row: stub fields + the requested property values.
@@ -1566,6 +1570,7 @@ export interface IAnnotationListRow extends IAnnotationStub {
 export interface IAnnotationListPage {
   total: number;
   rows: IAnnotationListRow[];
+  offset?: number | null;
 }
 
 export type THydrationMode = "shapes" | "dots";


### PR DESCRIPTION
Clicking an annotation in the viewer stopped highlighting and scrolling to
its row in the annotation list. Two regressions from the stub-annotation
work combined to break it:

1. setHoveredAnnotationFromCoordinates resolved the clicked feature only via
   getAnnotationFromId, which returns undefined for unhydrated non-point
   stubs. In stub-only mode (large datasets) every stub-rendered annotation
   was therefore silently unclickable. Resolve to the stub and hit-test the
   rendered dot (shouldSelectStub), mirroring the point-click selection path.
   Connection features are now skipped explicitly.

2. The AnnotationList hover watch returned early for the entire body in
   server mode, so it never scrolled to the hovered row. Only the client-side
   page-jump depends on the client filtered set; guard just that computation
   and keep the scroll-to-row behavior in both modes.

Add regression tests covering click-to-hover for hydrated point annotations,
stub-rendered annotations, empty-space clears, and the tool-selected no-op.

## Stub-mode page navigation (anchorId)

Fixing (2) restored the scroll-to-row, but in server/stub mode the list only
holds the current page of ~10 rows, so clicking an annotation that lives on
another page flashed and then showed the first page again — the browser
cannot know the annotation's page from what it holds. That position depends
on the filtered, sorted order computed in MongoDB, so it is resolved
server-side:

- New optional `anchorId` on `POST /upenn_annotation/list`. When supplied,
  the server locates the annotation under the same filters/sort and returns
  the page-aligned `offset` (null when the annotation is filtered out).
- `Annotation.listPosition` reuses the exact match/lookup/sort builders as
  `listPage`, so its ordering cannot drift from the list. The `_id`/default
  sort uses an indexed range count; non-`_id` sorts fetch the anchor's
  normalized sort value then count rows sorting strictly before it with a
  single `$expr` match (no full-set sort or window walk — bounded on 700K+
  datasets).
- Frontend `annotationListServer.fetchPageContaining` jumps to the returned
  page; a navigation sequence guard lets a later hover cancel an in-flight
  lookup, and a pre-navigation options snapshot lets a genuine user
  pagination click cancel the navigation while Vuetify's stale options echo
  is dropped.

## Verification

- Backend: flake8 clean; 305 backend tests (new anchor + self-consistency
  cases covering desc sorts, `_id` ties, missing `name` values, property
  sorts with/without values, and property filters).
- Frontend: `pnpm tsc`, `pnpm lint:ci`, and 2651 vitest tests green.
- Live against a 708,983-annotation dataset in stub mode: a real annotation
  click navigated the list to the containing page with the row highlighted
  and scrolled into view; normal pagination and hover-clear behave correctly.

See `codebaseDocumentation/ANNOTATION-LIST-CLICK-NAV-REVIEW.md` for the
review-finding tracker and live-verification notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)