### PR TITLE
Large-dataset annotation rendering: coverage mode, minimum-visible floor, reactive indicator

### DIFF
--- a/src/components/AnnotationViewer.test.ts
+++ b/src/components/AnnotationViewer.test.ts
@@ -571,10 +571,12 @@ describe("AnnotationViewer", () => {
     mockedAnnotationStore.visibilityConfig = {
       stubThreshold: 10000,
       maxVisible: 10000,
+      minimumVisible: 5000,
       maxHydrated: 5000,
       hydrationCacheCap: 10000,
       globalThreshold: true,
       coverageTarget: 0.15,
+      revealMoreOnZoom: true,
       viewportRefreshFraction: 0.2,
     };
     mockedAnnotationStore.averageStubRadius = 0;

--- a/src/components/AnnotationViewer.vue
+++ b/src/components/AnnotationViewer.vue
@@ -4101,25 +4101,9 @@ const STUB_STROKE_PX = 4;
 
 // Hysteresis baseline: the camera state at the last visibility refresh.
 let lastRefreshCamera: { zoom: number; center: IGeoJSPosition } | null = null;
-
-// World-unit diagonal of the viewport bounding box — the scale the pan
-// hysteresis measures center movement against. 0 when bounds are unavailable.
-function viewportExtent(gcsBounds: IGeoJSPosition[] | undefined): number {
-  if (!gcsBounds || gcsBounds.length < 2) {
-    return 0;
-  }
-  let minX = Infinity,
-    minY = Infinity,
-    maxX = -Infinity,
-    maxY = -Infinity;
-  for (const pt of gcsBounds) {
-    minX = Math.min(minX, pt.x);
-    minY = Math.min(minY, pt.y);
-    maxX = Math.max(maxX, pt.x);
-    maxY = Math.max(maxY, pt.y);
-  }
-  return Math.hypot(maxX - minX, maxY - minY);
-}
+// The previous camera event — used to tell a pure pan (zoom unchanged this
+// event) from a zoom, independently of the refresh baseline.
+let lastCameraEvent: { zoom: number; center: IGeoJSPosition } | null = null;
 
 // Visibility and hydration updates
 function updateVisibility() {
@@ -4134,7 +4118,7 @@ function updateVisibility() {
   // the full configured cap as the user zooms in. The zoomed-out floor is
   // derived from on-screen annotation density (size + stroke vs screen).
   const map = props.annotationLayer.map();
-  const { maxVisible, maxHydrated, coverageTarget } =
+  const { maxVisible, maxHydrated, coverageTarget, revealMoreOnZoom } =
     annotationStore.visibilityConfig;
   const zoomMin = map.zoomRange().min;
   const size = map.size();
@@ -4146,6 +4130,7 @@ function updateVisibility() {
     screenArea: size.width * size.height,
     strokePx: STUB_STROKE_PX,
     coverageTarget,
+    revealMoreOnZoom,
     maxVisible,
     maxHydrated,
     loaded: annotationStore.annotationStubs.size,
@@ -4176,23 +4161,26 @@ const updateVisibilityDebounced = debounce(updateVisibility, 250);
 // to avoid flash of empty frame while debounce waits
 watch([filteredAnnotations, xy, z, time], updateVisibility);
 
-// Camera changes (pan/zoom) are debounced since they fire rapidly. Unified
-// hysteresis (C4): skip the refresh until EITHER the zoom magnification OR the
-// center (as a fraction of the viewport) changes by viewportRefreshFraction —
-// avoids constant re-render + re-hydration churn on small pan/zoom nudges.
+// Camera changes (pan/zoom) are debounced since they fire rapidly. Pan refreshes
+// on any amount (a new region is revealed); zoom keeps a magnification
+// hysteresis (viewportRefreshFraction) to avoid re-render + re-hydration churn
+// on small zoom nudges. The debounce coalesces a drag into one refresh on settle.
 watch(
   () => store.cameraInfo,
   () => {
     stubPerf.trackCameraUpdate();
     const cam = store.cameraInfo;
-    if (
-      !cameraRefreshNeeded(
-        { zoom: cam.zoom, center: cam.center },
-        lastRefreshCamera,
-        annotationStore.visibilityConfig.viewportRefreshFraction,
-        viewportExtent(cam.gcsBounds),
-      )
-    ) {
+    const current = { zoom: cam.zoom, center: cam.center };
+    const needed = cameraRefreshNeeded(
+      current,
+      lastRefreshCamera,
+      lastCameraEvent,
+      annotationStore.visibilityConfig.viewportRefreshFraction,
+    );
+    // Track every event (not just refreshes) so a pure pan is detected as
+    // "zoom unchanged since the previous event" even after a sub-threshold zoom.
+    lastCameraEvent = current;
+    if (!needed) {
       return;
     }
     updateVisibilityDebounced();

--- a/src/components/RenderCoverageIndicator.vue
+++ b/src/components/RenderCoverageIndicator.vue
@@ -48,11 +48,25 @@ import VisibilitySettings from "@/components/VisibilitySettings.vue";
 
 // Shows how much of what's in the CURRENT VIEWPORT is actually drawn (the "am I
 // seeing everything here?" metric), with the dataset total as context. Always
-// visible in stub-only (large-dataset) mode — a stable readout and the home for
-// the rendering-settings gear.
+// visible in stub (large-dataset) mode — a stable readout and the home for the
+// rendering-settings gear.
+
+// "Stub mode" for display purposes, derived REACTIVELY (not the load-time
+// stubOnlyMode data flag): the dataset was loaded stub-only, OR its count now
+// exceeds the stub-mode threshold. Lowering the threshold below the count in
+// the settings therefore surfaces the indicator immediately, without a reload —
+// annotationStubs (replaced on load) and visibilityConfig (replaced on every
+// settings change) are both reactive, so this recomputes when either changes.
+const stubMode = computed(
+  () =>
+    annotationStore.stubOnlyMode ||
+    annotationStore.annotationStubs.size >
+      annotationStore.visibilityConfig.stubThreshold,
+);
+
 const coverage = computed(() =>
   computeRenderCoverage({
-    stubOnlyMode: annotationStore.stubOnlyMode,
+    stubMode: stubMode.value,
     viewportShown: annotationStore.viewportRenderedCount,
     viewportTotal: annotationStore.viewportAnnotationCount,
     loaded: annotationStore.annotationStubs.size,

--- a/src/components/VisibilitySettings.vue
+++ b/src/components/VisibilitySettings.vue
@@ -1,10 +1,15 @@
 <template>
   <div class="visibility-settings">
-    <p v-if="showBlurb" class="settings-blurb text-caption">
-      For datasets with very large annotation counts (e.g. spatial data),
-      NimbusImage renders a subset at a time to stay responsive. These tune that
-      behavior — the defaults suit most datasets, and showing more annotations
-      at once makes panning large datasets slower.
+    <p v-if="showBlurb" class="settings-blurb">
+      <v-icon size="x-small" class="settings-blurb__icon"
+        >mdi-information-outline</v-icon
+      >
+      <span>
+        For datasets with very large annotation counts (e.g. spatial data),
+        NimbusImage renders a subset at a time to stay responsive. These tune
+        that behavior — the defaults suit most datasets, and showing more
+        annotations at once makes panning large datasets slower.
+      </span>
     </p>
 
     <div v-for="field in numericFields" :key="field.key" class="field-row">
@@ -50,6 +55,19 @@
     <v-switch
       hide-details
       density="compact"
+      v-model="revealMoreOnZoom"
+      label="Reveal more when zooming in"
+      v-description="{
+        section: 'Annotation rendering',
+        title: 'Reveal more when zooming in',
+        description:
+          'When off (default), the coverage target is enforced at every zoom, so the view stays at that density (uncrowded) and reveals everything only when you zoom into a sparse region. When on, the coverage target only limits the fully-zoomed-out view and more annotations are progressively revealed as you zoom in (working zooms can get crowded).',
+      }"
+    />
+
+    <v-switch
+      hide-details
+      density="compact"
       v-model="globalThreshold"
       label="Global threshold (all layers)"
       v-description="{
@@ -59,6 +77,23 @@
           'When on, the visibility threshold applies to total annotations across all layers. When off, each layer is checked independently.',
       }"
     />
+
+    <div class="reset-row">
+      <v-btn
+        variant="text"
+        size="small"
+        prepend-icon="mdi-restore"
+        @click="resetToDefaults"
+        v-description="{
+          section: 'Annotation rendering',
+          title: 'Reset to defaults',
+          description:
+            'Restore all annotation-rendering settings to their shipped default values.',
+        }"
+      >
+        Reset to defaults
+      </v-btn>
+    </div>
   </div>
 </template>
 
@@ -98,6 +133,13 @@ const numericFields: INumericField[] = [
     step: 1000,
   },
   {
+    key: "minimumVisible",
+    label: "Minimum visible annotations",
+    description:
+      "Floor on the zoom-adaptive budget: at least this many are drawn at any zoom (never more than Max visible). A view holding fewer than this shows everything; a busier view shows at least this many (or the zoom-rule count, whichever is higher). Set to 0 to defer entirely to the zoom rule.",
+    step: 1000,
+  },
+  {
     key: "maxHydrated",
     label: "Max hydrated annotations",
     description:
@@ -120,9 +162,9 @@ const numericFields: INumericField[] = [
   },
   {
     key: "viewportRefreshFraction",
-    label: "Viewport refresh threshold",
+    label: "Zoom refresh threshold",
     description:
-      "How much the zoom (magnification) or pan (fraction of the viewport) must change (e.g. 0.2 = 20%) before the view re-renders and re-hydrates. Higher = fewer refreshes / less loading churn while navigating.",
+      "How much the zoom magnification must change (e.g. 0.2 = 20%) before the view re-renders and re-hydrates. Higher = fewer refreshes / less loading churn while zooming. Panning always refreshes, so this affects zoom only.",
     step: 0.05,
   },
 ];
@@ -185,12 +227,52 @@ const globalThreshold = computed({
     annotationStore.setVisibilityConfig({ globalThreshold: value });
   },
 });
+
+const revealMoreOnZoom = computed({
+  get: () => annotationStore.visibilityConfig.revealMoreOnZoom,
+  set: (value: boolean) => {
+    annotationStore.setVisibilityConfig({ revealMoreOnZoom: value });
+  },
+});
+
+function resetToDefaults() {
+  annotationStore.resetVisibilityConfig();
+  // Reflect the restored values back into the inputs and clear any pending
+  // "adjusted" notes/timers.
+  for (const field of numericFields) {
+    draft[field.key] = annotationStore.visibilityConfig[field.key];
+  }
+  for (const key of Object.keys(notes) as TVisibilityNumericKey[]) {
+    if (noteTimers[key] !== undefined) {
+      window.clearTimeout(noteTimers[key]);
+      delete noteTimers[key];
+    }
+    delete notes[key];
+  }
+}
 </script>
 
 <style lang="scss" scoped>
 .settings-blurb {
-  opacity: 0.8;
-  margin-bottom: 8px;
+  // Info-note styling: small, muted, with a leading info icon. Font size is set
+  // explicitly (not via the text-caption utility) so it wins over Vuetify's
+  // cascade-layered utilities, which an unlayered parent rule was overriding —
+  // that override is what made this blurb render at the surrounding body size.
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
+  opacity: 0.7;
+  margin-bottom: 10px;
+}
+
+.settings-blurb__icon {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: rgb(var(--v-theme-info));
+  opacity: 0.9;
 }
 
 .field-row {
@@ -209,5 +291,11 @@ const globalThreshold = computed({
 .adjust-note {
   margin-top: 2px;
   color: rgb(var(--v-theme-warning));
+}
+
+.reset-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
 }
 </style>

--- a/src/components/VisibilitySettings.vue
+++ b/src/components/VisibilitySettings.vue
@@ -155,9 +155,9 @@ const numericFields: INumericField[] = [
   },
   {
     key: "coverageTarget",
-    label: "Zoomed-out coverage target",
+    label: "Coverage target",
     description:
-      "Fraction of the screen the rendered dots may cover when fully zoomed out (only for datasets larger than the render cap). Lower = sparser, cleaner overview. The budget doubles per zoom level up to the cap.",
+      "Target fraction of the screen the rendered dots may cover (only for datasets larger than the render cap). Lower = sparser. With 'Reveal more when zooming in' OFF (default) it is evaluated at the current zoom, so density stays ~constant; with it ON it sets the zoomed-out budget, which doubles per zoom level up to the cap. Minimum visible can raise either budget.",
     step: 0.05,
   },
   {

--- a/src/store/__tests__/annotationStubs.test.ts
+++ b/src/store/__tests__/annotationStubs.test.ts
@@ -406,11 +406,17 @@ function createStubStore(spatialIndex: AnnotationSpatialIndex) {
           budget: visibleBudget,
           selectSubset: selectStableSubset,
         });
+        // Restrict hydration candidates to the drawn (visible) set (mirrors the
+        // store): only visible annotations are rendered, so hydrating others is
+        // wasted and can leave drawn annotations as dots.
+        const visibleSet = new Set(visibleIds);
 
-        const inViewportWithSize = inViewport.map((id) => ({
-          id,
-          size: state.annotationStubs.get(id)?.estimatedRadius ?? 0,
-        }));
+        const inViewportWithSize = inViewport
+          .filter((id) => visibleSet.has(id))
+          .map((id) => ({
+            id,
+            size: state.annotationStubs.get(id)?.estimatedRadius ?? 0,
+          }));
         inViewportWithSize.sort((a, b) => b.size - a.size);
 
         let idsToHydrate: string[];
@@ -420,10 +426,13 @@ function createStubStore(spatialIndex: AnnotationSpatialIndex) {
             .map((item) => item.id);
         } else {
           const remainingBudget = hydrationBudget - inViewportWithSize.length;
-          const offViewportWithSize = ring.concat(outside).map((id) => ({
-            id,
-            size: state.annotationStubs.get(id)?.estimatedRadius ?? 0,
-          }));
+          const offViewportWithSize = ring
+            .concat(outside)
+            .filter((id) => visibleSet.has(id))
+            .map((id) => ({
+              id,
+              size: state.annotationStubs.get(id)?.estimatedRadius ?? 0,
+            }));
           offViewportWithSize.sort((a, b) => b.size - a.size);
           idsToHydrate = [
             ...inViewportWithSize.map((item) => item.id),
@@ -1110,6 +1119,48 @@ describe("annotation stub/hydration store logic", () => {
       expect(store.state.hydratedAnnotations.size).toBeLessThanOrEqual(
         smallBudget,
       );
+    });
+
+    it("only hydrates annotations that are in the drawn (visible) set", async () => {
+      // Varying sizes so the "largest" hydration pick differs from the
+      // stable-hash visible subset; a budget below the in-view count forces a
+      // subset. Every hydrated annotation must still be one that is drawn —
+      // otherwise the backend hydrates undrawn annotations while drawn ones stay
+      // dots (the bug this restriction fixes).
+      store.state.visibilityConfig = {
+        maxVisible: 1000,
+        maxHydrated: 1000,
+        minimumVisible: 0,
+      };
+      const annotations = Array.from({ length: 100 }, (_, i) =>
+        makeSquareAnnotation(
+          `ann-${i}`,
+          5 + (i % 10) * 9,
+          5 + ((i / 10) | 0) * 9,
+          1 + (i % 7), // varying radius
+        ),
+      );
+      store.commit("setAnnotations", annotations);
+      const gcsBounds = [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ];
+
+      await store.dispatch("updateVisibilityAndHydration", {
+        filteredIds: annotations.map((a) => a.id),
+        gcsBounds,
+        currentFrameLocation: { XY: 0, Z: 0, Time: 0 },
+        maxVisible: 20, // visible budget 20 << 100 in view → a stable subset
+        maxHydrated: 20,
+      });
+
+      expect(store.state.visibleAnnotationIds.size).toBe(20);
+      expect(store.state.hydratedAnnotations.size).toBeGreaterThan(0);
+      for (const id of store.state.hydratedAnnotations.keys()) {
+        expect(store.state.visibleAnnotationIds.has(id)).toBe(true);
+      }
     });
 
     it("sets hydration mode to shapes when annotations are hydrated", async () => {

--- a/src/store/__tests__/annotationStubs.test.ts
+++ b/src/store/__tests__/annotationStubs.test.ts
@@ -26,6 +26,7 @@ import {
   selectStableSubset,
   stubFromAnnotation,
 } from "@/utils/annotation";
+import { selectVisibleIds, clampVisibleBudget } from "@/utils/visibilityBudget";
 import { AnnotationSpatialIndex } from "@/utils/spatialIndex";
 
 // ---------- helpers ----------
@@ -80,7 +81,11 @@ interface StubStoreState {
   visibleAnnotationIds: Set<string>;
   hydrationMode: THydrationMode;
   selectedAnnotationIds: Set<string>;
-  visibilityConfig: { maxVisible: number; maxHydrated: number };
+  visibilityConfig: {
+    maxVisible: number;
+    maxHydrated: number;
+    minimumVisible?: number;
+  };
 }
 
 function createStubStore(spatialIndex: AnnotationSpatialIndex) {
@@ -95,7 +100,11 @@ function createStubStore(spatialIndex: AnnotationSpatialIndex) {
         visibleAnnotationIds: markRaw(new Set()),
         hydrationMode: "dots",
         selectedAnnotationIds: markRaw(new Set()),
-        visibilityConfig: { maxVisible: 20000, maxHydrated: 10000 },
+        visibilityConfig: {
+          maxVisible: 20000,
+          maxHydrated: 10000,
+          minimumVisible: 5000,
+        },
       };
     },
     getters: {
@@ -310,10 +319,26 @@ function createStubStore(spatialIndex: AnnotationSpatialIndex) {
           filteredIds?: string[];
           gcsBounds?: { x: number; y: number }[];
           currentFrameLocation: IAnnotationLocation;
+          // Zoom-adaptive budget overrides (mirrors the real action). Fall back
+          // to the static config caps when not supplied.
+          maxVisible?: number;
+          maxHydrated?: number;
         },
       ) {
         const { filteredIds, gcsBounds, currentFrameLocation } = params;
-        const { maxVisible, maxHydrated } = state.visibilityConfig;
+        const zoomVisibleBudget =
+          params.maxVisible ?? state.visibilityConfig.maxVisible;
+        const zoomHydrated =
+          params.maxHydrated ?? state.visibilityConfig.maxHydrated;
+        // Floor the visible budget at minimumVisible, capped at the config max.
+        const minimumVisible = state.visibilityConfig.minimumVisible ?? 0;
+        const visibleBudget = clampVisibleBudget(
+          zoomVisibleBudget,
+          minimumVisible,
+          state.visibilityConfig.maxVisible,
+        );
+        // Never hydrate more than the drawn (visible) set (mirrors the store).
+        const hydrationBudget = Math.min(zoomHydrated, visibleBudget);
 
         const onCurrentFrame = (stub: IAnnotationStub | undefined) =>
           !!stub &&
@@ -338,14 +363,13 @@ function createStubStore(spatialIndex: AnnotationSpatialIndex) {
           }
         }
 
-        // Two viewport splits (mirrors the real action, C2): visibility uses
-        // an EXPANDED box (pan pre-load); hydration uses the UNEXPANDED box —
-        // the region the user actually sees — so zooming in re-prioritizes the
-        // newly-visible annotations.
-        let visInViewport = currentFrameIds;
-        let visOutOfViewport: string[] = [];
-        let hydInViewport = currentFrameIds;
-        let hydOutOfViewport: string[] = [];
+        // Single-pass three-way partition (mirrors the real action, C2): the
+        // UNEXPANDED viewport (drives hydration + coverage counts + visibility
+        // tier 1), the RING out to the 50%-expanded box (pan pre-load), and
+        // everything OUTSIDE.
+        let inViewport = currentFrameIds;
+        let ring: string[] = [];
+        let outside: string[] = [];
 
         if (gcsBounds && gcsBounds.length === 4) {
           let minX = Infinity,
@@ -358,55 +382,45 @@ function createStubStore(spatialIndex: AnnotationSpatialIndex) {
             maxX = Math.max(maxX, pt.x);
             maxY = Math.max(maxY, pt.y);
           }
-          // Unexpanded (raw) split — the actual viewport — drives hydration.
-          ({
-            inViewportIds: hydInViewport,
-            outOfViewportIds: hydOutOfViewport,
-          } = spatialIndex.splitByViewport(
-            currentFrameIds,
-            minX,
-            minY,
-            maxX,
-            maxY,
-          ));
-          // Expanded by 50% on each side — drives visibility (pan pre-load).
           const width = maxX - minX;
           const height = maxY - minY;
-          ({
-            inViewportIds: visInViewport,
-            outOfViewportIds: visOutOfViewport,
-          } = spatialIndex.splitByViewport(
+          ({ inViewport, ring, outside } = spatialIndex.partitionByViewports(
             currentFrameIds,
-            minX - width * 0.5,
-            minY - height * 0.5,
-            maxX + width * 0.5,
-            maxY + height * 0.5,
+            { minX, minY, maxX, maxY },
+            {
+              minX: minX - width * 0.5,
+              minY: minY - height * 0.5,
+              maxX: maxX + width * 0.5,
+              maxY: maxY + height * 0.5,
+            },
           ));
         }
 
-        let visibleIds: string[];
-        if (visInViewport.length >= maxVisible) {
-          visibleIds = selectStableSubset(visInViewport, maxVisible);
-        } else {
-          const remaining = maxVisible - visInViewport.length;
-          const offViewport = selectStableSubset(visOutOfViewport, remaining);
-          visibleIds = [...visInViewport, ...offViewport];
-        }
+        // Priority tiers (mirrors the real action): actual viewport first, then
+        // the pan-preload ring, then off-screen — so the minimumVisible floor
+        // (folded into visibleBudget) is honored in the visible area.
+        const visibleIds = selectVisibleIds({
+          inViewportIds: inViewport,
+          marginIds: ring,
+          offViewportIds: outside,
+          budget: visibleBudget,
+          selectSubset: selectStableSubset,
+        });
 
-        const inViewportWithSize = hydInViewport.map((id) => ({
+        const inViewportWithSize = inViewport.map((id) => ({
           id,
           size: state.annotationStubs.get(id)?.estimatedRadius ?? 0,
         }));
         inViewportWithSize.sort((a, b) => b.size - a.size);
 
         let idsToHydrate: string[];
-        if (inViewportWithSize.length >= maxHydrated) {
+        if (inViewportWithSize.length >= hydrationBudget) {
           idsToHydrate = inViewportWithSize
-            .slice(0, maxHydrated)
+            .slice(0, hydrationBudget)
             .map((item) => item.id);
         } else {
-          const remainingBudget = maxHydrated - inViewportWithSize.length;
-          const offViewportWithSize = hydOutOfViewport.map((id) => ({
+          const remainingBudget = hydrationBudget - inViewportWithSize.length;
+          const offViewportWithSize = ring.concat(outside).map((id) => ({
             id,
             size: state.annotationStubs.get(id)?.estimatedRadius ?? 0,
           }));
@@ -957,6 +971,121 @@ describe("annotation stub/hydration store logic", () => {
       expect(store.state.visibleAnnotationIds.size).toBeLessThanOrEqual(
         smallBudget,
       );
+    });
+
+    it("floors the visible-area count at minimumVisible when the zoom budget is lower", async () => {
+      // 200 annotations in the viewport, cap 1000, floor 50. A zoom-adaptive
+      // budget of 10 (passed in) is below the floor → at least 50 must be drawn
+      // in the actual viewport, not the raw 10.
+      store.state.visibilityConfig = {
+        maxVisible: 1000,
+        maxHydrated: 1000,
+        minimumVisible: 50,
+      };
+      const annotations = Array.from({ length: 200 }, (_, i) =>
+        makeSquareAnnotation(
+          `ann-${i}`,
+          5 + (i % 20) * 4,
+          5 + ((i / 20) | 0) * 9,
+          2,
+        ),
+      );
+      store.commit("setAnnotations", annotations);
+      const gcsBounds = [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ];
+
+      await store.dispatch("updateVisibilityAndHydration", {
+        filteredIds: annotations.map((a) => a.id),
+        gcsBounds,
+        currentFrameLocation: { XY: 0, Z: 0, Time: 0 },
+        maxVisible: 10, // zoom-adaptive budget below the floor
+      });
+
+      // Floored to minimumVisible (50), not the raw zoom budget (10)...
+      expect(store.state.visibleAnnotationIds.size).toBe(50);
+      // ...and every drawn annotation is one of the in-view 200 (the floor lands
+      // in the visible area, not the pan-preload margin).
+      for (const id of store.state.visibleAnnotationIds) {
+        expect(id.startsWith("ann-")).toBe(true);
+      }
+    });
+
+    it("keeps the floored draws in the viewport, not the pan-preload margin", async () => {
+      // 60 in the actual viewport (0..100) and 60 in the margin ring (110..140,
+      // inside the 50%-expanded box). Floor 30, zoom budget 5 → the 30 drawn must
+      // all come from the actual viewport.
+      store.state.visibilityConfig = {
+        maxVisible: 1000,
+        maxHydrated: 1000,
+        minimumVisible: 30,
+      };
+      const inView = Array.from({ length: 60 }, (_, i) =>
+        makeSquareAnnotation(
+          `in-${i}`,
+          5 + (i % 10) * 9,
+          5 + ((i / 10) | 0) * 15,
+          2,
+        ),
+      );
+      const margin = Array.from({ length: 60 }, (_, i) =>
+        makeSquareAnnotation(
+          `margin-${i}`,
+          112 + (i % 6) * 4,
+          5 + ((i / 6) | 0) * 9,
+          2,
+        ),
+      );
+      store.commit("setAnnotations", [...inView, ...margin]);
+      const gcsBounds = [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ];
+
+      await store.dispatch("updateVisibilityAndHydration", {
+        filteredIds: [...inView, ...margin].map((a) => a.id),
+        gcsBounds,
+        currentFrameLocation: { XY: 0, Z: 0, Time: 0 },
+        maxVisible: 5,
+      });
+
+      expect(store.state.visibleAnnotationIds.size).toBe(30);
+      for (const id of store.state.visibleAnnotationIds) {
+        expect(id.startsWith("in-")).toBe(true); // never a margin id
+      }
+    });
+
+    it("shows everything in view when fewer than minimumVisible are present", async () => {
+      // 20 in view, floor 50 → all 20 drawn (nothing to floor up to).
+      store.state.visibilityConfig = {
+        maxVisible: 1000,
+        maxHydrated: 1000,
+        minimumVisible: 50,
+      };
+      const annotations = Array.from({ length: 20 }, (_, i) =>
+        makeSquareAnnotation(`ann-${i}`, 10 + i * 4, 50, 2),
+      );
+      store.commit("setAnnotations", annotations);
+      const gcsBounds = [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ];
+
+      await store.dispatch("updateVisibilityAndHydration", {
+        filteredIds: annotations.map((a) => a.id),
+        gcsBounds,
+        currentFrameLocation: { XY: 0, Z: 0, Time: 0 },
+        maxVisible: 5,
+      });
+
+      expect(store.state.visibleAnnotationIds.size).toBe(20);
     });
 
     it("respects hydration budget (maxHydrated)", async () => {

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -47,6 +47,7 @@ import {
   idHasHydratableShape,
   materializeStubAnnotation,
 } from "@/utils/annotation";
+import { selectVisibleIds, clampVisibleBudget } from "@/utils/visibilityBudget";
 import { annotationSpatialIndex } from "@/utils/spatialIndex";
 import {
   createDebouncedAbortableTask,
@@ -79,6 +80,22 @@ function cloneAnnotation(annotation: IAnnotation): IAnnotation {
     coordinates: toRaw(rawAnnotation.coordinates),
   });
 }
+
+// Shipped defaults for the advanced annotation-rendering settings. Single
+// source of truth for both the store's initial value and the per-dataset reset
+// (settings are session state, not persisted, and snap back to these when the
+// dataset changes). Spread on use so each assignment gets a fresh object.
+const DEFAULT_VISIBILITY_CONFIG: IVisibilityConfig = {
+  stubThreshold: 100000,
+  maxVisible: 50000,
+  minimumVisible: 5000,
+  maxHydrated: 20000,
+  hydrationCacheCap: 40000,
+  globalThreshold: true,
+  coverageTarget: 0.3,
+  revealMoreOnZoom: false,
+  viewportRefreshFraction: 0.2,
+};
 
 @Module({ dynamic: true, store, name: "annotation" })
 export class Annotations extends VuexModule {
@@ -187,15 +204,7 @@ export class Annotations extends VuexModule {
   hydratedAnnotations: Map<string, IAnnotation> = markRaw(new Map());
   visibleAnnotationIds: Set<string> = markRaw(new Set());
   hydrationMode: THydrationMode = "dots";
-  visibilityConfig: IVisibilityConfig = {
-    stubThreshold: 100000,
-    maxVisible: 50000,
-    maxHydrated: 20000,
-    hydrationCacheCap: 40000,
-    globalThreshold: true,
-    coverageTarget: 0.3,
-    viewportRefreshFraction: 0.2,
-  };
+  visibilityConfig: IVisibilityConfig = { ...DEFAULT_VISIBILITY_CONFIG };
 
   // Average annotation radius (world units) over the loaded stubs, computed once
   // when stubs are set. Feeds the density-derived zoomed-out render budget.
@@ -210,6 +219,17 @@ export class Annotations extends VuexModule {
   @Mutation
   setVisibilityConfig(config: Partial<IVisibilityConfig>) {
     this.visibilityConfig = { ...this.visibilityConfig, ...config };
+  }
+
+  // Snap the advanced rendering settings back to the shipped defaults. Used by
+  // the settings "Reset to defaults" button and on a genuine dataset switch
+  // (settings are session tuning, not per-dataset, so a tweak for one dataset
+  // shouldn't silently carry into the next). An action so it can be dispatched
+  // cross-module from the main store; passing every default key makes the
+  // setVisibilityConfig merge resolve to exactly the defaults.
+  @Action
+  resetVisibilityConfig() {
+    this.setVisibilityConfig({ ...DEFAULT_VISIBILITY_CONFIG });
   }
 
   @Mutation
@@ -2316,8 +2336,24 @@ export class Annotations extends VuexModule {
     maxHydrated?: number;
   }) {
     const { filteredIds, gcsBounds, currentFrameLocation } = params;
-    const maxVisible = params.maxVisible ?? this.visibilityConfig.maxVisible;
-    const maxHydrated = params.maxHydrated ?? this.visibilityConfig.maxHydrated;
+    const zoomVisibleBudget =
+      params.maxVisible ?? this.visibilityConfig.maxVisible;
+    const zoomHydrated =
+      params.maxHydrated ?? this.visibilityConfig.maxHydrated;
+    // Floor the VISIBLE budget at minimumVisible so at least that many are drawn
+    // in the actual viewport (capped at the configured max).
+    const { minimumVisible, maxVisible: configMaxVisible } =
+      this.visibilityConfig;
+    const visibleBudget = clampVisibleBudget(
+      zoomVisibleBudget,
+      minimumVisible,
+      configMaxVisible,
+    );
+    // Never hydrate more than the drawn (visible) set — fetching coordinates for
+    // annotations that aren't drawn is wasted work. The zoom-progress scaling
+    // lives in the zoom budget; this just prevents over-hydration (notably in
+    // coverage mode, where the visible budget can be well below maxHydrated).
+    const hydrationBudget = Math.min(zoomHydrated, visibleBudget);
 
     // Capture the stub map once. `this.annotationStubs` resolves through the
     // vuex-module-decorators action proxy on every access; reading it inside the
@@ -2348,18 +2384,16 @@ export class Annotations extends VuexModule {
       }
     }
 
-    // Step 2: Split current-frame IDs by viewport into two boxes (C2).
-    // Visibility uses an EXPANDED box so panning reveals pre-loaded annotations.
-    // Hydration AND the render-coverage counts use the UNEXPANDED box — the
-    // region the user actually sees — so zooming in re-prioritizes the
-    // newly-visible annotations. (When zoomed out, the expanded box covers the
-    // whole frame, so ranking hydration against it never tracks zoom.)
-    const noSplit = {
-      inViewportIds: currentFrameIds,
-      outOfViewportIds: [] as string[],
-    };
-    let visibilitySplit = noSplit;
-    let hydrationSplit = noSplit;
+    // Step 2: Classify current-frame IDs against two nested boxes in ONE pass
+    // (C2): the UNEXPANDED viewport (what the user sees — drives hydration, the
+    // render-coverage counts, and visibility tier 1), a RING out to the box
+    // expanded 50% each side (the pan-preload margin — visibility tier 2), and
+    // everything else OUTSIDE (visibility tier 3). Zooming in re-prioritizes the
+    // newly-visible annotations. (When zoomed out, the box covers the whole
+    // frame, so ranking hydration against it never tracks zoom.)
+    let inViewport = currentFrameIds;
+    let ring: string[] = [];
+    let outside: string[] = [];
 
     if (gcsBounds && gcsBounds.length === 4) {
       let minX = Infinity,
@@ -2372,40 +2406,33 @@ export class Annotations extends VuexModule {
         maxX = Math.max(maxX, pt.x);
         maxY = Math.max(maxY, pt.y);
       }
-      // Unexpanded (raw) split — the actual viewport — drives hydration + the
-      // render-coverage indicator counts.
-      hydrationSplit = annotationSpatialIndex.splitByViewport(
-        currentFrameIds,
-        minX,
-        minY,
-        maxX,
-        maxY,
-      );
-      // Expanded by 50% on each side — drives visibility (pan pre-load).
       const width = maxX - minX;
       const height = maxY - minY;
-      visibilitySplit = annotationSpatialIndex.splitByViewport(
-        currentFrameIds,
-        minX - width * 0.5,
-        minY - height * 0.5,
-        maxX + width * 0.5,
-        maxY + height * 0.5,
-      );
+      ({ inViewport, ring, outside } =
+        annotationSpatialIndex.partitionByViewports(
+          currentFrameIds,
+          { minX, minY, maxX, maxY },
+          {
+            minX: minX - width * 0.5,
+            minY: minY - height * 0.5,
+            maxX: maxX + width * 0.5,
+            maxY: maxY + height * 0.5,
+          },
+        ));
     }
 
-    // Step 3: Fill visibility budget (two-tier, EXPANDED box).
-    const visInViewport = visibilitySplit.inViewportIds;
-    let visibleIds: string[];
-    if (visInViewport.length >= maxVisible) {
-      visibleIds = selectStableSubset(visInViewport, maxVisible);
-    } else {
-      const remaining = maxVisible - visInViewport.length;
-      const offViewport = selectStableSubset(
-        visibilitySplit.outOfViewportIds,
-        remaining,
-      );
-      visibleIds = [...visInViewport, ...offViewport];
-    }
+    // Step 3: Fill the visible budget in priority tiers — the actual
+    // (unexpanded) viewport first, then the pan-preload ring, then off-screen.
+    // Prioritizing the actual viewport is what makes the minimumVisible floor
+    // (folded into visibleBudget) hold IN THE VISIBLE AREA rather than being
+    // diluted across the larger pan-preload box.
+    const visibleIds = selectVisibleIds({
+      inViewportIds: inViewport,
+      marginIds: ring,
+      offViewportIds: outside,
+      budget: visibleBudget,
+      selectSubset: selectStableSubset,
+    });
 
     // Step 4: Fill hydration budget (two-tier, largest first, UNEXPANDED box).
     // Points are self-complete (centroid IS the only coordinate), so they never
@@ -2418,19 +2445,30 @@ export class Annotations extends VuexModule {
     const needsHydration = (id: string): boolean =>
       idHasHydratableShape(id, stubsMap);
     const sizeOf = (id: string) => stubsMap.get(id)?.estimatedRadius ?? 0;
-    const hydInViewport = hydrationSplit.inViewportIds.filter(needsHydration);
+    const hydInViewport = inViewport.filter(needsHydration);
     let idsToHydrate: string[];
-    if (hydInViewport.length >= maxHydrated) {
-      idsToHydrate = selectLargestBySize(hydInViewport, sizeOf, maxHydrated);
+    if (hydInViewport.length >= hydrationBudget) {
+      idsToHydrate = selectLargestBySize(
+        hydInViewport,
+        sizeOf,
+        hydrationBudget,
+      );
     } else {
-      const remainingBudget = maxHydrated - hydInViewport.length;
+      // Fill the rest from off the actual viewport (ring + outside). Built in a
+      // single filtered pass — no intermediate concat — and only in this branch,
+      // where the in-viewport shapes don't fill the budget (when zoomed out the
+      // in-viewport alone overflows the budget and this never runs).
+      const offHydratable: string[] = [];
+      for (const id of ring) {
+        if (needsHydration(id)) offHydratable.push(id);
+      }
+      for (const id of outside) {
+        if (needsHydration(id)) offHydratable.push(id);
+      }
+      const remainingBudget = hydrationBudget - hydInViewport.length;
       idsToHydrate = [
         ...hydInViewport,
-        ...selectLargestBySize(
-          hydrationSplit.outOfViewportIds.filter(needsHydration),
-          sizeOf,
-          remainingBudget,
-        ),
+        ...selectLargestBySize(offHydratable, sizeOf, remainingBudget),
       ];
     }
 
@@ -2439,18 +2477,16 @@ export class Annotations extends VuexModule {
 
     // Step 5b: Render-coverage counts for the ACTUAL (unexpanded) viewport — how
     // many annotations are in view vs how many of those are drawn. Reuses the
-    // hydration split (same unexpanded box) — one fewer splitByViewport than
-    // recomputing it here. Drives the render-coverage indicator.
-    const actualInView = hydrationSplit.inViewportIds;
+    // partition's inViewport bucket. Drives the render-coverage indicator.
     const visibleSet = new Set(visibleIds);
     let viewportRendered = 0;
-    for (const id of actualInView) {
+    for (const id of inViewport) {
       if (visibleSet.has(id)) {
         viewportRendered += 1;
       }
     }
     this.setViewportCounts({
-      total: actualInView.length,
+      total: inViewport.length,
       rendered: viewportRendered,
     });
 

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -2433,17 +2433,19 @@ export class Annotations extends VuexModule {
       budget: visibleBudget,
       selectSubset: selectStableSubset,
     });
+    const visibleSet = new Set(visibleIds);
 
     // Step 4: Fill hydration budget (two-tier, largest first, UNEXPANDED box).
-    // Points are self-complete (centroid IS the only coordinate), so they never
-    // hydrate — drop them from both tiers BEFORE budget allocation so the budget
-    // goes entirely to shapes that actually need coordinates. For an all-points
-    // dataset this filters the candidate lists to empty, so the size-selection
-    // is skipped entirely. selectLargestBySize then picks the largest by
-    // estimatedRadius via a bounded min-heap (not a full O(N log N) sort) — see
-    // its definition.
+    // Candidates are restricted to the DRAWN (visible) set: only visible
+    // annotations are rendered, so hydrating anything else fetches coordinates
+    // that never appear — and because visibility picks a stable-hash subset while
+    // hydration picks the largest, an unrestricted candidate list could hydrate
+    // mostly-undrawn annotations and leave drawn ones as dots. Points are
+    // self-complete (centroid IS the only coordinate) so they never hydrate —
+    // dropped here too. selectLargestBySize then picks the largest by
+    // estimatedRadius via a bounded min-heap (not a full O(N log N) sort).
     const needsHydration = (id: string): boolean =>
-      idHasHydratableShape(id, stubsMap);
+      visibleSet.has(id) && idHasHydratableShape(id, stubsMap);
     const sizeOf = (id: string) => stubsMap.get(id)?.estimatedRadius ?? 0;
     const hydInViewport = inViewport.filter(needsHydration);
     let idsToHydrate: string[];
@@ -2454,10 +2456,9 @@ export class Annotations extends VuexModule {
         hydrationBudget,
       );
     } else {
-      // Fill the rest from off the actual viewport (ring + outside). Built in a
-      // single filtered pass — no intermediate concat — and only in this branch,
-      // where the in-viewport shapes don't fill the budget (when zoomed out the
-      // in-viewport alone overflows the budget and this never runs).
+      // Fill the rest from off the actual viewport (ring + outside) — still only
+      // drawn ones. Built in a single filtered pass (no intermediate concat) and
+      // only in this branch, where the in-viewport shapes don't fill the budget.
       const offHydratable: string[] = [];
       for (const id of ring) {
         if (needsHydration(id)) offHydratable.push(id);
@@ -2478,7 +2479,6 @@ export class Annotations extends VuexModule {
     // Step 5b: Render-coverage counts for the ACTUAL (unexpanded) viewport — how
     // many annotations are in view vs how many of those are drawn. Reuses the
     // partition's inViewport bucket. Drives the render-coverage indicator.
-    const visibleSet = new Set(visibleIds);
     let viewportRendered = 0;
     for (const id of inViewport) {
       if (visibleSet.has(id)) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1452,6 +1452,10 @@ export class Main extends VuexModule {
     // are repopulated by the reload that follows.
     if (datasetChanged) {
       this.context.dispatch("resetFilterState");
+      // Advanced rendering settings are session tuning, not per-dataset — snap
+      // them back to defaults on a genuine switch (not a same-dataset refresh)
+      // so a tweak for one dataset can't silently carry into the next.
+      this.context.dispatch("resetVisibilityConfig");
     }
     if (!id) {
       this.setDataset({ id, data: null });

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1603,6 +1603,11 @@ export interface IVisibilityConfig {
   // Max annotations to render (stubs or shapes) — the cap when fully zoomed in.
   // Datasets at or below this render fully at every zoom (the size gate).
   maxVisible: number;
+  // Floor on the zoom-adaptive render budget: at least this many are drawn at
+  // any zoom (clamped to maxVisible). So a view holding fewer than this shows
+  // everything; a busier view shows at least this many (or the zoom-rule count,
+  // whichever is higher). Set to 0 to defer entirely to the zoom rule.
+  minimumVisible: number;
   // Max annotations to keep hydrated per visibility update — the cap when fully
   // zoomed in.
   maxHydrated: number;
@@ -1611,13 +1616,21 @@ export interface IVisibilityConfig {
   hydrationCacheCap: number;
   // If true, threshold applies to total frame annotations across all layers.
   globalThreshold: boolean;
-  // Fraction of the screen the rendered dots may cover when fully zoomed out.
-  // Sets the zoomed-out floor from annotation size + screen; the budget doubles
-  // per zoom level up to maxVisible.
+  // Fraction of the screen the rendered dots may cover. See revealMoreOnZoom for
+  // how this interacts with zoom.
   coverageTarget: number;
-  // Camera hysteresis: skip the camera-driven refresh until EITHER the zoom
-  // magnification OR the center (as a fraction of the viewport) changes by this
-  // fraction (e.g. 0.2 = 20%).
+  // Controls how the render budget responds to zoom:
+  //   false (default): enforce coverageTarget at EVERY zoom — the budget is the
+  //     number of dots that cover coverageTarget of the screen at the current
+  //     zoom, so the view stays at ~that density (uncrowded) and reveals
+  //     everything only when you zoom into a genuinely sparse region.
+  //   true: "reveal more as you zoom in" — coverageTarget sets the zoomed-out
+  //     floor and the budget doubles per zoom level up to maxVisible, so working
+  //     zooms progressively reveal (and can crowd) more.
+  revealMoreOnZoom: boolean;
+  // Zoom hysteresis: skip the camera-driven refresh until the zoom magnification
+  // changes by this fraction (e.g. 0.2 = 20%). Panning has no threshold — any
+  // pan refreshes — so this governs zoom only.
   viewportRefreshFraction: number;
 }
 

--- a/src/utils/__tests__/camera.test.ts
+++ b/src/utils/__tests__/camera.test.ts
@@ -62,112 +62,83 @@ describe("recenterCameraInfo", () => {
 });
 
 describe("cameraRefreshNeeded", () => {
-  // Unified zoom + pan hysteresis: skip the refresh only when BOTH the zoom
-  // magnification change is < fraction AND the center moved < fraction × the
-  // viewport extent. fraction 0.2 → zoom threshold = log2(1.2) ≈ 0.263 levels;
-  // pan threshold = 0.2 × extent. Here extent = 1000 → pan threshold = 200.
-  const last = { zoom: 4, center: { x: 100, y: 100 } };
-  const extent = 1000;
+  // Pan refreshes on ANY amount (zoom unchanged this event); zoom keeps a
+  // magnification hysteresis vs the last refresh: fraction 0.2 → threshold
+  // log2(1.2) ≈ 0.263 levels. Args: (current, lastRefresh, lastEvent, fraction).
+  const refresh = { zoom: 4, center: { x: 100, y: 100 } };
+  // "prev event" at the same zoom as the refresh, unless a test overrides it.
+  const sameZoomEvent = { zoom: 4, center: { x: 100, y: 100 } };
 
   it("refreshes when there is no prior refresh baseline", () => {
     expect(
       cameraRefreshNeeded(
         { zoom: 4, center: { x: 100, y: 100 } },
         null,
+        null,
         0.2,
-        extent,
       ),
     ).toBe(true);
   });
 
-  it("skips a small pan below the distance threshold (zoom unchanged)", () => {
-    // moved 100 < 200 → skip
+  it("refreshes on any pan when the zoom is unchanged this event", () => {
+    // Even a 1-unit move refreshes now (no pan threshold).
     expect(
       cameraRefreshNeeded(
-        { zoom: 4, center: { x: 200, y: 100 } },
-        last,
+        { zoom: 4, center: { x: 101, y: 100 } },
+        refresh,
+        sameZoomEvent,
         0.2,
-        extent,
-      ),
-    ).toBe(false);
-  });
-
-  it("refreshes a pan at or beyond the distance threshold", () => {
-    // moved 250 > 200 → refresh
-    expect(
-      cameraRefreshNeeded(
-        { zoom: 4, center: { x: 350, y: 100 } },
-        last,
-        0.2,
-        extent,
-      ),
-    ).toBe(true);
-    // diagonal move: hypot(200,200) ≈ 283 > 200 → refresh
-    expect(
-      cameraRefreshNeeded(
-        { zoom: 4, center: { x: 300, y: 300 } },
-        last,
-        0.2,
-        extent,
       ),
     ).toBe(true);
   });
 
   it("skips a centered zoom change below the magnification threshold", () => {
-    // |Δzoom| = 0.2 < log2(1.2) ≈ 0.263 → skip
+    // |Δzoom| = 0.2 < log2(1.2) ≈ 0.263, center unchanged → skip
     expect(
       cameraRefreshNeeded(
         { zoom: 4.2, center: { x: 100, y: 100 } },
-        last,
+        refresh,
+        sameZoomEvent,
         0.2,
-        extent,
       ),
     ).toBe(false);
   });
 
   it("refreshes a centered zoom change at or above the magnification threshold", () => {
-    // |Δzoom| = 0.3 > 0.263 → refresh
     expect(
       cameraRefreshNeeded(
         { zoom: 4.3, center: { x: 100, y: 100 } },
-        last,
+        refresh,
+        sameZoomEvent,
         0.2,
-        extent,
       ),
     ).toBe(true);
   });
 
-  it("skips when both a small pan and a small zoom are below their thresholds", () => {
-    // moved 100 < 200 AND |Δzoom| 0.2 < 0.263 → skip
+  it("keeps zoom hysteresis when a sub-threshold zoom also drifts the center", () => {
+    // Scroll-wheel zoom: this event changed the zoom (4 → 4.2) and drifted the
+    // center. Because the zoom changed THIS event, the drift is not a pan → skip.
     expect(
       cameraRefreshNeeded(
         { zoom: 4.2, center: { x: 180, y: 100 } },
-        last,
+        refresh,
+        sameZoomEvent, // previous event was at zoom 4
         0.2,
-        extent,
       ),
     ).toBe(false);
   });
 
-  it("refreshes when a sub-threshold pan combines with an over-threshold zoom", () => {
+  it("refreshes a pan after a sub-threshold zoom (does not get poisoned by the frozen refresh baseline)", () => {
+    // Regression: a sub-threshold zoom left the refresh baseline frozen at
+    // zoom 4, and the previous event is now at zoom 4.2. A subsequent pure pan
+    // (still zoom 4.2, center moved) must refresh — the zoom is unchanged vs the
+    // previous event, so it's a pan, even though |4.2 - 4| ≠ 0 vs the refresh.
     expect(
       cameraRefreshNeeded(
-        { zoom: 4.3, center: { x: 180, y: 100 } },
-        last,
+        { zoom: 4.2, center: { x: 200, y: 100 } },
+        refresh, // last refresh still at zoom 4
+        { zoom: 4.2, center: { x: 100, y: 100 } }, // previous event at zoom 4.2
         0.2,
-        extent,
-      ),
-    ).toBe(true);
-  });
-
-  it("refreshes on any pan when the viewport extent is unknown", () => {
-    // extent 0 → can't scale the pan distance → refresh on any center move (safe).
-    expect(
-      cameraRefreshNeeded(
-        { zoom: 4, center: { x: 101, y: 100 } },
-        last,
-        0.2,
-        0,
       ),
     ).toBe(true);
   });
@@ -176,9 +147,9 @@ describe("cameraRefreshNeeded", () => {
     expect(
       cameraRefreshNeeded(
         { zoom: 4, center: { x: 100, y: 100 } },
-        last,
+        refresh,
+        sameZoomEvent,
         0.2,
-        extent,
       ),
     ).toBe(false);
   });

--- a/src/utils/__tests__/camera.test.ts
+++ b/src/utils/__tests__/camera.test.ts
@@ -143,6 +143,20 @@ describe("cameraRefreshNeeded", () => {
     ).toBe(true);
   });
 
+  it("keeps zoom hysteresis on the FIRST camera event (no previous event)", () => {
+    // A non-camera refresh (e.g. a frame change) set lastRefresh but there is no
+    // prior camera event yet. A sub-threshold cursor-centered zoom drifts the
+    // center; it must be read as a zoom (vs the last-refresh zoom), not a pan.
+    expect(
+      cameraRefreshNeeded(
+        { zoom: 4.2, center: { x: 180, y: 100 } },
+        refresh,
+        null, // no previous camera event
+        0.2,
+      ),
+    ).toBe(false);
+  });
+
   it("skips when nothing changed", () => {
     expect(
       cameraRefreshNeeded(

--- a/src/utils/__tests__/renderCoverage.test.ts
+++ b/src/utils/__tests__/renderCoverage.test.ts
@@ -5,7 +5,7 @@ describe("computeRenderCoverage", () => {
   it("shows the indicator when not everything in the viewport is rendered", () => {
     // 12,000 of 45,000 annotations in the current view are drawn → downsampling.
     const c = computeRenderCoverage({
-      stubOnlyMode: true,
+      stubMode: true,
       viewportShown: 12000,
       viewportTotal: 45000,
       loaded: 708983,
@@ -18,10 +18,11 @@ describe("computeRenderCoverage", () => {
     expect(c.totalLabel).toBe(`${(708983).toLocaleString()} total annotations`);
   });
 
-  it("stays visible when everything in the viewport is rendered", () => {
-    // Zoomed in: all 2,767 annotations in view are drawn → bar reads full.
+  it("stays visible in stub mode when everything in the viewport is rendered", () => {
+    // Zoomed in: all 2,767 annotations in view are drawn → bar reads full, but
+    // the indicator persists so the user knows they are in stub mode.
     const c = computeRenderCoverage({
-      stubOnlyMode: true,
+      stubMode: true,
       viewportShown: 2767,
       viewportTotal: 2767,
       loaded: 708983,
@@ -30,19 +31,49 @@ describe("computeRenderCoverage", () => {
     expect(c.fraction).toBe(1);
   });
 
-  it("hides when not in stub-only mode", () => {
+  it("shows persistently in stub mode even at X of X in view", () => {
+    // A mid-size dataset the user opted into stub mode (by lowering the
+    // threshold below its count). Everything in view is drawn (X of X), but the
+    // indicator must stay visible so the user knows stub mode is active.
     const c = computeRenderCoverage({
-      stubOnlyMode: false,
+      stubMode: true,
+      viewportShown: 3940,
+      viewportTotal: 3940,
+      loaded: 52186,
+    });
+    expect(c.show).toBe(true);
+    expect(c.fraction).toBe(1);
+  });
+
+  it("shows when the render budget clips the view even outside stub mode", () => {
+    // A dataset not (yet) in stub mode whose maxVisible was lowered below the
+    // in-view count: the budget downsamples the view, so surface it rather than
+    // let downsampling happen silently.
+    const c = computeRenderCoverage({
+      stubMode: false,
       viewportShown: 100,
       viewportTotal: 45000,
       loaded: 45000,
     });
+    expect(c.show).toBe(true);
+    expect(c.fraction).toBeCloseTo(100 / 45000, 6);
+  });
+
+  it("hides when not in stub mode and everything in view is drawn", () => {
+    // No downsampling (viewportShown === viewportTotal) and not stub mode — a
+    // normal small dataset should never show the indicator.
+    const c = computeRenderCoverage({
+      stubMode: false,
+      viewportShown: 500,
+      viewportTotal: 500,
+      loaded: 500,
+    });
     expect(c.show).toBe(false);
   });
 
-  it("stays visible but reports an empty viewport in stub-only mode", () => {
+  it("stays visible but reports an empty viewport in stub mode", () => {
     const c = computeRenderCoverage({
-      stubOnlyMode: true,
+      stubMode: true,
       viewportShown: 0,
       viewportTotal: 0,
       loaded: 708983,
@@ -54,7 +85,7 @@ describe("computeRenderCoverage", () => {
 
   it("clamps the fraction to [0, 1]", () => {
     const over = computeRenderCoverage({
-      stubOnlyMode: true,
+      stubMode: true,
       viewportShown: 50,
       viewportTotal: 40, // shown should never exceed total, but guard anyway
       loaded: 100,

--- a/src/utils/__tests__/spatialIndex.test.ts
+++ b/src/utils/__tests__/spatialIndex.test.ts
@@ -87,6 +87,40 @@ describe("AnnotationSpatialIndex", () => {
     });
   });
 
+  describe("partitionByViewports", () => {
+    it("classifies IDs into viewport / ring / outside in one pass", () => {
+      index.bulkLoad([
+        { id: "in", x: 50, y: 50 }, // inside inner (0..60)
+        { id: "ring", x: 80, y: 80 }, // outside inner, inside outer (0..120)
+        { id: "out", x: 200, y: 200 }, // outside outer
+      ]);
+      const { inViewport, ring, outside } = index.partitionByViewports(
+        ["in", "ring", "out"],
+        { minX: 0, minY: 0, maxX: 60, maxY: 60 },
+        { minX: 0, minY: 0, maxX: 120, maxY: 120 },
+      );
+      expect(inViewport).toEqual(["in"]);
+      expect(ring).toEqual(["ring"]);
+      expect(outside).toEqual(["out"]);
+    });
+
+    it("only returns IDs from the provided list and preserves order", () => {
+      index.bulkLoad([
+        { id: "a", x: 10, y: 10 },
+        { id: "b", x: 90, y: 90 },
+        { id: "unlisted", x: 15, y: 15 },
+      ]);
+      const { inViewport, ring, outside } = index.partitionByViewports(
+        ["b", "a"], // "unlisted" omitted; order preserved
+        { minX: 0, minY: 0, maxX: 50, maxY: 50 },
+        { minX: 0, minY: 0, maxX: 100, maxY: 100 },
+      );
+      expect(inViewport).toEqual(["a"]);
+      expect(ring).toEqual(["b"]);
+      expect(outside).toEqual([]);
+    });
+  });
+
   describe("queryBox", () => {
     it("returns empty set for empty tree", () => {
       expect(index.queryBox(0, 0, 100, 100).size).toBe(0);

--- a/src/utils/__tests__/visibilityBudget.test.ts
+++ b/src/utils/__tests__/visibilityBudget.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { visibilityBudgetForZoom } from "@/utils/visibilityBudget";
+import {
+  visibilityBudgetForZoom,
+  selectVisibleIds,
+  clampVisibleBudget,
+} from "@/utils/visibilityBudget";
+
+// Deterministic, order-preserving stand-in for selectStableSubset: takes the
+// first `n` ids. Keeps the tiering assertions readable (no hashing).
+const takeFirst = (list: string[], n: number) => list.slice(0, Math.max(0, n));
+const mkIds = (prefix: string, count: number) =>
+  Array.from({ length: count }, (_, i) => `${prefix}-${i}`);
 
 describe("visibilityBudgetForZoom", () => {
   // Clean round-number inputs: stroke-only dot (avgRadius 0) of 10px → 100px²
@@ -11,6 +21,7 @@ describe("visibilityBudgetForZoom", () => {
     screenArea: 1_000_000,
     strokePx: 10,
     coverageTarget: 0.5,
+    revealMoreOnZoom: true, // reveal-more ramp is the default these cases assume
     maxVisible: 50_000,
     maxHydrated: 20_000,
     loaded: 1_000_000, // well over the cap → scaling active
@@ -108,5 +119,115 @@ describe("visibilityBudgetForZoom", () => {
       zoom: 0,
     });
     expect(b.maxVisible).toBe(5_000);
+  });
+
+  describe("revealMoreOnZoom = false (coverage at current zoom)", () => {
+    const cov = { ...base, revealMoreOnZoom: false };
+
+    it("matches the reveal-more floor at the most zoomed-out level", () => {
+      // At zoomMin both modes use the zoomMin dot area → same budget (5,000).
+      expect(visibilityBudgetForZoom({ ...cov, zoom: 0 }).maxVisible).toBe(
+        5_000,
+      );
+    });
+
+    it("SHRINKS (not grows) the budget as you zoom in", () => {
+      // avgRadius 45, upp 1: at zoomMin dotDiam = 2*45 + 10 = 100 → area 10,000 →
+      // budget 0.5*1e6/1e4 = 50. One level in, the radius doubles on screen
+      // (upp halves): dotDiam = 2*90 + 10 = 190 → area 36,100 → budget ~14.
+      const z0 = visibilityBudgetForZoom({ ...cov, avgRadius: 45, zoom: 0 });
+      const z1 = visibilityBudgetForZoom({ ...cov, avgRadius: 45, zoom: 1 });
+      expect(z0.maxVisible).toBe(50);
+      expect(z1.maxVisible).toBeLessThan(z0.maxVisible);
+      // Reveal-more mode would instead DOUBLE (50 → 100) over the same step.
+      expect(
+        visibilityBudgetForZoom({ ...base, avgRadius: 45, zoom: 1 }).maxVisible,
+      ).toBe(100);
+    });
+
+    it("still honors the size gate", () => {
+      const b = visibilityBudgetForZoom({ ...cov, loaded: 40_000, zoom: 3 });
+      expect(b).toEqual({ maxVisible: 50_000, maxHydrated: 20_000 });
+    });
+
+    it("ramps hydration UP with zoom even as the visible budget shrinks", () => {
+      // The reported bug: in coverage mode the visible budget shrinks as you
+      // zoom in, so scaling hydration off it left everything a dot. Hydration
+      // must instead ramp UP with zoom (shapes appear as you zoom in).
+      const z0 = visibilityBudgetForZoom({ ...cov, avgRadius: 45, zoom: 0 });
+      const z3 = visibilityBudgetForZoom({ ...cov, avgRadius: 45, zoom: 3 });
+      expect(z3.maxVisible).toBeLessThan(z0.maxVisible); // visible shrinks
+      expect(z3.maxHydrated).toBeGreaterThan(z0.maxHydrated); // hydration grows
+    });
+  });
+});
+
+describe("clampVisibleBudget", () => {
+  it("raises the budget to the minimum floor when the zoom rule is lower", () => {
+    expect(clampVisibleBudget(900, 5000, 50000)).toBe(5000);
+  });
+
+  it("keeps the zoom rule when it already exceeds the floor", () => {
+    expect(clampVisibleBudget(20000, 5000, 50000)).toBe(20000);
+  });
+
+  it("never exceeds the configured cap", () => {
+    expect(clampVisibleBudget(80000, 5000, 50000)).toBe(50000);
+    // Floor above the cap is also capped (bounds keep min <= max anyway).
+    expect(clampVisibleBudget(900, 90000, 50000)).toBe(50000);
+  });
+
+  it("defers entirely to the zoom rule when the floor is 0", () => {
+    expect(clampVisibleBudget(900, 0, 50000)).toBe(900);
+  });
+});
+
+describe("selectVisibleIds", () => {
+  it("gives the whole budget to the viewport when it alone meets it", () => {
+    // 9,000 in view, budget 5,000 (e.g. minimumVisible floor when zoomed out):
+    // draw a stable 5,000 from the viewport — nothing spent off-screen. This is
+    // the fix: the floor lands IN the visible area, not diluted into the margin.
+    const result = selectVisibleIds({
+      inViewportIds: mkIds("v", 9000),
+      marginIds: mkIds("m", 5000),
+      offViewportIds: mkIds("o", 5000),
+      budget: 5000,
+      selectSubset: takeFirst,
+    });
+    expect(result.length).toBe(5000);
+    expect(result.every((id) => id.startsWith("v-"))).toBe(true);
+  });
+
+  it("draws the whole viewport then pre-loads margin and off-screen", () => {
+    // 100 in view, budget 250 → all 100 viewport + 100 margin + 50 off.
+    const inViewportIds = mkIds("v", 100);
+    const marginIds = mkIds("m", 100);
+    const offViewportIds = mkIds("o", 100);
+    const result = selectVisibleIds({
+      inViewportIds,
+      marginIds,
+      offViewportIds,
+      budget: 250,
+      selectSubset: takeFirst,
+    });
+    expect(result.length).toBe(250);
+    expect(result.slice(0, 100)).toEqual(inViewportIds);
+    expect(result.slice(100, 200)).toEqual(marginIds);
+    expect(result.slice(200)).toEqual(offViewportIds.slice(0, 50));
+  });
+
+  it("shows everything in view when the viewport holds fewer than the budget", () => {
+    // 680 in view, budget 5,000 → all 680 drawn (plus preload). Every viewport
+    // id present.
+    const inViewportIds = mkIds("v", 680);
+    const result = selectVisibleIds({
+      inViewportIds,
+      marginIds: [],
+      offViewportIds: [],
+      budget: 5000,
+      selectSubset: takeFirst,
+    });
+    expect(result.length).toBe(680);
+    expect(new Set(result)).toEqual(new Set(inViewportIds));
   });
 });

--- a/src/utils/__tests__/visibilityConfigBounds.test.ts
+++ b/src/utils/__tests__/visibilityConfigBounds.test.ts
@@ -9,10 +9,12 @@ import type { IVisibilityConfig } from "@/store/model";
 const current: IVisibilityConfig = {
   stubThreshold: 10000,
   maxVisible: 50000,
+  minimumVisible: 5000,
   maxHydrated: 20000,
   hydrationCacheCap: 40000,
   globalThreshold: true,
   coverageTarget: 0.17,
+  revealMoreOnZoom: true,
   viewportRefreshFraction: 0.2,
 };
 
@@ -57,6 +59,32 @@ describe("clampVisibilityConfig", () => {
     expect(config.hydrationCacheCap).toBe(50000);
     expect(adjusted).toContain("maxHydrated");
     expect(adjusted).toContain("hydrationCacheCap");
+  });
+
+  it("caps minimumVisible at maxVisible (cross-field)", () => {
+    // A minimum floor above the render cap is nonsensical — clamp it down.
+    const { config, adjusted } = clampVisibilityConfig(
+      { minimumVisible: 90000 },
+      current,
+    );
+    expect(config.minimumVisible).toBe(current.maxVisible); // 50000
+    expect(adjusted).toContain("minimumVisible");
+  });
+
+  it("drags minimumVisible down when maxVisible is lowered below it", () => {
+    // Lowering the cap below the current floor pulls the floor down with it.
+    const { config } = clampVisibilityConfig({ maxVisible: 3000 }, current);
+    expect(config.maxVisible).toBe(3000);
+    expect(config.minimumVisible).toBe(3000);
+  });
+
+  it("allows minimumVisible of 0 (defer to the zoom rule)", () => {
+    const { config, adjusted } = clampVisibilityConfig(
+      { minimumVisible: 0 },
+      current,
+    );
+    expect(config.minimumVisible).toBe(0);
+    expect(adjusted).toEqual([]);
   });
 
   it("raises hydrationCacheCap to at least maxHydrated (cross-field)", () => {
@@ -107,6 +135,20 @@ describe("clampVisibilityConfig", () => {
       current,
     );
     expect(config.globalThreshold).toBe(false);
+  });
+
+  it("preserves the boolean revealMoreOnZoom (and defaults to current)", () => {
+    expect(
+      clampVisibilityConfig({ revealMoreOnZoom: false }, current).config
+        .revealMoreOnZoom,
+    ).toBe(false);
+    // Untouched → keeps the current value, and isn't reported as adjusted.
+    const { config, adjusted } = clampVisibilityConfig(
+      { maxVisible: 30000 },
+      current,
+    );
+    expect(config.revealMoreOnZoom).toBe(true);
+    expect(adjusted).not.toContain("revealMoreOnZoom");
   });
 
   it("exposes the agreed bounds", () => {

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -35,11 +35,15 @@ export function cameraRefreshNeeded(
     return true;
   }
   // Pan: the center moved since the last refresh AND this event isn't a zoom
-  // (zoom unchanged vs the previous event → it's a pure pan).
+  // (zoom unchanged vs the previous event → it's a pure pan). Fall back to the
+  // last-refresh zoom when there's no prior event, so the very first camera
+  // event after a non-camera refresh (e.g. a frame change) doesn't misread a
+  // sub-threshold cursor-centered zoom — which drifts the center — as a pan.
   const centerMoved =
     current.center.x !== lastRefresh.center.x ||
     current.center.y !== lastRefresh.center.y;
-  const zoomUnchangedThisEvent = !lastEvent || current.zoom === lastEvent.zoom;
+  const previousZoom = lastEvent?.zoom ?? lastRefresh.zoom;
+  const zoomUnchangedThisEvent = current.zoom === previousZoom;
   return centerMoved && zoomUnchangedThisEvent;
 }
 

--- a/src/utils/camera.ts
+++ b/src/utils/camera.ts
@@ -1,52 +1,46 @@
 import type { ICameraInfo, IGeoJSPosition } from "@/store/model";
 
 /**
- * Unified pan + zoom hysteresis for the camera-driven visibility refresh.
+ * Camera-driven visibility refresh gate: PAN refreshes on any amount, ZOOM keeps
+ * a hysteresis.
  *
- * Recomputing the render budget + re-hydrating on every tiny camera change causes
- * constant loading churn. This gates the refresh on a single sensitivity
- * `fraction` (e.g. 0.2 = 20%): refresh once EITHER
- *   - the zoom magnification changed by >= the fraction (zoom is logarithmic, so
- *     a 20% change is `log2(1.2)` ≈ 0.263 zoom levels), OR
- *   - the center moved by >= the fraction of the viewport extent (world units).
- * Skip only when BOTH are below threshold. Covering pan too is what actually
- * suppresses scroll-wheel zoom (which shifts the center toward the cursor) — a
- * zoom-only gate would still refresh on its center drift.
+ * Recomputing the render budget + re-hydrating on every tiny zoom nudge causes
+ * loading churn, so a zoom change refreshes only past a magnification threshold
+ * measured against the LAST REFRESH (`zoomFraction`, e.g. 0.2 = 20% →
+ * `log2(1.2)` ≈ 0.263 zoom levels). Panning reveals a genuinely new region, so
+ * ANY center movement refreshes — there is no pan threshold.
  *
- * `viewportExtent` is a world-unit scale for the pan threshold (the viewport
- * diagonal); when it is unknown (<= 0) any pan refreshes, which is the safe
- * default.
+ * The trick that keeps the two apart (and keeps zoom hysteresis intact for
+ * scroll-wheel zoom, which drifts the center toward the cursor): a center move
+ * counts as a pan only when THIS EVENT didn't change the zoom (`lastEvent` is
+ * the previous camera event). A center drift accompanying a zoom stays gated by
+ * the zoom threshold. Comparing the pan against the last EVENT rather than the
+ * last REFRESH is essential: a sub-threshold zoom leaves the refresh baseline
+ * frozen at the old zoom, so a "zoom unchanged vs last refresh" test would treat
+ * every following pan as a zoom and never refresh.
  */
 export function cameraRefreshNeeded(
   current: { zoom: number; center: IGeoJSPosition },
-  last: { zoom: number; center: IGeoJSPosition } | null,
-  fraction: number,
-  viewportExtent: number,
+  lastRefresh: { zoom: number; center: IGeoJSPosition } | null,
+  lastEvent: { zoom: number; center: IGeoJSPosition } | null,
+  zoomFraction: number,
 ): boolean {
-  if (!last || !current.center || !last.center) {
+  if (!lastRefresh || !current.center || !lastRefresh.center) {
     return true;
   }
-  // Pan: refresh if the center moved by >= fraction of the viewport extent.
+  // Zoom: refresh past the magnification threshold since the last refresh.
   if (
-    current.center.x !== last.center.x ||
-    current.center.y !== last.center.y
+    Math.abs(current.zoom - lastRefresh.zoom) >= Math.log2(1 + zoomFraction)
   ) {
-    // Written as `!(x > 0)` rather than `x <= 0` so it also catches NaN (an
-    // unknown/uninitialized extent): NaN comparisons are always false, so
-    // `!(NaN > 0)` is true → refresh on any pan, the safe default.
-    if (!(viewportExtent > 0)) {
-      return true; // can't scale the move → refresh on any pan (safe)
-    }
-    const panDistance = Math.hypot(
-      current.center.x - last.center.x,
-      current.center.y - last.center.y,
-    );
-    if (panDistance >= fraction * viewportExtent) {
-      return true;
-    }
+    return true;
   }
-  // Zoom: refresh only past the magnification threshold.
-  return Math.abs(current.zoom - last.zoom) >= Math.log2(1 + fraction);
+  // Pan: the center moved since the last refresh AND this event isn't a zoom
+  // (zoom unchanged vs the previous event → it's a pure pan).
+  const centerMoved =
+    current.center.x !== lastRefresh.center.x ||
+    current.center.y !== lastRefresh.center.y;
+  const zoomUnchangedThisEvent = !lastEvent || current.zoom === lastEvent.zoom;
+  return centerMoved && zoomUnchangedThisEvent;
 }
 
 /**

--- a/src/utils/renderCoverage.ts
+++ b/src/utils/renderCoverage.ts
@@ -23,19 +23,28 @@ export interface IRenderCoverage {
 }
 
 export function computeRenderCoverage(input: {
-  stubOnlyMode: boolean;
+  // Whether the dataset is being treated as a large ("stub mode") dataset:
+  // either it was loaded stub-only, OR its count now exceeds the stub-mode
+  // threshold. The caller derives this reactively so lowering the threshold
+  // below the count surfaces the indicator without a reload (it is NOT the
+  // load-time stubOnlyMode data flag, which stays load-time only).
+  stubMode: boolean;
   viewportShown: number; // rendered annotations within the actual viewport
   viewportTotal: number; // all annotations within the actual viewport (current frame)
   loaded: number; // total stubs held in memory
 }): IRenderCoverage {
-  const { stubOnlyMode, viewportShown, viewportTotal, loaded } = input;
-  // Always visible in stub-only mode — it stays a stable, useful readout (and a
-  // home for the settings gear) whether the budget is downsampling the view or
-  // showing everything in it. When fully zoomed in, fraction is 1 and the bar
-  // reads full ("everything here is drawn"); an empty region reads "No
-  // annotations in view".
-  const show = stubOnlyMode;
+  const { stubMode, viewportShown, viewportTotal, loaded } = input;
   const hasAnnotations = viewportTotal > 0;
+  // Show whenever the dataset is in stub mode, OR the render is actively
+  // downsampling (not everything in the current view is drawn):
+  //   - Stub mode: a stable, persistent readout (and the home for the settings
+  //     gear) so the user knows a large dataset is being handled specially —
+  //     even when fully zoomed in and the bar reads full ("Showing X of X").
+  //   - Downsampling outside stub mode (e.g. maxVisible tightened below the
+  //     dataset size so the budget clips the view): surfaces it rather than
+  //     letting it happen silently.
+  // An empty region (no annotations in view) reads "No annotations in view".
+  const show = stubMode || viewportShown < viewportTotal;
   const fraction = hasAnnotations
     ? clamp(viewportShown / viewportTotal, 0, 1)
     : 0;

--- a/src/utils/spatialIndex.ts
+++ b/src/utils/spatialIndex.ts
@@ -70,6 +70,45 @@ export class AnnotationSpatialIndex {
     return { inViewportIds, outOfViewportIds };
   }
 
+  /**
+   * Classify `currentFrameIds` against TWO nested boxes in a single pass:
+   *   - `inViewport`: inside the inner (unexpanded) box — the region the user sees
+   *   - `ring`: inside the outer (expanded) box but NOT the inner — the pan-preload margin
+   *   - `outside`: outside the outer box
+   * The inner box must be contained in the outer box (it always is here: the outer
+   * is the inner expanded by 50% each side). This replaces two `splitByViewport`
+   * calls plus a caller-side set-difference with one iteration over
+   * `currentFrameIds`, which matters on the hot visibility-update path at ~700K.
+   */
+  partitionByViewports(
+    currentFrameIds: string[],
+    innerBox: { minX: number; minY: number; maxX: number; maxY: number },
+    outerBox: { minX: number; minY: number; maxX: number; maxY: number },
+  ): { inViewport: string[]; ring: string[]; outside: string[] } {
+    const innerSet = new Set<string>();
+    for (const item of this.tree.search(innerBox)) {
+      innerSet.add(item.id);
+    }
+    const outerSet = new Set<string>();
+    for (const item of this.tree.search(outerBox)) {
+      outerSet.add(item.id);
+    }
+
+    const inViewport: string[] = [];
+    const ring: string[] = [];
+    const outside: string[] = [];
+    for (const id of currentFrameIds) {
+      if (innerSet.has(id)) {
+        inViewport.push(id);
+      } else if (outerSet.has(id)) {
+        ring.push(id);
+      } else {
+        outside.push(id);
+      }
+    }
+    return { inViewport, ring, outside };
+  }
+
   queryBox(
     minX: number,
     minY: number,

--- a/src/utils/visibilityBudget.ts
+++ b/src/utils/visibilityBudget.ts
@@ -11,12 +11,22 @@
 //     before they cover `coverageTarget` of the screen, given each dot's
 //     on-screen footprint (radius at the min zoom + the fixed stub stroke). This
 //     self-tunes to a dataset's cell size and the viewport — no magic fraction.
-//   - From that floor the budget DOUBLES per zoom level up to the configured cap.
-//     On-screen count shrinks ~4x per level while the budget grows 2x, so the
-//     rendered fraction of what's in view rises until everything in view is
-//     shown — the "reveal more as you zoom in" behavior.
+//   - Two zoom responses, chosen by `revealMoreOnZoom`:
+//       • false (default): coverage is recomputed at the CURRENT zoom (dots grow
+//         as you zoom in, so fewer fit) — density stays ~coverageTarget at every
+//         zoom (uncrowded), revealing everything only in genuinely sparse
+//         regions.
+//       • true: from that floor the budget DOUBLES per zoom level up to the cap.
+//         On-screen count shrinks ~4x per level while the budget grows 2x, so the
+//         rendered fraction rises until everything in view is shown — "reveal
+//         more as you zoom in" (working zooms can crowd).
 //   - A SIZE GATE renders datasets that fit under the cap fully at every zoom
 //     (no downsampling): only datasets that overflow the cap get the treatment.
+//
+// The `minimumVisible` floor is applied by the store (not here): it floors the
+// VISIBLE budget only — hydration keeps the zoom-adaptive value — and the
+// visible fill (selectVisibleIds) prioritizes the actual viewport so the floor
+// is honored in the region the user is looking at.
 //
 // Kept pure for unit testing; the component supplies the live map geometry.
 
@@ -34,7 +44,11 @@ export function visibilityBudgetForZoom(input: {
   unitsPerPixelAtZoomMin: number; // map resolution at the most zoomed-out level
   screenArea: number; // viewport area, px²
   strokePx: number; // stub stroke width (fixed px, dominates the dot when zoomed out)
-  coverageTarget: number; // fraction of the screen the rendered dots may cover when zoomed out
+  coverageTarget: number; // fraction of the screen the rendered dots may cover
+  // See IVisibilityConfig.revealMoreOnZoom. true → coverage sets the zoomed-out
+  // floor and the budget doubles per zoom level; false → coverage is enforced at
+  // the CURRENT zoom (constant density, uncrowded).
+  revealMoreOnZoom: boolean;
   maxVisible: number; // render cap (the budget when fully zoomed in)
   maxHydrated: number; // hydration cap (the budget when fully zoomed in)
   loaded: number; // total loaded stub count
@@ -47,6 +61,7 @@ export function visibilityBudgetForZoom(input: {
     screenArea,
     strokePx,
     coverageTarget,
+    revealMoreOnZoom,
     maxVisible,
     maxHydrated,
     loaded,
@@ -58,22 +73,101 @@ export function visibilityBudgetForZoom(input: {
     return { maxVisible, maxHydrated };
   }
 
-  // On-screen dot footprint at the most zoomed-out level. The radius term is
-  // tiny when zoomed out (cells are sub-pixel), so the fixed stroke dominates.
-  const radiusPx = (avgRadius || 0) / unitsPerPixelAtZoomMin;
-  const dotDiameter = 2 * radiusPx + strokePx;
-  const dotArea = dotDiameter * dotDiameter;
-  const floor =
+  const levelsIn = Math.max(0, zoom - zoomMin);
+  // Cells shrink with distance zoomed out; the fixed stroke dominates the dot
+  // footprint when zoomed out. Compute the dot's on-screen area at the level we
+  // care about: zoomMin for the reveal-more floor, the current zoom otherwise.
+  const dotAreaAt = (levels: number): number => {
+    const unitsPerPixel = unitsPerPixelAtZoomMin / 2 ** levels;
+    const diameter = (2 * (avgRadius || 0)) / unitsPerPixel + strokePx;
+    return diameter * diameter;
+  };
+  // Number of dots that cover coverageTarget of the screen at a given dot area.
+  const coverageBudget = (dotArea: number): number =>
     dotArea > 0 ? (coverageTarget * screenArea) / dotArea : maxVisible;
 
-  const levelsIn = Math.max(0, zoom - zoomMin);
-  const visible = clamp(Math.round(floor * 2 ** levelsIn), 1, maxVisible);
-  // Hydration cap tracks the same fraction so fewer shapes are hydrated/drawn
-  // when zoomed out (where they look like dots anyway).
+  // The reveal-more ramp (coverage floor doubled per zoom level up to the cap).
+  // It rises monotonically as you zoom in, so it doubles as a "how zoomed in are
+  // we" signal — used for `visible` in reveal-more mode and for hydration in BOTH
+  // modes.
+  const revealRamp = clamp(
+    Math.round(coverageBudget(dotAreaAt(0)) * 2 ** levelsIn),
+    1,
+    maxVisible,
+  );
+
+  const visible = revealMoreOnZoom
+    ? revealRamp
+    : // Enforce coverage at the CURRENT zoom: as you zoom in the dots grow, so
+      // fewer fit within coverageTarget — density stays ~constant (uncrowded) and
+      // everything shows only when the actual in-view count drops below this.
+      clamp(Math.round(coverageBudget(dotAreaAt(levelsIn))), 1, maxVisible);
+
+  // Hydration ramps with ZOOM (few shapes zoomed out — they read as dots — up to
+  // maxHydrated zoomed in), tracked off the reveal-more ramp in BOTH modes. In
+  // coverage mode the visible budget deliberately SHRINKS as you zoom in, so
+  // scaling hydration off `visible` there would starve it (everything would stay
+  // a dot). The store caps this at the visible budget so it never fetches coords
+  // for annotations that aren't drawn.
   const hydrated = clamp(
-    Math.round(maxHydrated * (visible / maxVisible)),
+    Math.round(maxHydrated * (revealRamp / maxVisible)),
     1,
     maxHydrated,
   );
   return { maxVisible: visible, maxHydrated: hydrated };
+}
+
+/**
+ * Apply the `minimumVisible` floor to the zoom-adaptive visible budget, capped
+ * at `maxVisible`: draw at least `minimumVisible` (so a busy view isn't stripped
+ * below it) but never more than the configured cap. Shared by the store and its
+ * test replica so both floor identically.
+ */
+export function clampVisibleBudget(
+  zoomBudget: number,
+  minimumVisible: number,
+  maxVisible: number,
+): number {
+  return Math.min(Math.max(zoomBudget, minimumVisible), maxVisible);
+}
+
+/**
+ * Choose which annotation ids to draw for a given total `budget`, in priority
+ * tiers:
+ *   1. the actual (unexpanded) viewport — what the user is looking at
+ *   2. the expanded pan-preload margin
+ *   3. anything else off-screen
+ *
+ * Prioritizing the actual viewport is what lets the caller's `minimumVisible`
+ * floor (folded into `budget`) be honored IN THE VISIBLE AREA rather than
+ * diluted across the larger pan-preload box: the viewport is filled first, so it
+ * receives min(inViewport, budget) draws. When the viewport alone meets or
+ * exceeds the budget, a stable subset of just the viewport is drawn (no budget
+ * spent off-screen); otherwise the remainder pre-loads the margin, then
+ * off-screen, for smooth panning.
+ *
+ * `selectSubset` is injected (the store passes `selectStableSubset`) to keep
+ * this pure and dependency-light for unit testing.
+ */
+export function selectVisibleIds(input: {
+  inViewportIds: string[]; // actual (unexpanded) viewport
+  marginIds: string[]; // expanded margin, excluding inViewportIds
+  offViewportIds: string[]; // outside the expanded box
+  budget: number; // total render budget (already floored/capped by the caller)
+  selectSubset: (ids: string[], maxCount: number) => string[];
+}): string[] {
+  const { inViewportIds, marginIds, offViewportIds, budget, selectSubset } =
+    input;
+  if (inViewportIds.length >= budget) {
+    // Viewport alone meets/exceeds the budget: draw a stable subset of just the
+    // viewport — no budget spent on off-screen pre-load.
+    return selectSubset(inViewportIds, budget);
+  }
+  // The whole viewport fits; spend what's left on the pan-preload margin first,
+  // then anything else off-screen.
+  let remaining = budget - inViewportIds.length;
+  const marginPick = selectSubset(marginIds, remaining);
+  remaining -= marginPick.length;
+  const offPick = remaining > 0 ? selectSubset(offViewportIds, remaining) : [];
+  return [...inViewportIds, ...marginPick, ...offPick];
 }

--- a/src/utils/visibilityConfigBounds.ts
+++ b/src/utils/visibilityConfigBounds.ts
@@ -18,10 +18,11 @@ export interface IVisibilityBound {
   integer: boolean;
 }
 
-// The numeric fields of IVisibilityConfig (globalThreshold is a boolean).
+// The numeric fields of IVisibilityConfig (globalThreshold and revealMoreOnZoom
+// are booleans, handled separately).
 export type TVisibilityNumericKey = Exclude<
   keyof IVisibilityConfig,
-  "globalThreshold"
+  "globalThreshold" | "revealMoreOnZoom"
 >;
 
 // Hard ceilings are "slow-but-survivable, never OOM/freeze" caps, a little
@@ -34,6 +35,7 @@ export const VISIBILITY_BOUNDS: Record<
 > = {
   stubThreshold: { min: 1000, max: 200000, integer: true },
   maxVisible: { min: 1000, max: 200000, integer: true },
+  minimumVisible: { min: 0, max: 200000, integer: true },
   maxHydrated: { min: 500, max: 200000, integer: true },
   hydrationCacheCap: { min: 500, max: 200000, integer: true },
   coverageTarget: { min: 0.01, max: 1, integer: false },
@@ -85,6 +87,8 @@ export function clampVisibilityConfig(
   // Cross-field invariants.
   next.maxHydrated = Math.min(next.maxHydrated, next.maxVisible);
   next.hydrationCacheCap = Math.max(next.hydrationCacheCap, next.maxHydrated);
+  // The minimum floor can't exceed the cap it floors toward.
+  next.minimumVisible = Math.min(next.minimumVisible, next.maxVisible);
 
   const adjusted = NUMERIC_KEYS.filter((key) => next[key] !== requested[key]);
 
@@ -92,6 +96,7 @@ export function clampVisibilityConfig(
     config: {
       ...next,
       globalThreshold: proposed.globalThreshold ?? current.globalThreshold,
+      revealMoreOnZoom: proposed.revealMoreOnZoom ?? current.revealMoreOnZoom,
     },
     adjusted,
   };


### PR DESCRIPTION
## Summary

Overhauls how NimbusImage budgets annotation rendering on large (stub-only) datasets so the advanced settings behave the way users expect, the "Showing X of Y" indicator is honest, and working zooms stay responsive and uncrowded.

All frontend, no backend changes.

## What changed

**Render-coverage indicator**
- "Stub mode" for the indicator is now derived **reactively** (`stubOnlyMode || stub count > stubThreshold`), so lowering the stub-mode threshold below a dataset's count surfaces the "Showing X of Y in view" readout immediately — no reload. It also stays visible whenever the render is downsampling.

**Visible-budget controls**
- New **Minimum visible annotations** setting: a floor on the zoom-adaptive budget, honored *in the actual viewport* via a three-tier fill (viewport → pan-preload ring → off-screen) rather than diluted across the expanded box. So "at least N in view" actually holds in view.
- New **Reveal more when zooming in** setting:
  - **Off (new default):** the coverage target is enforced at *every* zoom, so the view holds ~constant density (uncrowded) and reveals everything only when you zoom into a genuinely sparse region.
  - **On:** the previous "reveal more as you zoom in" ramp (coverage bounds the fully-zoomed-out view; the budget doubles per zoom level to the cap).
- **Reset to defaults** button, and the settings reset on a genuine dataset switch (session tuning shouldn't leak between datasets). Defaults live in one `DEFAULT_VISIBILITY_CONFIG` constant.

**Hydration**
- The hydration budget now ramps with **zoom** (few shapes zoomed out, up to `maxHydrated` zoomed in) in both modes, and is capped at the visible budget. Fixes annotations rendering as dots instead of filled shapes in coverage mode.

**Camera refresh**
- **Any pan** now triggers a visibility refresh (previously it needed to cross ~20% of the viewport); **zoom** keeps its magnification hysteresis. A center drift that rides along with a sub-threshold zoom stays gated by the zoom threshold, and a pure pan after a sub-threshold zoom still refreshes (it's classified against the previous camera event, not the frozen refresh baseline).

**Performance**
- Replaced two `splitByViewport` calls plus a caller-side set-difference with a single-pass `partitionByViewports` (viewport / ring / outside).

**UI**
- Restyled the "Advanced settings" blurb as a small, muted info note with an icon (was rendering at body size due to a Vuetify cascade-layer override).

## Testing

- 380 unit/integration tests pass (`renderCoverage`, `visibilityBudget`, `visibilityConfigBounds`, `spatialIndex`, `camera`, and the annotation-store replica), including regression tests for the in-view floor, coverage-mode hydration ramp, and the pan-after-sub-threshold-zoom refresh. `tsc` + `eslint` clean.
- Verified live on the 52K HCR and 708K Xenium datasets: reactive indicator, `minimumVisible` floor landing in view, reset button + reset-on-dataset-switch, both zoom modes, any-pan refresh, and shapes hydrating at working zoom.

## Related

- #1251 — follow-up: persist these settings per-dataset in configuration metadata (this PR resets to defaults on dataset switch; that issue tracks true persistence).
- #1252 — follow-up: the ~750ms visibility update when fully zoomed out on very large datasets (pre-existing, pool-hashing dominated; out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
