### PR TITLE
Speed up visibility updates for very large annotation datasets

### DIFF
--- a/src/utils/__tests__/annotationStubUtils.test.ts
+++ b/src/utils/__tests__/annotationStubUtils.test.ts
@@ -78,7 +78,11 @@ describe("selectStableSubset", () => {
     const expected = [...ids]
       .sort((a, b) => hashString(a) - hashString(b))
       .slice(0, k);
-    expect(new Set(selectStableSubset(ids, k))).toEqual(new Set(expected));
+    expect(selectStableSubset(ids, k)).toEqual(expected);
+  });
+
+  it("returns an empty subset for a zero budget", () => {
+    expect(selectStableSubset(["a", "b", "c"], 0)).toEqual([]);
   });
 
   it("selects the same set regardless of input order", () => {

--- a/src/utils/__tests__/annotationStubUtils.test.ts
+++ b/src/utils/__tests__/annotationStubUtils.test.ts
@@ -92,6 +92,14 @@ describe("selectStableSubset", () => {
       new Set(selectStableSubset(shuffled, 10)),
     );
   });
+
+  it("breaks hash collisions by id regardless of input order", () => {
+    const largerId = "d63cf0eeecc40375b230be50";
+    const smallerId = "38817f7125d2721c2651e6cb";
+    expect(hashString(largerId)).toBe(hashString(smallerId));
+    expect(selectStableSubset([largerId, smallerId], 1)).toEqual([smallerId]);
+    expect(selectStableSubset([smallerId, largerId], 1)).toEqual([smallerId]);
+  });
 });
 
 describe("selectLargestBySize", () => {
@@ -131,6 +139,18 @@ describe("selectLargestBySize", () => {
     ]);
     expect(selectLargestBySize(["e", "d", "c", "b", "a"], sizeOf, 1)).toEqual([
       lowerHash,
+    ]);
+  });
+
+  it("breaks size and hash collisions by id regardless of input order", () => {
+    const largerId = "d63cf0eeecc40375b230be50";
+    const smallerId = "38817f7125d2721c2651e6cb";
+    expect(hashString(largerId)).toBe(hashString(smallerId));
+    expect(selectLargestBySize([largerId, smallerId], () => 1, 1)).toEqual([
+      smallerId,
+    ]);
+    expect(selectLargestBySize([smallerId, largerId], () => 1, 1)).toEqual([
+      smallerId,
     ]);
   });
 

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -336,22 +336,60 @@ export function hashString(str: string): number {
  * set stays stable across pans instead of reshuffling each frame.
  */
 export function selectStableSubset(ids: string[], maxCount: number): string[] {
+  if (maxCount <= 0) return [];
   if (ids.length <= maxCount) return ids;
   // Pick the `maxCount` lowest-hash ids (a deterministic, order-independent
-  // pseudo-random subset). Compute each id's hash exactly once into a parallel
-  // typed array and sort an index array — the previous `sort((a, b) =>
-  // hashString(a) - hashString(b))` recomputed the hash twice per comparison
-  // (~2·N·log₂N hashes), which dominated the per-pan cost at 700K (~1.1 s).
+  // pseudo-random subset). Quickselect partitions the candidates in O(N), then
+  // only the retained subset is sorted. Full-sorting every candidate made the
+  // 708K-annotation zoomed-out case pay O(N log N) even when it kept only 5K.
   const n = ids.length;
   const hashes = new Uint32Array(n);
+  const order = new Uint32Array(n);
   for (let i = 0; i < n; i++) {
     hashes[i] = hashString(ids[i]);
+    order[i] = i;
   }
-  const order = Array.from({ length: n }, (_, i) => i);
-  order.sort((a, b) => hashes[a] - hashes[b]);
+
+  // The id tie-break makes the result independent of input order even in the
+  // rare event of a 32-bit hash collision.
+  const compareIndices = (a: number, b: number): number => {
+    const hashDifference = hashes[a] - hashes[b];
+    if (hashDifference !== 0) return hashDifference;
+    return ids[a] < ids[b] ? -1 : ids[a] > ids[b] ? 1 : 0;
+  };
+
+  let left = 0;
+  let right = n - 1;
+  const target = maxCount - 1;
+  while (left < right) {
+    let low = left;
+    let high = right;
+    const pivot = order[left + ((right - left) >> 1)];
+    while (low <= high) {
+      while (compareIndices(order[low], pivot) < 0) low += 1;
+      while (compareIndices(order[high], pivot) > 0) high -= 1;
+      if (low <= high) {
+        const swap = order[low];
+        order[low] = order[high];
+        order[high] = swap;
+        low += 1;
+        high -= 1;
+      }
+    }
+    if (target <= high) {
+      right = high;
+    } else if (target >= low) {
+      left = low;
+    } else {
+      break;
+    }
+  }
+
+  const selected = order.slice(0, maxCount);
+  selected.sort(compareIndices);
   const result: string[] = new Array(maxCount);
   for (let i = 0; i < maxCount; i++) {
-    result[i] = ids[order[i]];
+    result[i] = ids[selected[i]];
   }
   return result;
 }

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -424,10 +424,13 @@ export function selectLargestBySize(
   // root is the worst kept element, so a new candidate replaces it iff it beats
   // it. O(n log count) — ~4× faster than sorting all n at 700K — and avoids the
   // O(n log n) full sort the old object-sort paid. `worse(a, b)` ⇒ a is more
-  // evictable than b: smaller size, or (size tie) larger hash — so the smaller
-  // hash survives ties, matching the deterministic tie-break above.
-  const worse = (a: number, b: number) =>
-    sizes[a] !== sizes[b] ? sizes[a] < sizes[b] : hashes[a] > hashes[b];
+  // evictable than b: smaller size, or (size tie) larger hash/id — so the
+  // smaller hash/id survives ties, matching the deterministic tie-break above.
+  const worse = (a: number, b: number) => {
+    if (sizes[a] !== sizes[b]) return sizes[a] < sizes[b];
+    if (hashes[a] !== hashes[b]) return hashes[a] > hashes[b];
+    return ids[a] > ids[b];
+  };
   const heap = new Int32Array(count);
   let size = 0;
   for (let i = 0; i < n; i++) {

--- a/src/utils/spatialIndex.ts
+++ b/src/utils/spatialIndex.ts
@@ -92,20 +92,25 @@ export class AnnotationSpatialIndex {
     const outside: string[] = [];
     for (const id of currentFrameIds) {
       const item = this.itemById.get(id);
+      if (!item) {
+        outside.push(id);
+        continue;
+      }
+      // SpatialItem entries are points: bulkLoad and insert always set
+      // minX === maxX and minY === maxY.
+      const { minX, minY } = item;
       if (
-        item &&
-        item.minX >= innerBox.minX &&
-        item.minX <= innerBox.maxX &&
-        item.minY >= innerBox.minY &&
-        item.minY <= innerBox.maxY
+        minX >= innerBox.minX &&
+        minX <= innerBox.maxX &&
+        minY >= innerBox.minY &&
+        minY <= innerBox.maxY
       ) {
         inViewport.push(id);
       } else if (
-        item &&
-        item.minX >= outerBox.minX &&
-        item.minX <= outerBox.maxX &&
-        item.minY >= outerBox.minY &&
-        item.minY <= outerBox.maxY
+        minX >= outerBox.minX &&
+        minX <= outerBox.maxX &&
+        minY >= outerBox.minY &&
+        minY <= outerBox.maxY
       ) {
         ring.push(id);
       } else {

--- a/src/utils/spatialIndex.ts
+++ b/src/utils/spatialIndex.ts
@@ -78,29 +78,35 @@ export class AnnotationSpatialIndex {
    * The inner box must be contained in the outer box (it always is here: the outer
    * is the inner expanded by 50% each side). This replaces two `splitByViewport`
    * calls plus a caller-side set-difference with one iteration over
-   * `currentFrameIds`, which matters on the hot visibility-update path at ~700K.
+   * `currentFrameIds`, using the already-indexed point coordinates directly
+   * instead of running two tree searches and building two full result sets.
+   * That matters on the hot visibility-update path at ~700K.
    */
   partitionByViewports(
     currentFrameIds: string[],
     innerBox: { minX: number; minY: number; maxX: number; maxY: number },
     outerBox: { minX: number; minY: number; maxX: number; maxY: number },
   ): { inViewport: string[]; ring: string[]; outside: string[] } {
-    const innerSet = new Set<string>();
-    for (const item of this.tree.search(innerBox)) {
-      innerSet.add(item.id);
-    }
-    const outerSet = new Set<string>();
-    for (const item of this.tree.search(outerBox)) {
-      outerSet.add(item.id);
-    }
-
     const inViewport: string[] = [];
     const ring: string[] = [];
     const outside: string[] = [];
     for (const id of currentFrameIds) {
-      if (innerSet.has(id)) {
+      const item = this.itemById.get(id);
+      if (
+        item &&
+        item.minX >= innerBox.minX &&
+        item.minX <= innerBox.maxX &&
+        item.minY >= innerBox.minY &&
+        item.minY <= innerBox.maxY
+      ) {
         inViewport.push(id);
-      } else if (outerSet.has(id)) {
+      } else if (
+        item &&
+        item.minX >= outerBox.minX &&
+        item.minX <= outerBox.maxX &&
+        item.minY >= outerBox.minY &&
+        item.minY <= outerBox.maxY
+      ) {
         ring.push(id);
       } else {
         outside.push(id);


### PR DESCRIPTION
Closes #1252

## What changed

- replace the full candidate sort in `selectStableSubset` with linear-time quickselect, sorting only the retained visibility budget
- classify current-frame annotations directly from already-indexed point coordinates instead of running two RBush searches and building two full result sets
- preserve deterministic lowest-hash selection, including an ID tie-break for rare hash collisions
- strengthen subset tests and cover the zero-budget edge case

## Why

At a fully zoomed-out 708,983-annotation dataset, the visibility update processed the entire candidate pool in two expensive phases even though only a small render budget was retained. The selection phase full-sorted all candidates, and viewport partitioning materialized two full-frame search result sets.

## Impact

A local 708,983-ID warm-median benchmark reduced the two affected phases from about 624 ms combined to 153 ms combined (~4.1×):

- stable subset selection: 233 ms → 55 ms
- viewport partitioning: 392 ms → 98 ms

The selected ID set is unchanged.

## Validation

- live foreground browser test on the local 708,983-annotation Xenium dataset; a real fully-zoomed-out pan updated coverage correctly from 708,972 to 611,635 annotations in view while retaining 12,431 rendered
- `pnpm tsc`
- `pnpm lint:ci`
- `pnpm test -- --run` (163 files, 2,706 tests)
- targeted annotation-stub and spatial-index tests (89 tests)