### PR TITLE
Backend: property compute access check, bulk-create validation, orphan cleanup (#1241, #1242, #1243)

### DIFF
--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -17,6 +17,7 @@ from ..helpers.validation import (
     MAX_LIST_LIMIT,
     dropNoOpPropertyFilters,
     requireInt,
+    requireList,
     requireObjectBody,
     requireObjectId,
     validateAnnotationIdCount,
@@ -160,8 +161,16 @@ class Annotation(Resource):
         "Create multiple annotations", getDatasetIdFromAnnotationListInBody
     )
     def createMultiple(self, params, *args, **kwargs):
-        bodyJson = kwargs["memoizedBodyJson"]
-        annotations = self._annotationModel.convertIdsToObjectIds(bodyJson)
+        # Validate the body shape at the API boundary (400, not 500): a
+        # non-list body or a non-dict entry would otherwise trip an uncaught
+        # AttributeError/TypeError in convertIdsToObjectIds.
+        bodyJson = requireList(kwargs["memoizedBodyJson"], "Request body")
+        for entry in bodyJson:
+            requireObjectBody(entry, "Each annotation")
+        try:
+            annotations = self._annotationModel.convertIdsToObjectIds(bodyJson)
+        except InvalidId:
+            raise RestException("Invalid id in annotation", code=400)
         datasetIds = {
             ann["datasetId"] for ann in annotations
             if "datasetId" in ann

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -480,6 +480,10 @@ class Annotation(Resource):
             raise RestException(
                 code=400, message="Missing datasetId parameter"
             )
+        # Validate the id shape here so a malformed datasetId is a clean 400,
+        # not a 500 from bson deep inside Folder().load. Keep the original
+        # string: runJobRequest passes datasetId to the worker as a string.
+        requireObjectId(datasetId, "datasetId")
         return self._annotationModel.compute(
             datasetId, self.getBodyJson(), self.getCurrentUser()
         )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/connections.py
@@ -7,9 +7,11 @@ from girder.models.folder import Folder
 
 from ..helpers.access_helpers import requireDatasetsAccess
 from ..helpers.proxiedModel import recordable, memoizeBodyJson
+from ..helpers.validation import requireList, requireObjectBody
 from ..models.annotation import Annotation as AnnotationModel
 from ..models.connections import AnnotationConnection as ConnectionModel
 
+from bson.errors import InvalidId
 from bson.objectid import ObjectId
 
 
@@ -27,7 +29,15 @@ def getDatasetIdFromConnectionListInBody(
     self: "AnnotationConnection", *args, **kwargs
 ):
     connections = kwargs["memoizedBodyJson"]
-    return None if len(connections) <= 0 else connections[0]["datasetId"]
+    # Defensive: this runs (in the @recordable wrapper) before the handler's
+    # input validation, so a malformed body must not raise here -- return None
+    # so recording is skipped and the handler produces the clean 400.
+    if not isinstance(connections, list) or len(connections) <= 0:
+        return None
+    first = connections[0]
+    if not isinstance(first, dict):
+        return None
+    return first.get("datasetId")
 
 
 def getDatasetIdFromLoadedConnection(
@@ -122,8 +132,16 @@ class AnnotationConnection(Resource):
         "Create multiple connections", getDatasetIdFromConnectionListInBody
     )
     def multipleCreate(self, params, *args, **kwargs):
-        bodyJson = kwargs["memoizedBodyJson"]
-        connections = self._connectionModel.convertIdsToObjectIds(bodyJson)
+        # Validate the body shape at the API boundary (400, not 500): a
+        # non-list body or a non-dict entry would otherwise trip an uncaught
+        # AttributeError/TypeError in convertIdsToObjectIds.
+        bodyJson = requireList(kwargs["memoizedBodyJson"], "Request body")
+        for entry in bodyJson:
+            requireObjectBody(entry, "Each connection")
+        try:
+            connections = self._connectionModel.convertIdsToObjectIds(bodyJson)
+        except InvalidId:
+            raise RestException("Invalid id in connection", code=400)
         datasetIds = {
             conn["datasetId"] for conn in connections
             if "datasetId" in conn

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
@@ -61,9 +61,12 @@ class AnnotationProperty(Resource):
     )
     def compute(self, annotation_property, params):
         datasetId = params.get("datasetId", None)
-        if datasetId and id:
+        if datasetId:
             return self._propertyModel.compute(
-                annotation_property, datasetId, self.getBodyJson()
+                annotation_property,
+                datasetId,
+                self.getBodyJson(),
+                self.getCurrentUser(),
             )
         return {}
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
@@ -4,6 +4,7 @@ from girder.constants import AccessType, TokenScope
 from girder.api.rest import Resource, loadmodel
 from ..models.property import AnnotationProperty as PropertyModel
 from ..models.collection import Collection as CollectionModel
+from ..helpers.validation import requireObjectId
 from girder.exceptions import RestException, AccessException
 from bson import ObjectId
 from bson.errors import InvalidId
@@ -62,6 +63,11 @@ class AnnotationProperty(Resource):
     def compute(self, annotation_property, params):
         datasetId = params.get("datasetId", None)
         if datasetId:
+            # Validate the id shape at the API boundary so a malformed
+            # datasetId is a clean 400, not a 500 from bson deep inside
+            # Folder().load. Keep the original string: runJobRequest passes
+            # datasetId to the worker as a string container arg.
+            requireObjectId(datasetId, "datasetId")
             return self._propertyModel.compute(
                 annotation_property,
                 datasetId,

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/propertyValues.py
@@ -1,4 +1,5 @@
 from bson import ObjectId
+from bson.errors import InvalidId
 
 from girder.api import access
 from girder.api.describe import Description, describeRoute
@@ -82,8 +83,19 @@ class PropertyValues(Resource):
         )
     )
     def addMultiple(self, params):
-        propertyValuesList = self._annotationPropertyValuesModel.\
-            convertIdsToObjectIds(self.getBodyJson())
+        # Validate the body shape at the API boundary (400, not 500): a
+        # non-list body or a non-dict entry would otherwise trip an uncaught
+        # AttributeError/TypeError in convertIdsToObjectIds.
+        bodyJson = requireList(self.getBodyJson(), "Request body")
+        for entry in bodyJson:
+            requireObjectBody(entry, "Each property value entry")
+        try:
+            propertyValuesList = self._annotationPropertyValuesModel.\
+                convertIdsToObjectIds(bodyJson)
+        except InvalidId:
+            raise RestException(
+                "Invalid id in property value entry", code=400
+            )
         datasetIds = {
             entry["datasetId"]
             for entry in propertyValuesList

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/connections.py
@@ -62,36 +62,21 @@ class AnnotationConnection(AccessControlMixin, ProxiedModel):
     )
 
     def annotationsRemovedEvent(self, event):
-        # Clean connections orphaned by the deletion of the annotations
-        annotationStringIds = event.info
-        pipeline = [
-            # Select the first annotation from the array
-            {"$match": {"_id": annotationStringIds[0]}},
-            # Bring up all connections who share the same datasetId
-            {"$lookup":
-                {
-                    "from": "annotation_connection",
-                    "localField": "datasetId",
-                    "foreignField": "datasetId",
-                    "as": "datasetConnections"
-                }},
-            # Replace root with connections (remove unnecessary annotation
-            # information)
-            {"$unwind": "$datasetConnections"},
-            {"$replaceRoot": {"newRoot": "$datasetConnections"}},
-            # Only match connections whose childId or parentId match one of
-            # the annotations to remove
-            {"$match": {"$or": [
-                {"childId": {"$in": annotationStringIds}},
-                {"parentId": {"$in": annotationStringIds}}
-            ]}},
-            # Only keep the necessary information
-            {"$project": {"_id": 1}}
-        ]
-        connectionsToRemove = [
-            connection["_id"]
-            for connection in Annotation().collection.aggregate(pipeline)]
-        self.removeWithQuery({"_id": {"$in": connectionsToRemove}})
+        # Clean connections orphaned by the deletion of the annotations.
+        # Ids arrive as strings from bulk deletes and as ObjectIds from single
+        # deletes; childId/parentId are stored as ObjectIds, so normalize
+        # before the $in query (a string $in never matches an ObjectId field,
+        # which previously left bulk-deleted annotations' connections
+        # orphaned). A connection references only annotations, so any
+        # connection whose child or parent is being removed is orphaned and
+        # is removed directly via the childId/parentId indices.
+        annotationIds = [ObjectId(str(i)) for i in event.info]
+        if not annotationIds:
+            return
+        self.removeWithQuery({"$or": [
+            {"childId": {"$in": annotationIds}},
+            {"parentId": {"$in": annotationIds}},
+        ]})
 
     def folderRemovedEvent(self, event):
         if event.info and event.info["_id"]:

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/property.py
@@ -1,6 +1,7 @@
 from ..helpers.proxiedModel import ProxiedModel
-from girder.exceptions import ValidationException, RestException
+from girder.exceptions import ValidationException
 from girder.constants import AccessType
+from girder.models.folder import Folder
 from ..helpers.tasks import runJobRequest
 
 from ..helpers.fastjsonschema import customJsonSchemaCompile
@@ -65,11 +66,14 @@ class AnnotationProperty(ProxiedModel):
     def getPropertyById(self, id, user=None):
         return self.load(id, user=user)
 
-    def compute(self, property, datasetId, params):
+    def compute(self, property, datasetId, params, user=None):
+        # Mirror the annotation compute path: require WRITE on the dataset
+        # before scheduling a worker, so a caller can't spawn a (doomed) job
+        # against a dataset they lack access to. exc=True -> 403/404 here.
+        Folder().load(
+            datasetId, user=user, level=AccessType.WRITE, exc=True
+        )
         image = property.get("image", None)
         if not image:
-            raise RestException(code=500, message="Invalid property: no image")
-
-        if property:
-            return runJobRequest(image, datasetId, params, "compute")
-        return {}
+            raise ValidationException("Invalid property: no image")
+        return runJobRequest(image, datasetId, params, "compute")

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_annotations.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_annotations.py
@@ -645,3 +645,21 @@ class TestCreateMultipleValidation:
         sample = upenn_utilities.getSampleAnnotation("not-a-valid-object-id")
         resp = self._post(server, admin, [sample])
         assertStatus(resp, 400)
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestComputeValidation:
+    """POST /upenn_annotation/compute must reject a malformed datasetId with
+    400, not a 500 from bson deep inside Folder().load."""
+
+    def testMalformedDatasetIdReturns400(self, admin, server):
+        resp = server.request(
+            path="/upenn_annotation/compute",
+            method="POST",
+            user=admin,
+            params={"datasetId": "not-a-valid-object-id"},
+            body=json.dumps({"image": "worker:latest"}),
+            type="application/json",
+        )
+        assertStatus(resp, 400)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_annotations.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_annotations.py
@@ -612,3 +612,36 @@ class TestFindDefaultSort:
 
         returnedIds = [doc["_id"] for doc in resp.json]
         assert returnedIds == [str(i) for i in idsAscending]
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestCreateMultipleValidation:
+    """POST /upenn_annotation/multiple must reject malformed input with 400.
+
+    Regression for issue #1242: the bulk-create endpoint validated its body
+    far less than the bulk-update endpoint, so a non-list body, a non-dict
+    entry, or a malformed id raised a 500 instead of a clean 400.
+    """
+
+    def _post(self, server, user, body):
+        return server.request(
+            path="/upenn_annotation/multiple",
+            method="POST",
+            user=user,
+            body=json.dumps(body),
+            type="application/json",
+        )
+
+    def testNonListBodyReturns400(self, admin, server):
+        resp = self._post(server, admin, {"not": "a list"})
+        assertStatus(resp, 400)
+
+    def testNonDictEntryReturns400(self, admin, server):
+        resp = self._post(server, admin, [123])
+        assertStatus(resp, 400)
+
+    def testInvalidDatasetIdReturns400(self, admin, server):
+        sample = upenn_utilities.getSampleAnnotation("not-a-valid-object-id")
+        resp = self._post(server, admin, [sample])
+        assertStatus(resp, 400)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_connections.py
@@ -2,11 +2,14 @@ import json
 import pytest
 import math
 
-from pytest_girder.assertions import assertStatusOk
+from pytest_girder.assertions import assertStatus, assertStatusOk
 
 from upenncontrast_annotation.server.models.annotation import Annotation
 from upenncontrast_annotation.server.models.connections import (
     AnnotationConnection,
+)
+from upenncontrast_annotation.server.models.propertyValues import (
+    AnnotationPropertyValues,
 )
 from upenncontrast_annotation.server.models import connections
 from upenncontrast_annotation.server.helpers.connections import (
@@ -636,3 +639,112 @@ class TestConnectionEndpoints:
         )
         assertStatusOk(resp)
         assert len(resp.json) == 3
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestMultipleCreateValidation:
+    """POST /annotation_connection/multiple must reject malformed input.
+
+    Regression for issue #1242: the bulk-create endpoint didn't validate its
+    body shape, so a non-list body or a non-dict entry raised 500 not 400.
+    """
+
+    def _post(self, server, user, body):
+        return server.request(
+            path="/annotation_connection/multiple",
+            method="POST",
+            user=user,
+            body=json.dumps(body),
+            type="application/json",
+        )
+
+    def testNonListBodyReturns400(self, admin, server):
+        resp = self._post(server, admin, {"not": "a list"})
+        assertStatus(resp, 400)
+
+    def testNonDictEntryReturns400(self, admin, server):
+        resp = self._post(server, admin, [123])
+        assertStatus(resp, 400)
+
+    def testInvalidIdReturns400(self, admin, server):
+        (parent, child, dataset) = createTwoAnnotations(admin)
+        connection = upenn_utilities.getSampleConnection(
+            str(parent["_id"]), str(child["_id"]), "not-a-valid-object-id"
+        )
+        resp = self._post(server, admin, [connection])
+        assertStatus(resp, 400)
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestBulkDeleteCleanup:
+    """Bulk-deleting annotations must clean up their dependent documents.
+
+    Regression for issue #1243: the bulk-delete path emits string ids into
+    the removeStringIds event, but property values (annotationId) and
+    connections (childId/parentId) are stored as ObjectIds. A string $in
+    never matches an ObjectId field, so bulk-deleted annotations left both
+    their property values AND their connections orphaned. (Single delete
+    passed an ObjectId and worked, hence the single-vs-bulk asymmetry.)
+    """
+
+    def _makeDataset(self, admin):
+        return utilities.createFolder(
+            admin, "cleanup-ds", upenn_utilities.datasetMetadata
+        )
+
+    def testBulkDeleteRemovesPropertyValues(self, admin):
+        dataset = self._makeDataset(admin)
+        annotations = [
+            Annotation().create(
+                upenn_utilities.getSampleAnnotation(dataset["_id"])
+            )
+            for _ in range(3)
+        ]
+        for annotation in annotations:
+            AnnotationPropertyValues().appendValues(
+                {"propA": 1.0}, annotation["_id"], dataset["_id"]
+            )
+        annotationIds = [a["_id"] for a in annotations]
+        assert len(list(AnnotationPropertyValues().find(
+            {"annotationId": {"$in": annotationIds}}
+        ))) == 3
+
+        # Bulk delete via the string-id path (what the REST endpoint uses).
+        Annotation().deleteMultiple([str(i) for i in annotationIds])
+
+        assert len(list(AnnotationPropertyValues().find(
+            {"annotationId": {"$in": annotationIds}}
+        ))) == 0
+
+    def testBulkDeleteRemovesConnections(self, admin):
+        dataset = self._makeDataset(admin)
+        annotations = [
+            Annotation().create(
+                upenn_utilities.getSampleAnnotation(dataset["_id"])
+            )
+            for _ in range(3)
+        ]
+        annotationIds = [a["_id"] for a in annotations]
+        # A chain of connections referencing the annotations.
+        AnnotationConnection().create(
+            upenn_utilities.getSampleConnection(
+                annotationIds[0], annotationIds[1], dataset["_id"]
+            )
+        )
+        AnnotationConnection().create(
+            upenn_utilities.getSampleConnection(
+                annotationIds[1], annotationIds[2], dataset["_id"]
+            )
+        )
+        assert len(list(AnnotationConnection().find(
+            {"datasetId": dataset["_id"]}
+        ))) == 2
+
+        # Bulk delete via the string-id path (what the REST endpoint uses).
+        Annotation().deleteMultiple([str(i) for i in annotationIds])
+
+        assert len(list(AnnotationConnection().find(
+            {"datasetId": dataset["_id"]}
+        ))) == 0

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_properties.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_properties.py
@@ -2,13 +2,17 @@ import json
 
 import pytest
 
-from pytest_girder.assertions import assertStatusOk
+from pytest_girder.assertions import assertStatus, assertStatusOk
 
 from upenncontrast_annotation.server.models.property import (
     AnnotationProperty,
 )
 
 from girder.constants import AccessType
+from girder.models.folder import Folder
+
+from . import girder_utilities as utilities
+from . import upenn_testing_utilities as upenn_utilities
 
 
 @pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
@@ -59,3 +63,54 @@ class TestPropertyEndpoints:
         assert "_malicious" not in loaded
         assert "accessLevel" not in loaded
         assert "unknownField" not in loaded
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestPropertyComputeAccess:
+    """Access-control tests for POST /annotation_property/:id/compute.
+
+    Regression for issue #1241: the compute endpoint spawned a worker job
+    against a caller-supplied datasetId without checking the caller had
+    WRITE access to that dataset (unlike the annotation compute path, which
+    is gated). A user with only READ on the dataset must be refused before a
+    worker is ever scheduled.
+    """
+
+    def _createProperty(self, owner):
+        prop = {
+            "name": "compute-prop",
+            "image": "test-image:latest",
+            "shape": "point",
+            "tags": {"tags": [], "exclusive": False},
+            "workerInterface": {},
+        }
+        model = AnnotationProperty()
+        model.setUserAccess(
+            prop, user=owner, level=AccessType.ADMIN, save=False
+        )
+        return model.save(prop)
+
+    def testReadOnlyDatasetAccessIsRefused(self, admin, user, server):
+        """A user with only READ on the dataset gets 403 (never reaches the
+        worker), because the dataset is loaded at WRITE first."""
+        dataset = utilities.createFolder(
+            admin, "compute-ds", upenn_utilities.datasetMetadata
+        )
+        # Share the dataset with `user` at READ only.
+        Folder().setUserAccess(
+            dataset, user=user, level=AccessType.READ, save=True
+        )
+        # `user` owns the property, so @loadmodel (READ on the property)
+        # passes and the dataset WRITE check is what must reject the request.
+        prop = self._createProperty(user)
+
+        resp = server.request(
+            path="/annotation_property/%s/compute" % prop["_id"],
+            method="POST",
+            user=user,
+            params={"datasetId": str(dataset["_id"])},
+            body=json.dumps({}),
+            type="application/json",
+        )
+        assertStatus(resp, 403)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_properties.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_properties.py
@@ -114,3 +114,17 @@ class TestPropertyComputeAccess:
             type="application/json",
         )
         assertStatus(resp, 403)
+
+    def testMalformedDatasetIdReturns400(self, admin, server):
+        """A malformed datasetId is a clean 400, not a 500 from bson deep in
+        Folder().load."""
+        prop = self._createProperty(admin)
+        resp = server.request(
+            path="/annotation_property/%s/compute" % prop["_id"],
+            method="POST",
+            user=admin,
+            params={"datasetId": "not-a-valid-object-id"},
+            body=json.dumps({}),
+            type="application/json",
+        )
+        assertStatus(resp, 400)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_property_values_batch.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_property_values_batch.py
@@ -310,3 +310,39 @@ class TestFindByAnnotationIds:
         assert len(docs) == 1
         assert "_id" not in docs[0]
         assert "datasetId" not in docs[0]
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestAddMultipleValidation:
+    """POST /annotation_property_values/multiple must reject malformed input.
+
+    Regression for issue #1242: the bulk-add endpoint didn't validate its
+    body shape, so a non-list body or a non-dict entry raised 500 not 400.
+    """
+
+    def _post(self, server, user, body):
+        return server.request(
+            path="/annotation_property_values/multiple",
+            method="POST",
+            user=user,
+            body=json.dumps(body),
+            type="application/json",
+        )
+
+    def testNonListBodyReturns400(self, admin, server):
+        resp = self._post(server, admin, {"not": "a list"})
+        assertStatus(resp, 400)
+
+    def testNonDictEntryReturns400(self, admin, server):
+        resp = self._post(server, admin, [123])
+        assertStatus(resp, 400)
+
+    def testInvalidDatasetIdReturns400(self, admin, server):
+        entry = {
+            "datasetId": "not-a-valid-object-id",
+            "annotationId": "012345678901234567890123",
+            "values": {"propA": 1},
+        }
+        resp = self._post(server, admin, [entry])
+        assertStatus(resp, 400)


### PR DESCRIPTION
Fixes #1241, #1242, #1243. Backend-only (AnnotationPlugin). The frontend fix for #1239 was split into its own PR (#1262). Note: the branch name still contains `1239` for historical reasons, but this PR no longer includes that work.

Built TDD — each fix ships with tests. `flake8` is clean. Backend `tox` was **not** run in this environment — please run it locally.

## #1241 — property compute didn't check dataset access
`POST /annotation_property/{id}/compute` spawned a worker for a caller-supplied `datasetId` without checking access, unlike the annotation compute path.
- Thread the current user from the API handler into `PropertyModel.compute`.
- Load the dataset at `AccessType.WRITE` (`exc=True`) before `runJobRequest`, mirroring `AnnotationModel.compute`.
- Missing-image error changed from `RestException(500)` to `ValidationException` (API/model layer separation).
- Removed the dead `if datasetId and id` guard (the builtin `id` is always truthy) and the redundant `if property` check.
- Test: a READ-only user gets 403 before any worker is scheduled.

## #1242 — bulk-create endpoints returned 500 on malformed input
`createMultiple` (annotation), `multipleCreate` (connections), and `addMultiple` (propertyValues) validated far less than the sibling `updateMultiple`.
- Added API-boundary guards via the shared `server/helpers/validation.py` helpers (`requireList`, `requireObjectBody`); catch `bson.InvalidId` from id conversion → `RestException(400)`.
- Made the connection `@recordable` finder defensive so a malformed body can't 500 inside the decorator before the handler validates.
- Tests: per-endpoint assertions that a non-list body, a non-dict entry, and a malformed id each return 400.

## #1243 — orphaned connections after bulk annotation delete
Bulk delete emits string ids into `removeStringIds`, but connections store `childId`/`parentId` as ObjectIds, so a string `$in` matched nothing (single delete passed an ObjectId and worked — the reported single-vs-bulk asymmetry). Property-value cleanup already normalized ids; this brings connections in line.
- `connections.annotationsRemovedEvent`: normalize event ids to `ObjectId` and remove via a direct `childId`/`parentId` `$in` `removeWithQuery` (index-backed; no longer depends on the first annotation still existing).
- Regression tests: bulk-delete annotations and assert both their property values and connections are removed.

## Also — compute `datasetId` validation (review Finding #1, now fixed)
Both compute endpoints passed a caller-supplied `datasetId` straight to `Folder().load`, so a malformed id was a 500. Validate the id shape at the API boundary (`requireObjectId`) → 400, while keeping the original **string** for `runJobRequest` (the worker takes `datasetId` as a string container arg, so converting to ObjectId would break the job). Applied to both `property.py::compute` and `annotation.py::compute`; tests assert 400 on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)