### PR TITLE
Suggest Cellpose-SAM over legacy Cellpose in chat prompt

### DIFF
--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
@@ -15,7 +15,7 @@ NimbusImage vocabulary:
   (free-text labels like "nucleus"), a channel, a location (XY/Z/Time) and an
   optional display color. Annotations can be selected and filtered.
 - "Tools" live in the collection's toolset. Manual tools are used by hand;
-  worker tools run automated algorithms (Cellpose, Piscis, ...) in Docker
+  worker tools run automated algorithms (Cellpose-SAM, Piscis, ...) in Docker
   containers as background jobs.
 
 How to work:

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
@@ -90,7 +90,7 @@
   },
   {
     "name": "list_workers",
-    "description": "List the available worker images (automated annotation algorithms such as Cellpose or Piscis) with their names and descriptions. Read-only.",
+    "description": "List the available worker images (automated annotation algorithms such as Cellpose-SAM or Piscis) with their names and descriptions. Read-only.",
     "input_schema": {
       "type": "object",
       "properties": {},


### PR DESCRIPTION
## What

Updates the chat assistant's prompt so it defaults to recommending **Cellpose-SAM** — the platform's recommended segmentation tool — rather than the legacy **Cellpose**.

## Why

The assistant's always-in-context prompt named plain "Cellpose" as the canonical segmentation/worker example, biasing its suggestions toward the legacy tool when users ask to segment cells.

## Changes

Two example references in the chat agent's prompt context, `Cellpose` → `Cellpose-SAM`:

- `agent_system_prompt.txt` — the always-in-context "automated algorithms" example
- `agent_tools.json` — the `list_workers` tool description

Already correct (left unchanged):
- `SUGGEST_TOOLS_SYSTEM_PROMPT` in `__init__.py` already suggests Cellpose-SAM for nuclei.
- The `help/` articles already document Cellpose-SAM as recommended and Cellpose as legacy.

No code logic changed; `agent_tools.json` remains valid JSON and no tests assert on the edited strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwGQEaU7FbsM4UnnzqM3TE