### PR TITLE
AI panel: surface failed configuration saves instead of reporting success (#1239)

### DIFF
--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -1011,9 +1011,35 @@ describe("update_layer contrast scope", () => {
     expect(mockMain.saveContrastInConfiguration).toHaveBeenCalledWith({
       layerId: "l1",
       contrast,
+      delta: {},
       throwOnError: true,
     });
     expect(mockMain.saveContrastInView).not.toHaveBeenCalled();
+  });
+
+  it("writes layer fields and a collection-scoped contrast in one call", async () => {
+    // Both land in the configuration's "layers" key. Two separate writes
+    // could leave the shared collection partially updated if the second
+    // failed (Codex P2 on PR #1262).
+    await executeAgentTool(
+      "update_layer",
+      {
+        layer: "l1",
+        color: "#ff0000",
+        contrast,
+        contrastScope: "configuration",
+      },
+      context,
+    );
+    expect(mockMain.saveContrastInConfiguration).toHaveBeenCalledTimes(1);
+    expect(mockMain.saveContrastInConfiguration).toHaveBeenCalledWith({
+      layerId: "l1",
+      contrast,
+      delta: { color: "#ff0000" },
+      throwOnError: true,
+    });
+    // No separate changeLayer write for the colour.
+    expect(mockMain.changeLayer).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -938,6 +938,18 @@ describe("surfaces backend sync failures (#1239)", () => {
     mockMain.syncConfiguration = vi.fn(async () => undefined);
     mockMain.saveContrastInView = vi.fn(async () => undefined);
     mockMain.saveContrastInConfiguration = vi.fn(async () => undefined);
+    mockMain.setLayerMode = vi.fn(async () => undefined);
+    mockMain.saveScaleInConfiguration = vi.fn(async () => undefined);
+    mockMain.addToolToConfiguration = vi.fn(async () => undefined);
+    mockMain.configuration = { id: "conf1", name: "Collection", layers: [] };
+    mockProperties.workerImageList = {
+      "prop:1": {
+        isPropertyWorker: "x",
+        interfaceName: "Intensity",
+        annotationShape: "polygon",
+      },
+    };
+    mockProperties.getWorkerInterface = vi.fn(() => ({}));
   });
 
   it("update_layer reports a failed config save instead of success", async () => {
@@ -995,6 +1007,58 @@ describe("surfaces backend sync failures (#1239)", () => {
       delta: { color: "#ff0000" },
       throwOnError: true,
     });
+  });
+
+  it("set_layer_mode reports a failed sync instead of success", async () => {
+    mockMain.setLayerMode = vi.fn(async () => {
+      throw new Error("Write access denied");
+    });
+    await expect(
+      executeAgentTool("set_layer_mode", { mode: "multiple" }, context),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockMain.setLayerMode).toHaveBeenCalledWith({
+      mode: "multiple",
+      throwOnError: true,
+    });
+  });
+
+  it("set_scale reports a failed sync instead of success", async () => {
+    mockMain.saveScaleInConfiguration = vi.fn(async () => {
+      throw new Error("Write access denied");
+    });
+    await expect(
+      executeAgentTool(
+        "set_scale",
+        { pixelSize: { value: 0.65, unit: "µm" } },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+  });
+
+  it("create_tool reports a failed sync instead of success", async () => {
+    mockMain.addToolToConfiguration = vi.fn(async () => {
+      throw new Error("Write access denied");
+    });
+    await expect(
+      executeAgentTool("create_tool", { manualShape: "polygon" }, context),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    // The AI panel opts into error propagation via the options form.
+    expect(mockMain.addToolToConfiguration).toHaveBeenCalledWith(
+      expect.objectContaining({ throwOnError: true }),
+    );
+  });
+
+  it("create_property reports a failed backend save instead of success", async () => {
+    mockProperties.createProperty = vi.fn(async () => {
+      throw new Error("Write access denied");
+    });
+    await expect(
+      executeAgentTool(
+        "create_property",
+        { propertyWorkerImage: "prop:1", shape: "polygon" },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
   });
 });
 
@@ -1065,10 +1129,12 @@ describe("set_scale", () => {
     expect(mockMain.saveScaleInConfiguration).toHaveBeenCalledWith({
       itemId: "pixelSize",
       scale: { value: 0.65, unit: "µm" },
+      throwOnError: true,
     });
     expect(mockMain.saveScaleInConfiguration).toHaveBeenCalledWith({
       itemId: "zStep",
       scale: { value: 2, unit: "µm" },
+      throwOnError: true,
     });
   });
 

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -247,6 +247,10 @@ beforeEach(() => {
   mockProperties.computedPropertyPaths = [];
   mockProperties.propertyStatuses = {};
   mockProperties.getWorkerInterface = vi.fn(() => ({}));
+  // Reassigned (not just cleared) by tests that make a persist reject, so
+  // reset them here — clearAllMocks only resets call history.
+  mockMain.syncConfiguration = vi.fn();
+  mockMain.setViewContrastOverrides = vi.fn();
   mockMain.drawAnnotations = true;
   mockMain.annotationOpacity = 0.5;
   mockMain.showScalebar = true;
@@ -2124,6 +2128,48 @@ describe("snapshotViewState / restoreViewState", () => {
       expect.objectContaining({ layerId: "l1", sync: false }),
     );
     expect(mockMain.syncConfiguration).toHaveBeenCalledTimes(1);
+    // The revert must opt into error propagation, otherwise a rejected write
+    // is swallowed and revertViewChanges still reports "Reverted the view
+    // changes" for a change that only applied locally (issue #1239).
+    expect(mockMain.syncConfiguration).toHaveBeenCalledWith({
+      key: "layers",
+      throwOnError: true,
+    });
+  });
+
+  it("rejects when the revert's configuration sync fails", async () => {
+    mockMain.configuration.layers = [
+      {
+        id: "l1",
+        name: "DAPI",
+        color: "#0000ff",
+        visible: true,
+        contrast: { mode: "percentile", blackPoint: 0, whitePoint: 100 },
+      },
+    ];
+    mockMain.getConfigurationLayerFromId = vi.fn(
+      () => mockMain.configuration.layers[0],
+    );
+    const snapshot = snapshotViewState();
+    mockMain.configuration.layers[0].color = "#00ff00";
+    mockMain.syncConfiguration = vi.fn(async () => {
+      throw new Error("Read-only collection");
+    });
+
+    await expect(restoreViewState(snapshot)).rejects.toBeInstanceOf(
+      ToolExecutionError,
+    );
+  });
+
+  it("rejects when the revert's view-contrast persist fails", async () => {
+    const snapshot = snapshotViewState();
+    mockMain.setViewContrastOverrides = vi.fn(async () => {
+      throw new Error("Dataset view is read-only");
+    });
+
+    await expect(restoreViewState(snapshot)).rejects.toBeInstanceOf(
+      ToolExecutionError,
+    );
   });
 
   it("reverts property filters added or changed during the turn", async () => {

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/store", () => ({
     saveContrastInView: vi.fn(),
     saveContrastInConfiguration: vi.fn(),
     saveScaleInConfiguration: vi.fn(),
+    saveScalesInConfiguration: vi.fn(),
     scales: {
       pixelSize: { value: 1, unit: "µm" },
       zStep: { value: 1, unit: "µm" },
@@ -1036,6 +1037,7 @@ describe("surfaces backend sync failures (#1239)", () => {
     mockMain.saveContrastInConfiguration = vi.fn(async () => undefined);
     mockMain.setLayerMode = vi.fn(async () => undefined);
     mockMain.saveScaleInConfiguration = vi.fn(async () => undefined);
+    mockMain.saveScalesInConfiguration = vi.fn(async () => undefined);
     mockMain.addToolToConfiguration = vi.fn(async () => undefined);
     mockMain.configuration = { id: "conf1", name: "Collection", layers: [] };
     mockProperties.workerImageList = {
@@ -1119,7 +1121,7 @@ describe("surfaces backend sync failures (#1239)", () => {
   });
 
   it("set_scale reports a failed sync instead of success", async () => {
-    mockMain.saveScaleInConfiguration = vi.fn(async () => {
+    mockMain.saveScalesInConfiguration = vi.fn(async () => {
       throw new Error("Write access denied");
     });
     await expect(
@@ -1222,14 +1224,14 @@ describe("set_scale", () => {
       },
       context,
     );
-    expect(mockMain.saveScaleInConfiguration).toHaveBeenCalledWith({
-      itemId: "pixelSize",
-      scale: { value: 0.65, unit: "µm" },
-      throwOnError: true,
-    });
-    expect(mockMain.saveScaleInConfiguration).toHaveBeenCalledWith({
-      itemId: "zStep",
-      scale: { value: 2, unit: "µm" },
+    // One backend write for all requested fields, not one per field
+    // (Codex P2 on PR #1262).
+    expect(mockMain.saveScalesInConfiguration).toHaveBeenCalledTimes(1);
+    expect(mockMain.saveScalesInConfiguration).toHaveBeenCalledWith({
+      scales: {
+        pixelSize: { value: 0.65, unit: "µm" },
+        zStep: { value: 2, unit: "µm" },
+      },
       throwOnError: true,
     });
   });
@@ -1242,7 +1244,7 @@ describe("set_scale", () => {
         context,
       ),
     ).rejects.toBeInstanceOf(ToolExecutionError);
-    expect(mockMain.saveScaleInConfiguration).not.toHaveBeenCalled();
+    expect(mockMain.saveScalesInConfiguration).not.toHaveBeenCalled();
   });
 
   it("rejects a length unit on the time step and vice versa", async () => {
@@ -1260,6 +1262,24 @@ describe("set_scale", () => {
         context,
       ),
     ).rejects.toBeInstanceOf(ToolExecutionError);
+  });
+
+  it("writes nothing when a later field is invalid", async () => {
+    // Validation used to be interleaved with saving, so a valid pixelSize was
+    // already persisted before an invalid tStep threw, leaving the shared
+    // collection partially updated (Codex P2 on PR #1262).
+    await expect(
+      executeAgentTool(
+        "set_scale",
+        {
+          pixelSize: { value: 0.65, unit: "µm" },
+          tStep: { value: 1, unit: "µm" },
+        },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockMain.saveScalesInConfiguration).not.toHaveBeenCalled();
+    expect(mockMain.saveScaleInConfiguration).not.toHaveBeenCalled();
   });
 
   it("requires at least one dimension", async () => {

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -496,10 +496,12 @@ describe("executeAgentTool", () => {
     expect(mockMain.changeLayer).toHaveBeenCalledWith({
       layerId: "l1",
       delta: { color: "#ff0000" },
+      throwOnError: true,
     });
     expect(mockMain.saveContrastInView).toHaveBeenCalledWith({
       layerId: "l1",
       contrast,
+      throwOnError: true,
     });
   });
 
@@ -898,6 +900,7 @@ describe("update_layer contrast scope", () => {
     expect(mockMain.saveContrastInView).toHaveBeenCalledWith({
       layerId: "l1",
       contrast,
+      throwOnError: true,
     });
     expect(mockMain.saveContrastInConfiguration).not.toHaveBeenCalled();
   });
@@ -911,8 +914,87 @@ describe("update_layer contrast scope", () => {
     expect(mockMain.saveContrastInConfiguration).toHaveBeenCalledWith({
       layerId: "l1",
       contrast,
+      throwOnError: true,
     });
     expect(mockMain.saveContrastInView).not.toHaveBeenCalled();
+  });
+});
+
+describe("surfaces backend sync failures (#1239)", () => {
+  const layer = {
+    id: "l1",
+    name: "DAPI",
+    color: "#0000ff",
+    visible: true,
+    contrast: { mode: "percentile", blackPoint: 0, whitePoint: 100 },
+  };
+  const contrast = { mode: "percentile", blackPoint: 5, whitePoint: 95 } as any;
+
+  beforeEach(() => {
+    mockMain.layers = [layer];
+    mockMain.getLayerFromId = vi.fn(() => layer);
+    // Reset to benign resolving mocks (a prior test may have made one reject).
+    mockMain.changeLayer = vi.fn(async () => undefined);
+    mockMain.syncConfiguration = vi.fn(async () => undefined);
+    mockMain.saveContrastInView = vi.fn(async () => undefined);
+    mockMain.saveContrastInConfiguration = vi.fn(async () => undefined);
+  });
+
+  it("update_layer reports a failed config save instead of success", async () => {
+    // syncConfiguration with throwOnError rejects on a read-only collection;
+    // changeLayer propagates it. The tool must fail, not report the layer as
+    // updated.
+    mockMain.changeLayer = vi.fn(async () => {
+      throw new Error("Write access denied");
+    });
+    await expect(
+      executeAgentTool(
+        "update_layer",
+        { layer: "l1", color: "#ff0000" },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+  });
+
+  it("update_layer reports a failed contrast save", async () => {
+    mockMain.saveContrastInView = vi.fn(async () => {
+      throw new Error("network error");
+    });
+    await expect(
+      executeAgentTool("update_layer", { layer: "l1", contrast }, context),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+  });
+
+  it("set_layer_visibility reports a failed sync instead of success", async () => {
+    mockMain.syncConfiguration = vi.fn(async () => {
+      throw new Error("Write access denied");
+    });
+    await expect(
+      executeAgentTool(
+        "set_layer_visibility",
+        { visibleLayers: ["l1"] },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    // The failing sync is the one that opted into throwOnError.
+    expect(mockMain.syncConfiguration).toHaveBeenCalledWith({
+      key: "layers",
+      throwOnError: true,
+    });
+  });
+
+  it("update_layer still succeeds when the save succeeds", async () => {
+    const { result } = await executeAgentTool(
+      "update_layer",
+      { layer: "l1", color: "#ff0000" },
+      context,
+    );
+    expect(result.layer.id).toBe("l1");
+    expect(mockMain.changeLayer).toHaveBeenCalledWith({
+      layerId: "l1",
+      delta: { color: "#ff0000" },
+      throwOnError: true,
+    });
   });
 });
 

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -1055,7 +1055,12 @@ const registry: { [name: string]: IAgentToolEntry } = {
       }
       const LENGTH_UNITS = ["nm", "µm", "mm", "m"];
       const TIME_UNITS = ["ms", "s", "m", "h", "d"];
-      const apply = async (
+      // Validate every requested field BEFORE writing any of them, then
+      // persist the whole scales object in one backend write. Validating and
+      // saving field-by-field issued a write per field and left the shared
+      // collection partially updated when a later field was rejected - by the
+      // backend, or by this validation (Codex P2 on PR #1262).
+      const validate = (
         itemId: "pixelSize" | "zStep" | "tStep",
         scale: { value: number; unit: string },
         units: string[],
@@ -1072,35 +1077,34 @@ const registry: { [name: string]: IAgentToolEntry } = {
         }
         // scale.unit was just validated against the allowed unit list, so the
         // narrowing cast to the branded unit type is sound here.
-        await persistOrThrow(`${itemId} scale`, () =>
-          main.saveScaleInConfiguration({
-            itemId,
-            scale: {
-              value: scale.value,
-              unit: scale.unit as TUnitLength | TUnitTime,
-            } as IScaleInformation<TUnitLength | TUnitTime>,
-            throwOnError: true,
-          }),
-        );
+        return {
+          value: scale.value,
+          unit: scale.unit as TUnitLength | TUnitTime,
+        } as IScaleInformation<TUnitLength | TUnitTime>;
       };
-      let changed = false;
+      const scales: Partial<
+        Record<
+          "pixelSize" | "zStep" | "tStep",
+          IScaleInformation<TUnitLength | TUnitTime>
+        >
+      > = {};
       if (input.pixelSize) {
-        await apply("pixelSize", input.pixelSize, LENGTH_UNITS);
-        changed = true;
+        scales.pixelSize = validate("pixelSize", input.pixelSize, LENGTH_UNITS);
       }
       if (input.zStep) {
-        await apply("zStep", input.zStep, LENGTH_UNITS);
-        changed = true;
+        scales.zStep = validate("zStep", input.zStep, LENGTH_UNITS);
       }
       if (input.tStep) {
-        await apply("tStep", input.tStep, TIME_UNITS);
-        changed = true;
+        scales.tStep = validate("tStep", input.tStep, TIME_UNITS);
       }
-      if (!changed) {
+      if (Object.keys(scales).length === 0) {
         throw new ToolExecutionError(
           "Provide at least one of pixelSize, zStep, tStep",
         );
       }
+      await persistOrThrow("scales", () =>
+        main.saveScalesInConfiguration({ scales, throwOnError: true }),
+      );
       return { result: { scales: main.scales } };
     },
   },

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -991,7 +991,7 @@ const registry: { [name: string]: IAgentToolEntry } = {
       }
       const LENGTH_UNITS = ["nm", "µm", "mm", "m"];
       const TIME_UNITS = ["ms", "s", "m", "h", "d"];
-      const apply = (
+      const apply = async (
         itemId: "pixelSize" | "zStep" | "tStep",
         scale: { value: number; unit: string },
         units: string[],
@@ -1008,25 +1008,28 @@ const registry: { [name: string]: IAgentToolEntry } = {
         }
         // scale.unit was just validated against the allowed unit list, so the
         // narrowing cast to the branded unit type is sound here.
-        main.saveScaleInConfiguration({
-          itemId,
-          scale: {
-            value: scale.value,
-            unit: scale.unit as TUnitLength | TUnitTime,
-          } as IScaleInformation<TUnitLength | TUnitTime>,
-        });
+        await persistOrThrow(`${itemId} scale`, () =>
+          main.saveScaleInConfiguration({
+            itemId,
+            scale: {
+              value: scale.value,
+              unit: scale.unit as TUnitLength | TUnitTime,
+            } as IScaleInformation<TUnitLength | TUnitTime>,
+            throwOnError: true,
+          }),
+        );
       };
       let changed = false;
       if (input.pixelSize) {
-        apply("pixelSize", input.pixelSize, LENGTH_UNITS);
+        await apply("pixelSize", input.pixelSize, LENGTH_UNITS);
         changed = true;
       }
       if (input.zStep) {
-        apply("zStep", input.zStep, LENGTH_UNITS);
+        await apply("zStep", input.zStep, LENGTH_UNITS);
         changed = true;
       }
       if (input.tStep) {
-        apply("tStep", input.tStep, TIME_UNITS);
+        await apply("tStep", input.tStep, TIME_UNITS);
         changed = true;
       }
       if (!changed) {
@@ -1046,7 +1049,9 @@ const registry: { [name: string]: IAgentToolEntry } = {
       unrollT?: boolean;
     }) => {
       requireLogin();
-      await main.setLayerMode(input.mode);
+      await persistOrThrow("layer mode", () =>
+        main.setLayerMode({ mode: input.mode, throwOnError: true }),
+      );
       if (input.unrollXY != null) {
         await main.setUnrollXY(input.unrollXY);
       }
@@ -1428,7 +1433,9 @@ const registry: { [name: string]: IAgentToolEntry } = {
           "Could not build the requested tool (missing tool template)",
         );
       }
-      await main.addToolToConfiguration(tool);
+      await persistOrThrow("tool", () =>
+        main.addToolToConfiguration({ tool, throwOnError: true }),
+      );
       return {
         result: {
           toolId: tool.id,
@@ -1507,16 +1514,24 @@ const registry: { [name: string]: IAgentToolEntry } = {
         image,
         input.workerInterfaceValues ?? {},
       );
-      const property = await propertyStore.createProperty({
-        name:
-          input.name ??
-          propertyStore.workerImageList[image]?.interfaceName ??
-          "Property",
-        image,
-        tags: { tags: input.tags ?? [], exclusive: input.exclusive ?? false },
-        shape: input.shape as AnnotationShape,
-        workerInterface,
-      });
+      // createProperty hits the backend directly (PropertiesAPI rejects on
+      // failure rather than swallowing), so wrap it to report a clean failure
+      // instead of leaking a raw error (issue #1239).
+      const property = await persistOrThrow("property", () =>
+        propertyStore.createProperty({
+          name:
+            input.name ??
+            propertyStore.workerImageList[image]?.interfaceName ??
+            "Property",
+          image,
+          tags: {
+            tags: input.tags ?? [],
+            exclusive: input.exclusive ?? false,
+          },
+          shape: input.shape as AnnotationShape,
+          workerInterface,
+        }),
+      );
       if (!property) {
         throw new ToolExecutionError("Failed to create the property");
       }

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -2389,7 +2389,12 @@ export async function restoreViewState(snapshot: IViewStateSnapshot) {
   await main.setZ(snapshot.location.z);
   await main.setTime(snapshot.location.time);
   if (main.layerMode !== snapshot.layerMode) {
-    await main.setLayerMode(snapshot.layerMode);
+    // throwOnError like the forward-direction tools: revertViewChanges tells
+    // the user "Reverted the view changes", so a revert that only applied
+    // locally must not be reported as a success either (issue #1239).
+    await persistOrThrow("layer mode", () =>
+      main.setLayerMode({ mode: snapshot.layerMode, throwOnError: true }),
+    );
   }
   await main.setUnrollXY(snapshot.unroll.xy);
   await main.setUnrollZ(snapshot.unroll.z);
@@ -2422,9 +2427,15 @@ export async function restoreViewState(snapshot: IViewStateSnapshot) {
     }
   }
   if (layersChanged) {
-    await main.syncConfiguration("layers");
+    await persistOrThrow("layer changes", () =>
+      main.syncConfiguration({ key: "layers", throwOnError: true }),
+    );
   }
-  await main.setViewContrastOverrides(snapshot.viewContrasts);
+  // setViewContrastOverrides already rejects on a failed persist (it awaits
+  // updateDatasetView without catching); wrap it for a consistent message.
+  await persistOrThrow("view contrast overrides", () =>
+    main.setViewContrastOverrides(snapshot.viewContrasts),
+  );
   filterStore.setTagFilter(snapshot.tagFilter);
   filterStore.setOnlyCurrentFrame(snapshot.onlyCurrentFrame);
   // Restore property filters: disable any added since the snapshot (matching

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -14,6 +14,7 @@ import {
   IProgressInfo,
   IPropertyAnnotationFilter,
   IScaleInformation,
+  IScales,
   IToolConfiguration,
   IWorkerInterfaceValues,
   PropertyFilterMode,
@@ -1061,7 +1062,7 @@ const registry: { [name: string]: IAgentToolEntry } = {
       // collection partially updated when a later field was rejected - by the
       // backend, or by this validation (Codex P2 on PR #1262).
       const validate = (
-        itemId: "pixelSize" | "zStep" | "tStep",
+        itemId: keyof IScales,
         scale: { value: number; unit: string },
         units: string[],
       ) => {
@@ -1083,10 +1084,7 @@ const registry: { [name: string]: IAgentToolEntry } = {
         } as IScaleInformation<TUnitLength | TUnitTime>;
       };
       const scales: Partial<
-        Record<
-          "pixelSize" | "zStep" | "tStep",
-          IScaleInformation<TUnitLength | TUnitTime>
-        >
+        Record<keyof IScales, IScaleInformation<TUnitLength | TUnitTime>>
       > = {};
       if (input.pixelSize) {
         scales.pixelSize = validate("pixelSize", input.pixelSize, LENGTH_UNITS);
@@ -1167,13 +1165,17 @@ const registry: { [name: string]: IAgentToolEntry } = {
         // Both target the configuration's "layers" key, so write them
         // together: two separate writes could leave the shared collection
         // partially updated if the second failed (Codex P2 on PR #1262).
-        await persistOrThrow("layer update", () =>
-          main.saveContrastInConfiguration({
-            layerId: layer.id,
-            contrast,
-            delta,
-            throwOnError: true,
-          }),
+        // Label by what actually changed: this one call may carry only the
+        // contrast, and the message becomes the model's failure reason.
+        await persistOrThrow(
+          Object.keys(delta).length > 0 ? "layer update" : "contrast",
+          () =>
+            main.saveContrastInConfiguration({
+              layerId: layer.id,
+              contrast,
+              delta,
+              throwOnError: true,
+            }),
         );
       } else {
         if (Object.keys(delta).length > 0) {

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -1159,25 +1159,32 @@ const registry: { [name: string]: IAgentToolEntry } = {
           "Provide at least one of color, visible, contrast, name",
         );
       }
-      if (Object.keys(delta).length > 0) {
+      const contrast = input.contrast;
+      // Default matches the UI slider: a personal view override. Pass
+      // contrastScope "configuration" to change the shared collection
+      // instead (persisted for everyone using the collection).
+      if (contrast != null && input.contrastScope === "configuration") {
+        // Both target the configuration's "layers" key, so write them
+        // together: two separate writes could leave the shared collection
+        // partially updated if the second failed (Codex P2 on PR #1262).
         await persistOrThrow("layer update", () =>
-          main.changeLayer({ layerId: layer.id, delta, throwOnError: true }),
+          main.saveContrastInConfiguration({
+            layerId: layer.id,
+            contrast,
+            delta,
+            throwOnError: true,
+          }),
         );
-      }
-      if (input.contrast != null) {
-        const contrast = input.contrast;
-        // Default matches the UI slider: a personal view override. Pass
-        // contrastScope "configuration" to change the shared collection
-        // instead (persisted for everyone using the collection).
-        if (input.contrastScope === "configuration") {
-          await persistOrThrow("contrast", () =>
-            main.saveContrastInConfiguration({
-              layerId: layer.id,
-              contrast,
-              throwOnError: true,
-            }),
+      } else {
+        if (Object.keys(delta).length > 0) {
+          await persistOrThrow("layer update", () =>
+            main.changeLayer({ layerId: layer.id, delta, throwOnError: true }),
           );
-        } else {
+        }
+        // A view-scoped contrast lands in the dataset view, a different
+        // resource from the configuration, so it is necessarily a second
+        // write - there is no single call that covers both.
+        if (contrast != null) {
           await persistOrThrow("contrast", () =>
             main.saveContrastInView({
               layerId: layer.id,

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -96,6 +96,29 @@ const MAX_LIST_ANNOTATIONS = LARGE_ANNOTATION_RESULT;
 // can correct its call.
 export class ToolExecutionError extends Error {}
 
+// Configuration/view mutations persist to the backend and can be rejected
+// (e.g. a read-only collection, a network failure). syncConfiguration swallows
+// those failures app-wide and only surfaces them via the global saving-state
+// indicator (issue #1239) — but the AI panel asserts success in prose, so a
+// swallowed failure would have the model tell the user a change was saved when
+// it only persisted locally. These mutators opt into throwOnError; this wraps
+// them so a backend rejection becomes a ToolExecutionError the model reports as
+// a failure instead of success.
+async function persistOrThrow<T>(
+  what: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error: any) {
+    throw new ToolExecutionError(
+      `${what} could not be saved: ${
+        error?.message ?? "the backend rejected the change"
+      }`,
+    );
+  }
+}
+
 interface IAnnotationQuery {
   tags?: string[];
   exclusive?: boolean;
@@ -1064,22 +1087,31 @@ const registry: { [name: string]: IAgentToolEntry } = {
         );
       }
       if (Object.keys(delta).length > 0) {
-        await main.changeLayer({ layerId: layer.id, delta });
+        await persistOrThrow("layer update", () =>
+          main.changeLayer({ layerId: layer.id, delta, throwOnError: true }),
+        );
       }
       if (input.contrast != null) {
+        const contrast = input.contrast;
         // Default matches the UI slider: a personal view override. Pass
         // contrastScope "configuration" to change the shared collection
         // instead (persisted for everyone using the collection).
         if (input.contrastScope === "configuration") {
-          await main.saveContrastInConfiguration({
-            layerId: layer.id,
-            contrast: input.contrast,
-          });
+          await persistOrThrow("contrast", () =>
+            main.saveContrastInConfiguration({
+              layerId: layer.id,
+              contrast,
+              throwOnError: true,
+            }),
+          );
         } else {
-          await main.saveContrastInView({
-            layerId: layer.id,
-            contrast: input.contrast,
-          });
+          await persistOrThrow("contrast", () =>
+            main.saveContrastInView({
+              layerId: layer.id,
+              contrast,
+              throwOnError: true,
+            }),
+          );
         }
       }
       const updated = main.getLayerFromId(layer.id)!;
@@ -1119,7 +1151,9 @@ const registry: { [name: string]: IAgentToolEntry } = {
           });
         }
       }
-      await main.syncConfiguration("layers");
+      await persistOrThrow("layer visibility", () =>
+        main.syncConfiguration({ key: "layers", throwOnError: true }),
+      );
       return {
         result: {
           layers: main.layers.map((l) => ({

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -1359,7 +1359,13 @@ export class Annotations extends VuexModule {
    * would corrupt the stored annotation, defeat patch diffing in
    * getAnnotationUpdatePatch, and prevent rollback on error.
    */
-  @Action
+  // rawError: true because both paths below rethrow after rolling back, so the
+  // real reason reaches the caller (and the console/Sentry) instead of
+  // vuex-module-decorators' generic ERR_ACTION_ACCESS_UNDEFINED text. The
+  // sync indicator is unaffected either way: setSaving receives the error
+  // caught inside this action, before any wrapping. See index.ts
+  // syncConfiguration.
+  @Action({ rawError: true })
   public async updateAnnotationsPerId({
     annotationIds,
     editFunction,

--- a/src/store/index.saveContrastInView.test.ts
+++ b/src/store/index.saveContrastInView.test.ts
@@ -1,18 +1,46 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import main from "./index";
+import store from "./root";
+
+// The generated module accessor exposes state as non-configurable getters, so
+// login state has to be set on the underlying Vuex state directly.
+function setLoggedIn(loggedIn: boolean) {
+  (store.state as any).main.girderUser = loggedIn ? { _id: "u1" } : null;
+}
 
 // Regression test for issue #1239 / Codex review on PR #1262:
 // saveContrastInView must NOT silently succeed when the personal dataset view
 // cannot be persisted. Only callers opting into throwOnError (the AI panel)
 // see the rejection; interactive UI callers keep the silent local-override
 // behavior.
+//
+// These tests dispatch the REAL Vuex actions (no "./index" mock) on purpose:
+// vuex-module-decorators replaces any error thrown from an @Action with a
+// generic "ERR_ACTION_ACCESS_UNDEFINED" message unless the action declares
+// { rawError: true }. That quirk silently defeats this whole feature - the AI
+// panel would still report a failure, but with a cryptic message plus stack
+// traces instead of the real reason. See the matching note in index.test.ts.
 
 const contrast = {
   mode: "percentile",
   blackPoint: 5,
   whitePoint: 95,
 } as any;
+
+// `.rejects.toThrow(/regex/)` only checks that the message CONTAINS the
+// pattern, and the ERR_ACTION_ACCESS_UNDEFINED wrapper embeds the original
+// error's `.stack` (which includes its message) inside its own message. So a
+// substring match passes even when rawError is missing. Assert on the exact
+// message instead so a regression is actually caught.
+async function messageOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error("Expected the promise to reject, but it resolved");
+}
 
 describe("saveContrastInView throwOnError", () => {
   beforeEach(() => {
@@ -22,17 +50,32 @@ describe("saveContrastInView throwOnError", () => {
 
   it("throws when there is no dataset view", async () => {
     main.setDatasetViewImpl(null);
-    await expect(
-      main.saveContrastInView({ layerId: "l1", contrast, throwOnError: true }),
-    ).rejects.toThrow(/no dataset view/);
+    expect(
+      await messageOf(
+        main.saveContrastInView({
+          layerId: "l1",
+          contrast,
+          throwOnError: true,
+        }),
+      ),
+    ).toBe("Cannot save the contrast: no dataset view is open");
   });
 
   it("throws when the dataset view is not editable", async () => {
     // _accessLevel 0 => canEditDatasetView is false regardless of login.
     main.setDatasetViewImpl({ layerContrasts: {}, _accessLevel: 0 } as any);
-    await expect(
-      main.saveContrastInView({ layerId: "l1", contrast, throwOnError: true }),
-    ).rejects.toThrow(/permission to edit/);
+    expect(
+      await messageOf(
+        main.saveContrastInView({
+          layerId: "l1",
+          contrast,
+          throwOnError: true,
+        }),
+      ),
+    ).toBe(
+      "Cannot save the contrast: you do not have permission to edit this " +
+        "dataset view",
+    );
     // The local override is still applied (it just can't be persisted).
     expect(main.datasetView?.layerContrasts.l1).toEqual(contrast);
   });
@@ -44,5 +87,98 @@ describe("saveContrastInView throwOnError", () => {
       main.saveContrastInView({ layerId: "l1", contrast }),
     ).resolves.toBeUndefined();
     expect(main.datasetView?.layerContrasts.l1).toEqual(contrast);
+  });
+
+  it("propagates the backend's own message when persisting the view fails", async () => {
+    main.setDatasetViewImpl({ layerContrasts: {}, _accessLevel: 2 } as any);
+    setLoggedIn(true);
+    (main as any).api.updateDatasetView = vi.fn(async () => {
+      throw new Error("Storage quota exceeded");
+    });
+
+    expect(
+      await messageOf(
+        main.saveContrastInView({
+          layerId: "l1",
+          contrast,
+          throwOnError: true,
+        }),
+      ),
+    ).toBe("Storage quota exceeded");
+  });
+});
+
+// The configuration-scoped mutators reach the backend through
+// syncConfiguration, which rethrows the API error when throwOnError is set.
+// That error crosses two @Action boundaries (e.g. changeLayer ->
+// syncConfiguration), so BOTH must declare rawError: true for the original
+// message to survive.
+describe("configuration mutators propagate the backend error unmangled", () => {
+  beforeEach(() => {
+    setLoggedIn(true);
+    (main as any).setConfigurationImpl({
+      id: "c1",
+      data: {
+        id: "c1",
+        name: "config",
+        layers: [{ id: "l1", name: "DAPI", visible: true }],
+        tools: [],
+        scales: {},
+      } as any,
+    });
+    (main as any).api.updateConfigurationKey = vi.fn(async () => {
+      throw new Error("Backend rejected the write");
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("syncConfiguration surfaces the API error", async () => {
+    expect(
+      await messageOf(
+        main.syncConfiguration({ key: "layers", throwOnError: true }),
+      ),
+    ).toBe("Backend rejected the write");
+  });
+
+  it("changeLayer surfaces the API error through syncConfiguration", async () => {
+    expect(
+      await messageOf(
+        main.changeLayer({
+          layerId: "l1",
+          delta: { color: "#ff0000" },
+          throwOnError: true,
+        }),
+      ),
+    ).toBe("Backend rejected the write");
+  });
+
+  it("saveScaleInConfiguration surfaces the API error", async () => {
+    expect(
+      await messageOf(
+        main.saveScaleInConfiguration({
+          itemId: "pixelSize",
+          scale: { value: 1, unit: "µm" } as any,
+          throwOnError: true,
+        }),
+      ),
+    ).toBe("Backend rejected the write");
+  });
+
+  it("addToolToConfiguration surfaces the API error", async () => {
+    expect(
+      await messageOf(
+        main.addToolToConfiguration({
+          tool: { id: "t1", name: "tool", type: "create" } as any,
+          throwOnError: true,
+        }),
+      ),
+    ).toBe("Backend rejected the write");
+  });
+
+  it("still swallows the error for callers that do not opt in", async () => {
+    await expect(main.syncConfiguration("layers")).resolves.toBeUndefined();
   });
 });

--- a/src/store/index.saveContrastInView.test.ts
+++ b/src/store/index.saveContrastInView.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import main from "./index";
+
+// Regression test for issue #1239 / Codex review on PR #1262:
+// saveContrastInView must NOT silently succeed when the personal dataset view
+// cannot be persisted. Only callers opting into throwOnError (the AI panel)
+// see the rejection; interactive UI callers keep the silent local-override
+// behavior.
+
+const contrast = {
+  mode: "percentile",
+  blackPoint: 5,
+  whitePoint: 95,
+} as any;
+
+describe("saveContrastInView throwOnError", () => {
+  beforeEach(() => {
+    // Make updateDatasetView observable/benign for the editable path.
+    (main as any).api.updateDatasetView = vi.fn(async () => ({}));
+  });
+
+  it("throws when there is no dataset view", async () => {
+    main.setDatasetViewImpl(null);
+    await expect(
+      main.saveContrastInView({ layerId: "l1", contrast, throwOnError: true }),
+    ).rejects.toThrow(/no dataset view/);
+  });
+
+  it("throws when the dataset view is not editable", async () => {
+    // _accessLevel 0 => canEditDatasetView is false regardless of login.
+    main.setDatasetViewImpl({ layerContrasts: {}, _accessLevel: 0 } as any);
+    await expect(
+      main.saveContrastInView({ layerId: "l1", contrast, throwOnError: true }),
+    ).rejects.toThrow(/permission to edit/);
+    // The local override is still applied (it just can't be persisted).
+    expect(main.datasetView?.layerContrasts.l1).toEqual(contrast);
+  });
+
+  it("does not throw for non-AI callers even when not editable", async () => {
+    main.setDatasetViewImpl({ layerContrasts: {}, _accessLevel: 0 } as any);
+    // No throwOnError: interactive UI behavior is unchanged (silent).
+    await expect(
+      main.saveContrastInView({ layerId: "l1", contrast }),
+    ).resolves.toBeUndefined();
+    expect(main.datasetView?.layerContrasts.l1).toEqual(contrast);
+  });
+});

--- a/src/store/index.saveContrastInView.test.ts
+++ b/src/store/index.saveContrastInView.test.ts
@@ -181,4 +181,31 @@ describe("configuration mutators propagate the backend error unmangled", () => {
   it("still swallows the error for callers that do not opt in", async () => {
     await expect(main.syncConfiguration("layers")).resolves.toBeUndefined();
   });
+
+  // addToolToConfiguration accepts either a bare tool (interactive callers) or
+  // {tool, throwOnError} (the AI panel). The executors test mocks the action,
+  // so only a real dispatch exercises which branch a payload takes. The
+  // `tool: "future-field"` below stands in for IToolConfiguration one day
+  // gaining a "tool" key, which would silently misroute a bare payload if the
+  // discrimination keyed off "tool" in payload instead of "template".
+  it("adds the tool for both the bare and wrapped payload forms", async () => {
+    (main as any).api.updateConfigurationKey = vi.fn(async () => ({}));
+    const bare = {
+      id: "bare",
+      name: "bare tool",
+      type: "create",
+      template: { name: "t", interface: [] },
+      values: {},
+      hotkey: null,
+      tool: "future-field",
+    } as any;
+    await main.addToolToConfiguration(bare);
+    expect(main.configuration?.tools.map((t) => t.id)).toContain("bare");
+
+    await main.addToolToConfiguration({
+      tool: { ...bare, id: "wrapped" },
+      throwOnError: true,
+    });
+    expect(main.configuration?.tools.map((t) => t.id)).toContain("wrapped");
+  });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2616,6 +2616,31 @@ export class Main extends VuexModule {
     }
   }
 
+  // Batch sibling of saveScaleInConfiguration: assigns every provided scale
+  // and syncs once. The AI panel's set_scale can set pixelSize, zStep and
+  // tStep in a single call; saving them one at a time issued a backend write
+  // per field and could leave the collection partially updated when a later
+  // one failed (Codex P2 on PR #1262). The interactive UI edits one field at
+  // a time and keeps using the singular action.
+  @Action({ rawError: true })
+  async saveScalesInConfiguration({
+    scales,
+    throwOnError,
+  }: {
+    scales: Partial<
+      Record<keyof IScales, IScaleInformation<TUnitLength | TUnitTime>>
+    >;
+    throwOnError?: boolean;
+  }) {
+    if (!this.configuration) {
+      return;
+    }
+    for (const [itemId, scale] of Object.entries(scales)) {
+      (this.configuration.scales as any)[itemId] = scale;
+    }
+    await this.syncConfiguration({ key: "scales", throwOnError });
+  }
+
   @Action
   saveScalesInView({
     itemId,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2580,7 +2580,10 @@ export class Main extends VuexModule {
   // Replace the whole per-view contrast override map in one backend sync,
   // instead of one saveContrastInView call (and dataset-view update) per
   // layer. Used by the AI panel's revert-view-changes.
-  @Action
+  // rawError: true because this action propagates a failed persist to its only
+  // caller (the AI panel's revert) rather than swallowing it, and that caller
+  // logs the reason (see syncConfiguration).
+  @Action({ rawError: true })
   async setViewContrastOverrides(layerContrasts: {
     [layerId: string]: IContrast;
   }) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -870,7 +870,21 @@ export class Main extends VuexModule {
   }
 
   @Action
-  addToolToConfiguration(tool: IToolConfiguration) {
+  async addToolToConfiguration(
+    // Accept a bare tool or {tool, throwOnError}. throwOnError lets the AI
+    // panel surface a failed persist (issue #1239); existing callers pass the
+    // bare tool and keep the swallow behavior. IToolConfiguration has no
+    // "tool" key, so its presence unambiguously marks the options form.
+    payload:
+      | IToolConfiguration
+      | {
+          tool: IToolConfiguration;
+          throwOnError?: boolean;
+        },
+  ) {
+    const tool = "tool" in payload ? payload.tool : payload;
+    const throwOnError =
+      "tool" in payload ? payload.throwOnError ?? false : false;
     if (this.configuration) {
       this.setConfigurationTools([...this.configuration.tools, tool]);
       // Fetch the worker interface for this new tool if there is one
@@ -878,7 +892,7 @@ export class Main extends VuexModule {
       if (image) {
         this.context.dispatch("requestWorkerInterface", image);
       }
-      this.syncConfiguration("tools");
+      await this.syncConfiguration({ key: "tools", throwOnError });
     }
   }
 
@@ -2217,7 +2231,17 @@ export class Main extends VuexModule {
   }
 
   @Action
-  async setLayerMode(mode: TLayerMode) {
+  async setLayerMode(
+    // Accept either a bare mode or {mode, throwOnError}, mirroring
+    // syncConfiguration's payload shape. throwOnError lets the AI panel
+    // surface a failed persist instead of reporting success (issue #1239);
+    // existing callers pass the bare mode and keep the swallow behavior.
+    payload: TLayerMode | { mode: TLayerMode; throwOnError?: boolean },
+  ) {
+    const mode = typeof payload === "string" ? payload : payload.mode;
+    const throwOnError =
+      typeof payload === "string" ? false : payload.throwOnError ?? false;
+
     // Store current visibility state before changing mode
     this.storeLayerVisibility(mode);
 
@@ -2234,7 +2258,7 @@ export class Main extends VuexModule {
 
     // Sync the configuration with the backend
     if (this.isLoggedIn) {
-      await this.syncConfiguration("layers");
+      await this.syncConfiguration({ key: "layers", throwOnError });
     }
   }
 
@@ -2359,16 +2383,20 @@ export class Main extends VuexModule {
   }
 
   @Action
-  saveScaleInConfiguration({
+  async saveScaleInConfiguration({
     itemId,
     scale,
+    throwOnError,
   }: {
     itemId: keyof IScales;
     scale: IScaleInformation<TUnitLength | TUnitTime>;
+    // Opt-in error propagation for the AI panel (issue #1239); existing
+    // callers omit it and keep the swallow behavior.
+    throwOnError?: boolean;
   }) {
     if (this.configuration) {
       (this.configuration.scales as any)[itemId] = scale;
-      this.syncConfiguration("scales");
+      await this.syncConfiguration({ key: "scales", throwOnError });
     }
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2120,7 +2120,10 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true because this rolls back and rethrows so the caller can
+  // report the real reason (see syncConfiguration). Third link in the
+  // create_property chain the AI panel reports on (#1239).
+  @Action({ rawError: true })
   async updateConfigurationProperties(propertyIds: string[]) {
     const configuration = this.configuration;
     if (!configuration) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -912,7 +912,9 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true so a throwOnError rejection keeps its original message
+  // (see syncConfiguration).
+  @Action({ rawError: true })
   async addToolToConfiguration(
     // Accept a bare tool or {tool, throwOnError}. throwOnError lets the AI
     // panel surface a failed persist (issue #1239); existing callers pass the
@@ -2150,7 +2152,13 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true is required because the throwOnError path rethrows the
+  // backend error and callers (the AI panel) read the original message.
+  // Without it, vuex-module-decorators replaces the error with a generic
+  // "ERR_ACTION_ACCESS_UNDEFINED" message. Same rationale as
+  // addMultiSourceMetadata. It is a no-op for the default swallow path,
+  // which never throws.
+  @Action({ rawError: true })
   async syncConfiguration(
     payload:
       | keyof IDatasetConfigurationBase
@@ -2416,7 +2424,9 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true so a throwOnError rejection keeps its original message
+  // (see syncConfiguration).
+  @Action({ rawError: true })
   async setLayerMode(
     // Accept either a bare mode or {mode, throwOnError}, mirroring
     // syncConfiguration's payload shape. throwOnError lets the AI panel
@@ -2492,7 +2502,9 @@ export class Main extends VuexModule {
     });
   }
 
-  @Action
+  // rawError: true so a throwOnError rejection keeps its original message
+  // (see syncConfiguration).
+  @Action({ rawError: true })
   async saveContrastInConfiguration({
     layerId,
     contrast,
@@ -2520,7 +2532,9 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true so a throwOnError rejection keeps its original message
+  // (see syncConfiguration).
+  @Action({ rawError: true })
   async saveContrastInView({
     layerId,
     contrast,
@@ -2579,7 +2593,9 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true so a throwOnError rejection keeps its original message
+  // (see syncConfiguration).
+  @Action({ rawError: true })
   async saveScaleInConfiguration({
     itemId,
     scale,
@@ -2643,7 +2659,9 @@ export class Main extends VuexModule {
     confLayers.splice(index, 1, Object.assign({}, layer, delta));
   }
 
-  @Action
+  // rawError: true so a throwOnError rejection keeps its original message
+  // (see syncConfiguration).
+  @Action({ rawError: true })
   async changeLayer(args: {
     layerId: string;
     delta: Partial<IDisplayLayer>;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2508,16 +2508,24 @@ export class Main extends VuexModule {
   async saveContrastInConfiguration({
     layerId,
     contrast,
+    delta,
     throwOnError,
   }: {
     layerId: string;
     contrast: IContrast;
+    // Extra layer fields to write in the SAME configuration sync as the
+    // contrast. The AI panel's update_layer can change colour/name/visibility
+    // and a collection-scoped contrast in one call; sending them as two
+    // changeLayer calls wrote the "layers" key twice and could leave the
+    // collection partially updated when the second failed (Codex P2 on
+    // PR #1262).
+    delta?: Partial<IDisplayLayer>;
     // See changeLayer: opt-in error propagation for the AI panel (#1239).
     throwOnError?: boolean;
   }) {
     await this.changeLayer({
       layerId,
-      delta: { contrast },
+      delta: { ...delta, contrast },
       sync: true,
       throwOnError,
     });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2286,15 +2286,26 @@ export class Main extends VuexModule {
   async saveContrastInConfiguration({
     layerId,
     contrast,
+    throwOnError,
   }: {
     layerId: string;
     contrast: IContrast;
+    // See changeLayer: opt-in error propagation for the AI panel (#1239).
+    throwOnError?: boolean;
   }) {
-    this.changeLayer({ layerId, delta: { contrast }, sync: true });
+    await this.changeLayer({
+      layerId,
+      delta: { contrast },
+      sync: true,
+      throwOnError,
+    });
     if (this.datasetView) {
       delete this.datasetView.layerContrasts[layerId];
       if (this.canEditDatasetView) {
-        this.api.updateDatasetView(this.datasetView);
+        const update = this.api.updateDatasetView(this.datasetView);
+        if (throwOnError) {
+          await update;
+        }
       }
     }
   }
@@ -2303,14 +2314,20 @@ export class Main extends VuexModule {
   async saveContrastInView({
     layerId,
     contrast,
+    throwOnError,
   }: {
     layerId: string;
     contrast: IContrast;
+    // See changeLayer: opt-in error propagation for the AI panel (#1239).
+    throwOnError?: boolean;
   }) {
     if (this.datasetView) {
       this.datasetView.layerContrasts[layerId] = contrast;
       if (this.canEditDatasetView) {
-        this.api.updateDatasetView(this.datasetView);
+        const update = this.api.updateDatasetView(this.datasetView);
+        if (throwOnError) {
+          await update;
+        }
       }
     }
   }
@@ -2406,10 +2423,18 @@ export class Main extends VuexModule {
     layerId: string;
     delta: Partial<IDisplayLayer>;
     sync?: boolean;
+    // Opt-in: propagate a failed backend persist to the caller (default is
+    // the app-wide swallow-and-surface-in-the-saving-indicator behavior).
+    // Used by the AI panel so a rejected write isn't reported as success
+    // (issue #1239).
+    throwOnError?: boolean;
   }) {
     this.changeLayerImpl(args);
     if (args.sync !== false && this.isLoggedIn) {
-      await this.syncConfiguration("layers");
+      await this.syncConfiguration({
+        key: "layers",
+        throwOnError: args.throwOnError,
+      });
     }
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2352,7 +2352,18 @@ export class Main extends VuexModule {
         if (throwOnError) {
           await update;
         }
+      } else if (throwOnError) {
+        // The local override was applied, but it can't be persisted (a
+        // read-only / public dataset view). Callers opting into throwOnError
+        // (the AI panel) must not report success for a change that won't
+        // survive a reload -- see issue #1239.
+        throw new Error(
+          "Cannot save the contrast: you do not have permission to edit " +
+            "this dataset view",
+        );
       }
+    } else if (throwOnError) {
+      throw new Error("Cannot save the contrast: no dataset view is open");
     }
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1480,7 +1480,13 @@ export class Main extends VuexModule {
     await this.initFromUrl();
   }
 
-  @Action
+  // rawError: true because the catch below turns the server's response into a
+  // user-facing message ("login already in use", ...) that
+  // UserMenuLoginForm.vue renders in its error alert. A bare @Action would
+  // replace it with vuex-module-decorators' generic
+  // ERR_ACTION_ACCESS_UNDEFINED text, so the user would see that instead of
+  // the reason their sign-up failed. See syncConfiguration.
+  @Action({ rawError: true })
   async signUp({
     domain,
     ...user
@@ -2139,7 +2145,11 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true because this rolls back and rethrows so the caller can
+  // report the real reason. The pipeline UI shows generic text but logs the
+  // error, so without this the log holds the ERR_ACTION_ACCESS_UNDEFINED blob
+  // instead of the failure. Mirrors updateConfigurationProperties.
+  @Action({ rawError: true })
   async updateConfigurationPipelines(pipelines: IPipeline[]) {
     const configuration = this.configuration;
     if (!configuration) {
@@ -3164,7 +3174,9 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true because this logs and rethrows so the caller sees the real
+  // reason (UserColorSettings.vue logs it). See syncConfiguration.
+  @Action({ rawError: true })
   async saveUserColors(channelColors: {
     [key: string]: string;
   }): Promise<void> {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -918,8 +918,7 @@ export class Main extends VuexModule {
   async addToolToConfiguration(
     // Accept a bare tool or {tool, throwOnError}. throwOnError lets the AI
     // panel surface a failed persist (issue #1239); existing callers pass the
-    // bare tool and keep the swallow behavior. IToolConfiguration has no
-    // "tool" key, so its presence unambiguously marks the options form.
+    // bare tool and keep the swallow behavior.
     payload:
       | IToolConfiguration
       | {
@@ -927,9 +926,13 @@ export class Main extends VuexModule {
           throwOnError?: boolean;
         },
   ) {
-    const tool = "tool" in payload ? payload.tool : payload;
-    const throwOnError =
-      "tool" in payload ? payload.throwOnError ?? false : false;
+    // Discriminate on a field the bare tool is REQUIRED to have rather than on
+    // "tool" in payload: the latter would silently misroute (with no type
+    // error, since both union members would match) if IToolConfiguration ever
+    // gained a "tool" field.
+    const isWrapped = !("template" in payload);
+    const tool = isWrapped ? payload.tool : payload;
+    const throwOnError = isWrapped ? payload.throwOnError ?? false : false;
     if (this.configuration) {
       this.setConfigurationTools([...this.configuration.tools, tool]);
       // Fetch the worker interface for this new tool if there is one

--- a/src/store/properties.createProperty.test.ts
+++ b/src/store/properties.createProperty.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import propertyStore from "./properties";
+import main from "./index";
+import store from "./root";
+
+// Regression tests for the create_property error chain (issue #1239, Codex P2
+// on PR #1262).
+//
+// The AI panel wraps propertyStore.createProperty and reports the failure
+// reason to the user. That error crosses FOUR @Action boundaries:
+//
+//   createProperty -> setProperties -> updateConfigurationProperties
+//                                   -> syncConfiguration
+//
+// vuex-module-decorators replaces a thrown error with a generic
+// ERR_ACTION_ACCESS_UNDEFINED message at EVERY boundary that lacks
+// { rawError: true }, so all four need it. These tests dispatch the REAL
+// actions: the executors test mocks createProperty, which bypasses the
+// decorator entirely and cannot catch this.
+
+// `.rejects.toThrow(/regex/)` is a substring match, and the wrapper embeds the
+// original error's `.stack` (which contains its message) inside its own
+// message -- so a substring assertion passes even when rawError is missing.
+// Assert the exact message instead. Same helper as index.test.ts.
+async function messageOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error("Expected the promise to reject, but it resolved");
+}
+
+function setLoggedIn(loggedIn: boolean) {
+  (store.state as any).main.girderUser = loggedIn ? { _id: "u1" } : null;
+}
+
+describe("createProperty propagates the real failure reason", () => {
+  beforeEach(() => {
+    setLoggedIn(true);
+    (main as any).setConfigurationImpl({
+      id: "c1",
+      data: {
+        id: "c1",
+        name: "config",
+        layers: [],
+        tools: [],
+        scales: {},
+        propertyIds: [],
+      } as any,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces the backend's message when the property POST fails", async () => {
+    vi.spyOn(propertyStore.propertiesAPI, "createProperty").mockRejectedValue(
+      new Error("Property name already in use"),
+    );
+
+    expect(
+      await messageOf(propertyStore.createProperty({ name: "area" } as any)),
+    ).toBe("Property name already in use");
+  });
+
+  it("surfaces the backend's message when the propertyIds sync fails", async () => {
+    // The POST succeeds, then persisting propertyIds to the configuration
+    // fails -- the error crosses all four action boundaries.
+    vi.spyOn(propertyStore.propertiesAPI, "createProperty").mockResolvedValue({
+      id: "p1",
+      name: "area",
+    } as any);
+    vi.spyOn(main.api, "updateConfigurationKey").mockRejectedValue(
+      new Error("Read-only collection"),
+    );
+
+    expect(
+      await messageOf(propertyStore.createProperty({ name: "area" } as any)),
+    ).toBe("Read-only collection");
+  });
+
+  it("rolls the property list back when the sync fails", async () => {
+    const before = propertyStore.properties.length;
+    vi.spyOn(propertyStore.propertiesAPI, "createProperty").mockResolvedValue({
+      id: "p1",
+      name: "area",
+    } as any);
+    vi.spyOn(main.api, "updateConfigurationKey").mockRejectedValue(
+      new Error("Read-only collection"),
+    );
+
+    await messageOf(propertyStore.createProperty({ name: "area" } as any));
+    expect(propertyStore.properties.length).toBe(before);
+  });
+});

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -767,7 +767,11 @@ export class Properties extends VuexModule {
     this.properties = [...properties];
   }
 
-  @Action
+  // rawError: true because this rolls back and rethrows so the caller can
+  // report the real reason; a bare @Action would replace the message with
+  // vuex-module-decorators' generic ERR_ACTION_ACCESS_UNDEFINED text. Part of
+  // the create_property chain the AI panel reports on (#1239).
+  @Action({ rawError: true })
   protected async setProperties(properties: IAnnotationProperty[]) {
     const previous = this.properties;
     this.setPropertiesImpl(properties);
@@ -910,7 +914,10 @@ export class Properties extends VuexModule {
     );
   }
 
-  @Action
+  // rawError: true because both awaits here propagate on failure (the
+  // annotation_property POST, and the propertyIds sync inside setProperties)
+  // and the AI panel reports that reason to the user. See setProperties.
+  @Action({ rawError: true })
   async createProperty(property: IAnnotationPropertyConfiguration) {
     const newProperty = await this.propertiesAPI.createProperty(property);
     if (newProperty) {


### PR DESCRIPTION
Fixes #1239. Split out of #1261 (which now carries only the backend fixes #1241/#1242/#1243).

`syncConfiguration` swallows backend write failures app-wide (surfacing them only via the global saving-state indicator), so an AI-panel tool that awaited a sync and then read back locally-mutated state reported success even when the backend rejected the write (e.g. a read-only collection) — and the model asserted the change was saved in prose.

This uses the existing opt-in `throwOnError` sync contract (already used for `propertyIds`/`pipelines`) rather than changing the app-wide swallow behavior. Existing callers pass the bare payload and are unaffected.

## Changes

**Store (`src/store/index.ts`)** — opt-in `throwOnError` threaded through the config mutators, via the same union-payload shape `syncConfiguration` already uses:
- `changeLayer`, `saveContrastInConfiguration`, `saveContrastInView`
- `setLayerMode`, `saveScaleInConfiguration`, `addToolToConfiguration` (the latter two are now `async` and `await` their sync)

**Executors (`src/agent/executors.ts`)** — a `persistOrThrow` helper turns a rejected persist into a `ToolExecutionError` the model reports as failure. Applied to every gated config-mutating tool:
- `update_layer`, `set_layer_visibility`, `set_layer_mode`, `set_scale`, `create_tool`
- `create_property` (already rejects via `PropertiesAPI` rather than swallowing — wrapped for a consistent message)

## Tests
`src/agent/executors.test.ts`: each mutator rejects with `ToolExecutionError` when its backend save fails, and still succeeds when it succeeds. 102/102 pass; `tsc` and `eslint` clean.

This addresses review Finding #2 from #1261 (extend beyond `update_layer`/`set_layer_visibility`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJjRGoL4gBPb8Rqgov18YV)_