### PR TITLE
Persist annotation visibility settings in dataset configurations

### DIFF
--- a/src/components/VisibilitySettings.test.ts
+++ b/src/components/VisibilitySettings.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { resolveVisibilityConfig } from "@/store/model";
+
+const h = vi.hoisted(() => ({
+  annotationStore: {
+    visibilityConfig: {} as ReturnType<
+      typeof import("@/store/model").resolveVisibilityConfig
+    >,
+    updateVisibilityConfig: vi.fn(),
+    resetVisibilityConfig: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/annotation", async () => {
+  const { reactive } = await import("vue");
+  h.annotationStore = reactive(h.annotationStore);
+  return { default: h.annotationStore };
+});
+
+import VisibilitySettings from "./VisibilitySettings.vue";
+
+describe("VisibilitySettings", () => {
+  beforeEach(() => {
+    h.annotationStore.visibilityConfig = resolveVisibilityConfig();
+    vi.clearAllMocks();
+  });
+
+  it("updates numeric drafts when configuration settings hydrate", async () => {
+    const wrapper = mount(VisibilitySettings);
+
+    h.annotationStore.visibilityConfig = resolveVisibilityConfig({
+      maxVisible: 75000,
+    });
+    await nextTick();
+
+    expect((wrapper.vm as any).draft.maxVisible).toBe(75000);
+  });
+});

--- a/src/components/VisibilitySettings.vue
+++ b/src/components/VisibilitySettings.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, reactive } from "vue";
+import { computed, onBeforeUnmount, reactive, watch } from "vue";
 import annotationStore from "@/store/annotation";
 import {
   VISIBILITY_BOUNDS,
@@ -185,6 +185,18 @@ const draft = reactive<Record<TVisibilityNumericKey, number>>(
 const notes = reactive<Partial<Record<TVisibilityNumericKey, string>>>({});
 const noteTimers: Partial<Record<TVisibilityNumericKey, number>> = {};
 
+// VisibilitySettings can mount before the selected configuration finishes
+// loading. Keep the editable numeric draft aligned when persisted settings are
+// hydrated or when the user switches configurations.
+watch(
+  () => annotationStore.visibilityConfig,
+  (config) => {
+    for (const field of numericFields) {
+      draft[field.key] = config[field.key];
+    }
+  },
+);
+
 function flashNote(key: TVisibilityNumericKey, value: number) {
   notes[key] = `Adjusted to ${value.toLocaleString()}`;
   if (noteTimers[key] !== undefined) {
@@ -210,7 +222,7 @@ function commitField(key: TVisibilityNumericKey) {
     { [key]: draft[key] },
     annotationStore.visibilityConfig,
   );
-  annotationStore.setVisibilityConfig(config);
+  annotationStore.updateVisibilityConfig(config);
   // Reflect the accepted values back into the inputs (covers cross-field
   // changes to fields the user didn't touch).
   for (const field of numericFields) {
@@ -224,14 +236,14 @@ function commitField(key: TVisibilityNumericKey) {
 const globalThreshold = computed({
   get: () => annotationStore.visibilityConfig.globalThreshold,
   set: (value: boolean) => {
-    annotationStore.setVisibilityConfig({ globalThreshold: value });
+    annotationStore.updateVisibilityConfig({ globalThreshold: value });
   },
 });
 
 const revealMoreOnZoom = computed({
   get: () => annotationStore.visibilityConfig.revealMoreOnZoom,
   set: (value: boolean) => {
-    annotationStore.setVisibilityConfig({ revealMoreOnZoom: value });
+    annotationStore.updateVisibilityConfig({ revealMoreOnZoom: value });
   },
 });
 

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -102,6 +102,9 @@ export default class GirderAPI {
   private readonly resolvedHistogramCache = markRaw(
     new Map<string, ITileHistogram>(),
   );
+  private readonly configurationUpdateChains = markRaw(
+    new Map<string, Promise<IUPennCollection>>(),
+  );
 
   constructor(client: RestClientInstance) {
     this.client = client;
@@ -885,14 +888,33 @@ export default class GirderAPI {
   async updateConfigurationKey(
     config: IDatasetConfiguration,
     key: keyof IDatasetConfigurationBase,
-  ): Promise<any> {
+  ): Promise<IUPennCollection> {
+    // Snapshot the value when the save is requested, then serialize writes for
+    // the same configuration key. Metadata updates replace the complete value
+    // for that key, so allowing an older request to finish last can discard a
+    // newer edit.
     const metadata = toConfiguationMetadata({ [key]: config[key] });
-    const data = new FormData();
-    data.set("metadata", JSON.stringify(metadata));
-    const collection: IUPennCollection = (
-      await this.client.put(`upenn_collection/${config.id}/metadata`, data)
-    ).data;
-    return collection;
+    const queueKey = `${config.id}:${key}`;
+    const previousUpdate =
+      this.configurationUpdateChains.get(queueKey) ?? Promise.resolve();
+    const update = previousUpdate
+      .catch(() => undefined)
+      .then(async () => {
+        const data = new FormData();
+        data.set("metadata", JSON.stringify(metadata));
+        return (
+          await this.client.put(`upenn_collection/${config.id}/metadata`, data)
+        ).data as IUPennCollection;
+      });
+    this.configurationUpdateChains.set(queueKey, update);
+
+    try {
+      return await update;
+    } finally {
+      if (this.configurationUpdateChains.get(queueKey) === update) {
+        this.configurationUpdateChains.delete(queueKey);
+      }
+    }
   }
 
   deleteConfiguration(

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -34,6 +34,7 @@ import {
   TJobType,
   IDatasetConfigurationCompatibility,
   IJob,
+  resolveVisibilityConfig,
 } from "@/store/model";
 import {
   toStyle,
@@ -1261,6 +1262,12 @@ export function setBaseCollectionValues(
     description: item.description,
   };
   for (const key of configurationBaseKeys) {
+    if (key === "visibilityConfig") {
+      config.visibilityConfig = resolveVisibilityConfig(
+        item.meta.visibilityConfig,
+      );
+      continue;
+    }
     config[key] =
       key in item.meta ? item.meta[key] : exampleConfigurationBase()[key];
   }

--- a/src/store/GirderAPI.visibilityConfig.test.ts
+++ b/src/store/GirderAPI.visibilityConfig.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/fetch", () => ({
+  fetchAllPages: vi.fn(),
+}));
+
+vi.mock("@/store/progress", () => ({
+  default: {},
+}));
+
+import GirderAPI, { setBaseCollectionValues } from "./GirderAPI";
+import { DEFAULT_VISIBILITY_CONFIG, type IDatasetConfiguration } from "./model";
+
+function makeConfiguration(
+  visibilityConfig = { ...DEFAULT_VISIBILITY_CONFIG },
+): IDatasetConfiguration {
+  return {
+    id: "configuration-1",
+    name: "Configuration",
+    description: "",
+    compatibility: {
+      xyDimensions: "multiple",
+      zDimensions: "multiple",
+      tDimensions: "multiple",
+      channels: {},
+    },
+    layers: [],
+    tools: [],
+    snapshots: [],
+    propertyIds: [],
+    pipelines: [],
+    scales: {
+      pixelSize: { value: 1, unit: "m" },
+      zStep: { value: 1, unit: "m" },
+      tStep: { value: 1, unit: "s" },
+    },
+    visibilityConfig,
+  };
+}
+
+describe("configuration visibility metadata", () => {
+  it("hydrates persisted visibility settings over shipped defaults", () => {
+    const persisted = {
+      maxVisible: 75000,
+      globalThreshold: false,
+    };
+
+    const configuration = setBaseCollectionValues({
+      _id: "configuration-1",
+      name: "Configuration",
+      description: "",
+      meta: { visibilityConfig: persisted },
+    } as any);
+
+    expect(configuration.visibilityConfig).toEqual({
+      ...DEFAULT_VISIBILITY_CONFIG,
+      ...persisted,
+    });
+  });
+
+  it("falls back to shipped defaults for older configurations", () => {
+    const configuration = setBaseCollectionValues({
+      _id: "configuration-1",
+      name: "Configuration",
+      description: "",
+      meta: {},
+    } as any);
+
+    expect(configuration.visibilityConfig).toEqual(DEFAULT_VISIBILITY_CONFIG);
+    expect(configuration.visibilityConfig).not.toBe(DEFAULT_VISIBILITY_CONFIG);
+  });
+
+  it("serializes visibility settings through the configuration sync API", async () => {
+    const client = {
+      put: vi.fn().mockResolvedValue({ data: {} }),
+    } as any;
+    const api = new GirderAPI(client);
+    const configuration = makeConfiguration({
+      ...DEFAULT_VISIBILITY_CONFIG,
+      coverageTarget: 0.5,
+    });
+
+    await api.updateConfigurationKey(configuration, "visibilityConfig");
+
+    const formData = client.put.mock.calls[0][1] as FormData;
+    expect(client.put).toHaveBeenCalledWith(
+      "upenn_collection/configuration-1/metadata",
+      expect.any(FormData),
+    );
+    expect(JSON.parse(formData.get("metadata") as string)).toEqual({
+      visibilityConfig: configuration.visibilityConfig,
+    });
+  });
+});

--- a/src/store/GirderAPI.visibilityConfig.test.ts
+++ b/src/store/GirderAPI.visibilityConfig.test.ts
@@ -91,4 +91,52 @@ describe("configuration visibility metadata", () => {
       visibilityConfig: configuration.visibilityConfig,
     });
   });
+
+  it("waits for an earlier visibility save before starting the latest save", async () => {
+    let finishFirstSave!: (value: { data: object }) => void;
+    const firstSave = new Promise<{ data: object }>((resolve) => {
+      finishFirstSave = resolve;
+    });
+    const client = {
+      put: vi
+        .fn()
+        .mockReturnValueOnce(firstSave)
+        .mockResolvedValueOnce({ data: {} }),
+    } as any;
+    const api = new GirderAPI(client);
+    const configuration = makeConfiguration({
+      ...DEFAULT_VISIBILITY_CONFIG,
+      maxVisible: 51000,
+    });
+
+    const earlierSave = api.updateConfigurationKey(
+      configuration,
+      "visibilityConfig",
+    );
+    configuration.visibilityConfig = {
+      ...DEFAULT_VISIBILITY_CONFIG,
+      ...configuration.visibilityConfig,
+      maxVisible: 52000,
+    };
+    const latestSave = api.updateConfigurationKey(
+      configuration,
+      "visibilityConfig",
+    );
+
+    await vi.waitFor(() => expect(client.put).toHaveBeenCalledTimes(1));
+
+    finishFirstSave({ data: {} });
+    await earlierSave;
+    await latestSave;
+
+    expect(client.put).toHaveBeenCalledTimes(2);
+    const earlierMetadata = JSON.parse(
+      (client.put.mock.calls[0][1] as FormData).get("metadata") as string,
+    );
+    const latestMetadata = JSON.parse(
+      (client.put.mock.calls[1][1] as FormData).get("metadata") as string,
+    );
+    expect(earlierMetadata.visibilityConfig.maxVisible).toBe(51000);
+    expect(latestMetadata.visibilityConfig.maxVisible).toBe(52000);
+  });
 });

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -33,6 +33,7 @@ import {
   type TAnnotationOrStub,
   type THydrationMode,
   type IVisibilityConfig,
+  resolveVisibilityConfig,
 } from "./model";
 import type AnnotationsAPI from "./AnnotationsAPI";
 
@@ -80,22 +81,6 @@ function cloneAnnotation(annotation: IAnnotation): IAnnotation {
     coordinates: toRaw(rawAnnotation.coordinates),
   });
 }
-
-// Shipped defaults for the advanced annotation-rendering settings. Single
-// source of truth for both the store's initial value and the per-dataset reset
-// (settings are session state, not persisted, and snap back to these when the
-// dataset changes). Spread on use so each assignment gets a fresh object.
-const DEFAULT_VISIBILITY_CONFIG: IVisibilityConfig = {
-  stubThreshold: 100000,
-  maxVisible: 50000,
-  minimumVisible: 5000,
-  maxHydrated: 20000,
-  hydrationCacheCap: 40000,
-  globalThreshold: true,
-  coverageTarget: 0.3,
-  revealMoreOnZoom: false,
-  viewportRefreshFraction: 0.2,
-};
 
 @Module({ dynamic: true, store, name: "annotation" })
 export class Annotations extends VuexModule {
@@ -204,7 +189,7 @@ export class Annotations extends VuexModule {
   hydratedAnnotations: Map<string, IAnnotation> = markRaw(new Map());
   visibleAnnotationIds: Set<string> = markRaw(new Set());
   hydrationMode: THydrationMode = "dots";
-  visibilityConfig: IVisibilityConfig = { ...DEFAULT_VISIBILITY_CONFIG };
+  visibilityConfig: IVisibilityConfig = resolveVisibilityConfig();
 
   // Average annotation radius (world units) over the loaded stubs, computed once
   // when stubs are set. Feeds the density-derived zoomed-out render budget.
@@ -221,15 +206,30 @@ export class Annotations extends VuexModule {
     this.visibilityConfig = { ...this.visibilityConfig, ...config };
   }
 
-  // Snap the advanced rendering settings back to the shipped defaults. Used by
-  // the settings "Reset to defaults" button and on a genuine dataset switch
-  // (settings are session tuning, not per-dataset, so a tweak for one dataset
-  // shouldn't silently carry into the next). An action so it can be dispatched
-  // cross-module from the main store; passing every default key makes the
-  // setVisibilityConfig merge resolve to exactly the defaults.
+  @Mutation
+  replaceVisibilityConfig(config?: Partial<IVisibilityConfig>) {
+    this.visibilityConfig = resolveVisibilityConfig(config);
+  }
+
+  // Load configuration metadata over the shipped defaults so configurations
+  // created before persistence (and partial metadata from future migrations)
+  // always get a complete, independent settings object.
   @Action
-  resetVisibilityConfig() {
-    this.setVisibilityConfig({ ...DEFAULT_VISIBILITY_CONFIG });
+  loadVisibilityConfig(config?: Partial<IVisibilityConfig>) {
+    this.replaceVisibilityConfig(config);
+  }
+
+  @Action
+  async updateVisibilityConfig(config: Partial<IVisibilityConfig>) {
+    this.setVisibilityConfig(config);
+    await main.saveVisibilityConfig(this.visibilityConfig);
+  }
+
+  // Reset the shared configuration metadata as well as the live renderer.
+  @Action
+  async resetVisibilityConfig() {
+    this.replaceVisibilityConfig();
+    await main.saveVisibilityConfig(this.visibilityConfig);
   }
 
   @Mutation

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -71,6 +71,7 @@ import {
   CombineToolStateSymbol,
   NotificationType,
   IDimensionStrategy,
+  IVisibilityConfig,
 } from "./model";
 
 import persister from "./Persister";
@@ -1130,6 +1131,7 @@ export class Main extends VuexModule {
     data: IDatasetConfiguration | null;
   }) {
     this.setConfigurationImpl({ id, data });
+    this.context.dispatch("loadVisibilityConfig", data?.visibilityConfig);
     // Warm the SAM model cache in the background: encoder downloads are
     // large, this way they are usually cached before a SAM tool is selected
     const samModels = new Set(
@@ -1157,6 +1159,13 @@ export class Main extends VuexModule {
     this.configuration = data;
     if (!data) {
       return;
+    }
+  }
+
+  @Mutation
+  private setConfigurationVisibilityConfig(config: IVisibilityConfig) {
+    if (this.configuration) {
+      this.configuration.visibilityConfig = { ...config };
     }
   }
 
@@ -1452,10 +1461,6 @@ export class Main extends VuexModule {
     // are repopulated by the reload that follows.
     if (datasetChanged) {
       this.context.dispatch("resetFilterState");
-      // Advanced rendering settings are session tuning, not per-dataset — snap
-      // them back to defaults on a genuine switch (not a same-dataset refresh)
-      // so a tweak for one dataset can't silently carry into the next.
-      this.context.dispatch("resetVisibilityConfig");
     }
     if (!id) {
       this.setDataset({ id, data: null });
@@ -2058,6 +2063,15 @@ export class Main extends VuexModule {
         throw error;
       }
     }
+  }
+
+  @Action
+  async saveVisibilityConfig(config: IVisibilityConfig) {
+    if (!this.configuration) {
+      return;
+    }
+    this.setConfigurationVisibilityConfig(config);
+    await this.syncConfiguration("visibilityConfig");
   }
 
   @Action

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -516,6 +516,10 @@ export interface IDatasetConfigurationBase {
   propertyIds: string[];
   pipelines: IPipeline[];
   scales: IScales;
+  // Shared annotation-rendering tuning for this configuration. Optional for
+  // compatibility with configurations created before these settings were
+  // persisted.
+  visibilityConfig?: IVisibilityConfig;
 }
 
 export interface IDatasetConfiguration extends IDatasetConfigurationBase {
@@ -1634,6 +1638,27 @@ export interface IVisibilityConfig {
   viewportRefreshFraction: number;
 }
 
+export const DEFAULT_VISIBILITY_CONFIG: IVisibilityConfig = {
+  stubThreshold: 100000,
+  maxVisible: 50000,
+  minimumVisible: 5000,
+  maxHydrated: 20000,
+  hydrationCacheCap: 40000,
+  globalThreshold: true,
+  coverageTarget: 0.3,
+  revealMoreOnZoom: false,
+  viewportRefreshFraction: 0.2,
+};
+
+export function resolveVisibilityConfig(
+  config?: Partial<IVisibilityConfig>,
+): IVisibilityConfig {
+  return {
+    ...DEFAULT_VISIBILITY_CONFIG,
+    ...config,
+  };
+}
+
 export function isHydratedAnnotation(
   annotation: TAnnotationOrStub,
 ): annotation is IAnnotation {
@@ -2280,6 +2305,7 @@ export function exampleConfigurationBase(): IDatasetConfigurationBase {
       zStep: { value: 1, unit: "m" },
       tStep: { value: 1, unit: "s" },
     },
+    visibilityConfig: resolveVisibilityConfig(),
   };
 }
 


### PR DESCRIPTION
Closes #1251.

## What changed

- persist the complete annotation `visibilityConfig` in shared configuration metadata
- hydrate saved values whenever a configuration loads
- merge missing or partial metadata over shipped defaults for backward compatibility
- keep the numeric settings draft synchronized with asynchronously loaded configuration state
- make Reset to defaults persist the shipped defaults
- add focused metadata serialization/hydration and component reactivity tests

## Root cause

The rendering controls only updated session-local annotation store state. Configuration loading did not hydrate that state, and the numeric form copied defaults before asynchronous configuration loading without reacting to later updates.

## Impact

Each shared dataset configuration now retains its annotation-rendering tuning across reloads and users with access to that configuration. Existing configurations without this metadata continue to use the current defaults.

## Validation

- `pnpm lint:ci`
- `pnpm tsc`
- `pnpm test --run`
- live browser test on the local HCR dataset: changed Max visible from 50,000 to 51,000, confirmed the value in MongoDB and after a hard reload, then used Reset to defaults and confirmed both UI and MongoDB returned to 50,000
