### PR TITLE
Add admin-only authenticated-users usage metric endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,11 @@ Plugin endpoints are registered in `__init__.py` (lines 159-173). Endpoint names
 | `/api/v1/annotation_import` | `server/api/dataImport.py` | Server-side JSON import (annotations, connections, property values) |
 | `/api/v1/project` | `server/api/project.py` | Project management |
 | `/api/v1/resource` | `server/api/resource.py` | Custom resource search |
+| `/api/v1/system/active_users` | `system.py` | Admin-only usage metric: count of distinct users who obtained an auth token within a look-back `window` (default `1d`). Added to Girder's core `system` route via `addSystemEndpoints`, not a plugin resource. |
 
 All source files under `devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/`. Swagger UI at `http://localhost:8080/api/v1#!/`.
+
+**Active-users metric — "active" definition:** a user counts as active in the window if the `token` collection holds a token whose `created` timestamp falls inside it, i.e. they authenticated (logged in / refreshed a session) during the window. The count is deduplicated per user (`$group` on `userId`). Because Girder deletes tokens once they expire (default ~180 days), counts for windows longer than the token lifetime are bounded by token retention.
 
 ### Image Rendering Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,11 +155,11 @@ Plugin endpoints are registered in `__init__.py` (lines 159-173). Endpoint names
 | `/api/v1/annotation_import` | `server/api/dataImport.py` | Server-side JSON import (annotations, connections, property values) |
 | `/api/v1/project` | `server/api/project.py` | Project management |
 | `/api/v1/resource` | `server/api/resource.py` | Custom resource search |
-| `/api/v1/system/active_users` | `system.py` | Admin-only usage metric: count of distinct users who obtained an auth token within a look-back `window` (default `1d`). Added to Girder's core `system` route via `addSystemEndpoints`, not a plugin resource. |
+| `/api/v1/system/authenticated_users` | `system.py` | Admin-only usage metric: count of distinct users who obtained an auth token within a look-back `window` (default `1d`). Added to Girder's core `system` route via `addSystemEndpoints`, not a plugin resource. |
 
 All source files under `devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/`. Swagger UI at `http://localhost:8080/api/v1#!/`.
 
-**Active-users metric — "active" definition:** a user counts as active in the window if the `token` collection holds a token whose `created` timestamp falls inside it, i.e. they authenticated (logged in / refreshed a session) during the window. The count is deduplicated per user (`$group` on `userId`). Because Girder deletes tokens once they expire (default ~180 days), counts for windows longer than the token lifetime are bounded by token retention.
+**Authenticated-users metric — what it measures:** a user is counted for the window if the `token` collection holds a token whose `created` timestamp falls inside it, i.e. they authenticated (logged in / refreshed a session) during the window. The count is deduplicated per user (`$group` on `userId`). It is deliberately **not** a general "used the app" metric: clients reuse a stored token across requests, so a user only mints a new token on a fresh login (or after their token expires) — someone using the app daily on a still-valid token won't reappear in a short window. Treat it as distinct authentications, not activity. Because Girder deletes tokens once they expire (default ~180 days), counts for windows longer than the token lifetime are bounded by token retention.
 
 ### Image Rendering Pipeline
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
@@ -26,9 +26,9 @@ logger = logging.getLogger(__name__)
 
 conversionJobs = {}
 
-# Look-back window units accepted by the active-users endpoint, expressed in
-# seconds.
-ACTIVE_USERS_WINDOW_UNITS = {
+# Look-back window units accepted by the authenticated-users endpoint,
+# expressed in seconds.
+WINDOW_UNITS = {
     "s": 1,
     "m": 60,
     "h": 3600,
@@ -40,7 +40,7 @@ ACTIVE_USERS_WINDOW_UNITS = {
 # (default ~180 days), so counts for windows longer than the token lifetime
 # are inherently limited by token retention; this cap keeps an unbounded
 # client-supplied value from scanning an arbitrarily large token range.
-MAX_ACTIVE_USERS_WINDOW_SECONDS = 366 * 86400
+MAX_WINDOW_SECONDS = 366 * 86400
 
 
 def addSystemEndpoints(apiRoot):
@@ -55,7 +55,9 @@ def addSystemEndpoints(apiRoot):
     # Added to the folder route
     apiRoot.folder.route("GET", ("query",), getFoldersByQuery)
     # Added to the system route (admin-only usage metrics)
-    apiRoot.system.route("GET", ("active_users",), getActiveUsers)
+    apiRoot.system.route(
+        "GET", ("authenticated_users",), getAuthenticatedUsers
+    )
 
     # Also bind some events
     events.bind(
@@ -112,25 +114,26 @@ def getFoldersByQuery(self, query, limit, offset, sort):
     )
 
 
-def _parseActiveUsersWindow(window):
+def _parseAuthenticatedUsersWindow(window):
     """
     Convert a window string (e.g. "1d", "24h", "7d") to a number of seconds.
 
-    :param window: an integer amount followed by a unit (s, m, h, d, w).
+    :param window: a normalized (stripped, lower-cased) window string: an
+        integer amount followed by a unit (s, m, h, d, w).
     :returns: the window length in seconds.
     :raises RestException: if the value is malformed or out of range.
     """
-    match = re.fullmatch(r"(\d+)([smhdw])", window.strip().lower())
+    match = re.fullmatch(r"(\d+)([smhdw])", window)
     if not match:
         raise RestException(
             "window must be a positive integer followed by one of "
             "s, m, h, d, w (e.g. '1d', '7d', '24h').",
             code=400,
         )
-    seconds = int(match.group(1)) * ACTIVE_USERS_WINDOW_UNITS[match.group(2)]
+    seconds = int(match.group(1)) * WINDOW_UNITS[match.group(2)]
     if seconds <= 0:
         raise RestException("window must be greater than zero.", code=400)
-    if seconds > MAX_ACTIVE_USERS_WINDOW_SECONDS:
+    if seconds > MAX_WINDOW_SECONDS:
         raise RestException(
             "window is too large; the maximum is 366d.", code=400
         )
@@ -139,12 +142,16 @@ def _parseActiveUsersWindow(window):
 
 @access.admin
 @autoDescribeRoute(
-    Description("Count distinct authenticated users active within a window.")
+    Description("Count distinct users who authenticated within a window.")
     .notes(
         "Returns the number of distinct users who obtained an authentication "
-        "token within the given look-back window. This counts users who "
-        "authenticated (logged in or refreshed a session) during the window, "
-        "deduplicated per user. Requires site administrator access.\n\n"
+        "token within the given look-back window, i.e. who authenticated "
+        "(logged in or refreshed a session) during the window, deduplicated "
+        "per user. Requires site administrator access.\n\n"
+        "This is NOT a count of users who merely used the app: clients reuse "
+        "a stored token across requests, so a user only produces a new token "
+        "when they log in afresh (or their token expires). Treat this as a "
+        "distinct-authentications metric, not a general activity metric.\n\n"
         "Because Girder deletes tokens once they expire (default ~180 days), "
         "counts for windows longer than the token lifetime are limited by "
         "token retention."
@@ -160,8 +167,11 @@ def _parseActiveUsersWindow(window):
     .errorResponse("The window parameter is invalid.", 400)
 )
 @boundHandler()
-def getActiveUsers(self, window):
-    windowSeconds = _parseActiveUsersWindow(window)
+def getAuthenticatedUsers(self, window):
+    # Normalize the client-supplied window once at the API boundary so the
+    # value echoed in the response matches the parsed windowSeconds.
+    window = window.strip().lower()
+    windowSeconds = _parseAuthenticatedUsersWindow(window)
     end = datetime.datetime.utcnow()
     start = end - datetime.timedelta(seconds=windowSeconds)
     # Aggregation is the one sanctioned use of collection directly; Girder's
@@ -177,7 +187,7 @@ def getActiveUsers(self, window):
         "windowSeconds": windowSeconds,
         "start": start,
         "end": end,
-        "activeUsers": aggregation[0]["count"] if aggregation else 0,
+        "authenticatedUsers": aggregation[0]["count"] if aggregation else 0,
     }
 
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/system.py
@@ -1,6 +1,8 @@
+import datetime
 import io
 import json
 import logging
+import re
 
 import large_image
 import yaml
@@ -13,6 +15,7 @@ from girder.exceptions import RestException
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
+from girder.models.token import Token
 from girder.models.upload import Upload
 from girder.models.user import User
 from girder_jobs.constants import JobStatus
@@ -22,6 +25,22 @@ from girder_large_image.models.image_item import ImageItem
 logger = logging.getLogger(__name__)
 
 conversionJobs = {}
+
+# Look-back window units accepted by the active-users endpoint, expressed in
+# seconds.
+ACTIVE_USERS_WINDOW_UNITS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+}
+
+# Upper bound on the look-back window. Girder deletes tokens once they expire
+# (default ~180 days), so counts for windows longer than the token lifetime
+# are inherently limited by token retention; this cap keeps an unbounded
+# client-supplied value from scanning an arbitrarily large token range.
+MAX_ACTIVE_USERS_WINDOW_SECONDS = 366 * 86400
 
 
 def addSystemEndpoints(apiRoot):
@@ -35,6 +54,8 @@ def addSystemEndpoints(apiRoot):
     apiRoot.item.route("PUT", (":itemId", "cache_maxmerge"), cacheMaxMerge)
     # Added to the folder route
     apiRoot.folder.route("GET", ("query",), getFoldersByQuery)
+    # Added to the system route (admin-only usage metrics)
+    apiRoot.system.route("GET", ("active_users",), getActiveUsers)
 
     # Also bind some events
     events.bind(
@@ -89,6 +110,75 @@ def getFoldersByQuery(self, query, limit, offset, sort):
     return Folder().findWithPermissions(
         query, offset=offset, limit=limit, sort=sort, user=user
     )
+
+
+def _parseActiveUsersWindow(window):
+    """
+    Convert a window string (e.g. "1d", "24h", "7d") to a number of seconds.
+
+    :param window: an integer amount followed by a unit (s, m, h, d, w).
+    :returns: the window length in seconds.
+    :raises RestException: if the value is malformed or out of range.
+    """
+    match = re.fullmatch(r"(\d+)([smhdw])", window.strip().lower())
+    if not match:
+        raise RestException(
+            "window must be a positive integer followed by one of "
+            "s, m, h, d, w (e.g. '1d', '7d', '24h').",
+            code=400,
+        )
+    seconds = int(match.group(1)) * ACTIVE_USERS_WINDOW_UNITS[match.group(2)]
+    if seconds <= 0:
+        raise RestException("window must be greater than zero.", code=400)
+    if seconds > MAX_ACTIVE_USERS_WINDOW_SECONDS:
+        raise RestException(
+            "window is too large; the maximum is 366d.", code=400
+        )
+    return seconds
+
+
+@access.admin
+@autoDescribeRoute(
+    Description("Count distinct authenticated users active within a window.")
+    .notes(
+        "Returns the number of distinct users who obtained an authentication "
+        "token within the given look-back window. This counts users who "
+        "authenticated (logged in or refreshed a session) during the window, "
+        "deduplicated per user. Requires site administrator access.\n\n"
+        "Because Girder deletes tokens once they expire (default ~180 days), "
+        "counts for windows longer than the token lifetime are limited by "
+        "token retention."
+    )
+    .param(
+        "window",
+        "Length of the look-back window: a positive integer followed by a "
+        "unit (s, m, h, d, w). Defaults to 1d.",
+        required=False,
+        default="1d",
+    )
+    .errorResponse("You are not a site administrator.", 403)
+    .errorResponse("The window parameter is invalid.", 400)
+)
+@boundHandler()
+def getActiveUsers(self, window):
+    windowSeconds = _parseActiveUsersWindow(window)
+    end = datetime.datetime.utcnow()
+    start = end - datetime.timedelta(seconds=windowSeconds)
+    # Aggregation is the one sanctioned use of collection directly; Girder's
+    # find() does not support aggregation pipelines. Grouping on userId
+    # deduplicates so the result is a distinct-user count, not a token count.
+    aggregation = list(Token().collection.aggregate([
+        {"$match": {"created": {"$gte": start}, "userId": {"$ne": None}}},
+        {"$group": {"_id": "$userId"}},
+        {"$count": "count"},
+    ]))
+    return {
+        "window": window,
+        "windowSeconds": windowSeconds,
+        "start": start,
+        "end": end,
+        "activeUsers": aggregation[0]["count"] if aggregation else 0,
+    }
 
 
 @access.user

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_active_users.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_active_users.py
@@ -1,0 +1,86 @@
+"""
+Tests for the admin-only active-users usage metric
+(GET /api/v1/system/active_users).
+"""
+import datetime
+
+import pytest
+from pytest_girder.assertions import assertStatus, assertStatusOk
+
+from girder.models.token import Token
+
+
+def ageToken(token, days):
+    """Backdate a token's ``created`` timestamp by ``days`` days."""
+    token["created"] = datetime.datetime.utcnow() - datetime.timedelta(
+        days=days
+    )
+    return Token().save(token)
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestActiveUsers:
+    def testCountsDistinctUsersDeduplicated(self, admin, user, server):
+        # Two tokens for the same user must count once.
+        Token().createToken(user=user)
+        Token().createToken(user=user)
+        Token().createToken(user=admin)
+
+        resp = server.request(
+            path="/system/active_users", method="GET", user=admin,
+            params={"window": "1d"},
+        )
+        assertStatusOk(resp)
+        # Distinct users active in the last day: admin and user. The request
+        # itself is authenticated with an admin token, which is also within
+        # the window.
+        assert resp.json["activeUsers"] == 2
+        assert resp.json["window"] == "1d"
+        assert resp.json["windowSeconds"] == 86400
+
+    def testExcludesTokensOutsideWindow(self, admin, user, server):
+        # A stale token for ``user`` should fall outside a 1d window, leaving
+        # only the admin token created to serve the request.
+        ageToken(Token().createToken(user=user), days=10)
+
+        resp = server.request(
+            path="/system/active_users", method="GET", user=admin,
+            params={"window": "1d"},
+        )
+        assertStatusOk(resp)
+        assert resp.json["activeUsers"] == 1
+
+        # Widening the window past the stale token includes ``user`` again.
+        resp = server.request(
+            path="/system/active_users", method="GET", user=admin,
+            params={"window": "30d"},
+        )
+        assertStatusOk(resp)
+        assert resp.json["activeUsers"] == 2
+
+    def testDefaultsToOneDay(self, admin, server):
+        resp = server.request(
+            path="/system/active_users", method="GET", user=admin,
+        )
+        assertStatusOk(resp)
+        assert resp.json["window"] == "1d"
+        assert resp.json["windowSeconds"] == 86400
+
+    def testRequiresAdmin(self, user, server):
+        resp = server.request(
+            path="/system/active_users", method="GET", user=user,
+        )
+        assertStatus(resp, 403)
+
+    def testRequiresAuthentication(self, server):
+        resp = server.request(path="/system/active_users", method="GET")
+        assertStatus(resp, 401)
+
+    @pytest.mark.parametrize("window", ["abc", "0d", "-1d", "5x", "9999d"])
+    def testRejectsInvalidWindow(self, admin, server, window):
+        resp = server.request(
+            path="/system/active_users", method="GET", user=admin,
+            params={"window": window},
+        )
+        assertStatus(resp, 400)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_authenticated_users.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_authenticated_users.py
@@ -1,6 +1,6 @@
 """
-Tests for the admin-only active-users usage metric
-(GET /api/v1/system/active_users).
+Tests for the admin-only authenticated-users usage metric
+(GET /api/v1/system/authenticated_users).
 """
 import datetime
 
@@ -20,7 +20,7 @@ def ageToken(token, days):
 
 @pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
 @pytest.mark.plugin("upenncontrast_annotation")
-class TestActiveUsers:
+class TestAuthenticatedUsers:
     def testCountsDistinctUsersDeduplicated(self, admin, user, server):
         # Two tokens for the same user must count once.
         Token().createToken(user=user)
@@ -28,14 +28,14 @@ class TestActiveUsers:
         Token().createToken(user=admin)
 
         resp = server.request(
-            path="/system/active_users", method="GET", user=admin,
+            path="/system/authenticated_users", method="GET", user=admin,
             params={"window": "1d"},
         )
         assertStatusOk(resp)
-        # Distinct users active in the last day: admin and user. The request
-        # itself is authenticated with an admin token, which is also within
-        # the window.
-        assert resp.json["activeUsers"] == 2
+        # Distinct users who authenticated in the last day: admin and user.
+        # The request itself is authenticated with an admin token, which is
+        # also within the window.
+        assert resp.json["authenticatedUsers"] == 2
         assert resp.json["window"] == "1d"
         assert resp.json["windowSeconds"] == 86400
 
@@ -45,42 +45,53 @@ class TestActiveUsers:
         ageToken(Token().createToken(user=user), days=10)
 
         resp = server.request(
-            path="/system/active_users", method="GET", user=admin,
+            path="/system/authenticated_users", method="GET", user=admin,
             params={"window": "1d"},
         )
         assertStatusOk(resp)
-        assert resp.json["activeUsers"] == 1
+        assert resp.json["authenticatedUsers"] == 1
 
         # Widening the window past the stale token includes ``user`` again.
         resp = server.request(
-            path="/system/active_users", method="GET", user=admin,
+            path="/system/authenticated_users", method="GET", user=admin,
             params={"window": "30d"},
         )
         assertStatusOk(resp)
-        assert resp.json["activeUsers"] == 2
+        assert resp.json["authenticatedUsers"] == 2
 
     def testDefaultsToOneDay(self, admin, server):
         resp = server.request(
-            path="/system/active_users", method="GET", user=admin,
+            path="/system/authenticated_users", method="GET", user=admin,
         )
         assertStatusOk(resp)
         assert resp.json["window"] == "1d"
         assert resp.json["windowSeconds"] == 86400
 
+    def testNormalizesEchoedWindow(self, admin, server):
+        # Whitespace/case in the client input is normalized once at the API
+        # boundary, so the echoed "window" matches the parsed windowSeconds.
+        resp = server.request(
+            path="/system/authenticated_users", method="GET", user=admin,
+            params={"window": "  2D "},
+        )
+        assertStatusOk(resp)
+        assert resp.json["window"] == "2d"
+        assert resp.json["windowSeconds"] == 2 * 86400
+
     def testRequiresAdmin(self, user, server):
         resp = server.request(
-            path="/system/active_users", method="GET", user=user,
+            path="/system/authenticated_users", method="GET", user=user,
         )
         assertStatus(resp, 403)
 
     def testRequiresAuthentication(self, server):
-        resp = server.request(path="/system/active_users", method="GET")
+        resp = server.request(path="/system/authenticated_users", method="GET")
         assertStatus(resp, 401)
 
     @pytest.mark.parametrize("window", ["abc", "0d", "-1d", "5x", "9999d"])
     def testRejectsInvalidWindow(self, admin, server, window):
         resp = server.request(
-            path="/system/active_users", method="GET", user=admin,
+            path="/system/authenticated_users", method="GET", user=admin,
             params={"window": window},
         )
         assertStatus(resp, 400)


### PR DESCRIPTION
Related to #1258 (does not fully resolve it — see "Scope & what this does not do" below).

## Summary

Exposes a lightweight usage metric so a site admin can answer "how many distinct users authenticated in the last N?" **without SSH or direct database access**.

Adds `GET /api/v1/system/authenticated_users?window=1d`, registered on Girder's core `system` route via `addSystemEndpoints` in `system.py` (alongside the existing `item/query` and `folder/query` additions). It counts **distinct** users who obtained an authentication token within the look-back window, by grouping on `userId` over the `token` collection.

## What this measures

A user is counted for the window if the `token` collection holds a token whose `created` timestamp falls inside it — i.e. they authenticated (logged in / refreshed a session) during the window. Girder persists tokens with `userId` + `created`, so a distinct-count aggregation is cheap and accurate. The count is deduplicated per user (`$group` on `userId`), so it is a user count, not a request or token count.

Because Girder deletes tokens once they expire (default ~180 days), counts for windows longer than the token lifetime are bounded by token retention. This is documented on the endpoint (`.notes()`) and in `CLAUDE.md`.

## Scope & what this does *not* do

The endpoint was originally named `active_users` / `activeUsers`, which overclaimed. It has been renamed to **`authenticated_users` / `authenticatedUsers`** to describe exactly what it measures.

It is **not** a general "used the app" activity metric. The frontend persists the auth token in `localStorage` and reuses it across reloads, minting a new token only on a **fresh login** (or after the token expires). So a user who logged in three weeks ago and uses the app every day generates no new token and will **not** appear in a short window. Read this as **distinct authentications in the window**, not daily-active usage.

Because of that gap, this PR is intentionally **not** marked as closing #1258 — a fuller "active = used the app" definition (e.g. a `lastSeen` touched on request/job activity) remains open there as a follow-up.

## Details

- `@access.admin` — gated to site administrators (anonymous → 401, non-admin → 403).
- `window` accepts an integer + unit (`s`/`m`/`h`/`d`/`w`), defaults to `1d`, and is capped at `366d` to bound the scanned token range. It is normalized once at the API boundary (strip/lower) so the echoed `window` matches the parsed `windowSeconds`. Malformed values return a clean `400`.
- Uses `collection.aggregate` — the sanctioned exception to the "no raw PyMongo" rule, since Girder's `find()` doesn't support aggregation pipelines.
- Response: `{ window, windowSeconds, start, end, authenticatedUsers }`.

## Acceptance criteria

- [x] An admin can retrieve the count of distinct authenticated users in a window without SSH / DB access.
- [x] The count is deduplicated per user (not request or IP counts).
- [x] The endpoint name and its definition/limitations are documented (Swagger `.notes()` + `CLAUDE.md`).

## Testing

Verified against the merged-up-to-date branch with the plugin rebuilt into the running Girder container:

- **Backend pytest** (`tox`): `test/test_authenticated_users.py` — **11 passing**. Covers distinct-user dedup, window boundary inclusion/exclusion, the `1d` default, normalized-echo of whitespace/case in `window`, admin gating (403), unauthenticated rejection (401), and invalid-window rejection (400).
- **Live HTTP** against `http://localhost:8080`: all window units (`s`/`m`/`h`/`d`/`w`), default window, access control (403 non-admin, 401 anonymous/bogus token), and the full invalid-window matrix (`abc`, `0d`, `-1d`, `5x`, `9999d`, `367d`, …) → all correct.
- **Correctness cross-check**: endpoint count matched an independent MongoDB aggregation over the `token` collection; anonymous (`userId: null`) tokens correctly excluded.
- **Dedup / window boundary** proven with controlled data: 5 tokens for one new user raised the distinct count by exactly 1; backdating those tokens to 100 days ago dropped the user out of a 90d window and back in at 200d.
- `flake8` clean on the changed backend files.

## Follow-ups (out of scope)

- A stricter `lastSeen`-based definition (touch on request/job activity) so users on a still-valid token are counted — this is what would let the endpoint answer #1258's "active users" intent in full.
- An admin-dashboard panel surfacing this metric.
- A daily distinct-user time series for trend visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N92Zx6tbPbCFczVMQJEmXR
