### PR TITLE
Debounce minimap image updates during slider scrubbing

### DIFF
--- a/src/components/ImageOverview.vue
+++ b/src/components/ImageOverview.vue
@@ -16,6 +16,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { debounce } from "lodash";
 import geojs from "geojs";
 
 import store from "@/store";
@@ -320,13 +321,25 @@ async function onUrlChanged() {
   }
 }
 
+// Refreshing the overview image re-renders the whole image region on the
+// backend, so we debounce it. This keeps the minimap from firing a fetch on
+// every intermediate frame while a navigation slider is being scrubbed; it
+// updates once scrubbing settles. The main image view is unaffected. The
+// outline rectangle (onParentPan) stays responsive and is not debounced.
+const OVERVIEW_UPDATE_DEBOUNCE_MS = 250;
+const debouncedOnUrlChanged = debounce(
+  onUrlChanged,
+  OVERVIEW_UPDATE_DEBOUNCE_MS,
+);
+
 watch(dataset, () => create());
 watch(() => props.parentCameraInfo, onParentPan);
-watch([urlPromise, osmLayer], onUrlChanged);
+watch([urlPromise, osmLayer], debouncedOnUrlChanged);
 
 onMounted(() => create());
 
 onBeforeUnmount(() => {
+  debouncedOnUrlChanged.cancel();
   if (observer.value) {
     observer.value.disconnect();
     observer.value = null;


### PR DESCRIPTION
The overview minimap re-renders the entire image region on the backend
each time store.currentLocation changes. While scrubbing navigation
sliders (z/time/xy) this fired a full-image fetch on every intermediate
frame. Debounce the overview URL refresh so it updates once scrubbing
settles; the main image view and the responsive outline rectangle
(onParentPan) are unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hAVL5MWMcw5VRzy5sFm5K