### PR TITLE
Regenerate agent skill files to fix sync CI check

### DIFF
--- a/.agents/skills/branch-review/SKILL.md
+++ b/.agents/skills/branch-review/SKILL.md
@@ -146,8 +146,8 @@ Flag `except Exception:` or bare `except:`. These swallow errors like KeyboardIn
 
 ### 10. Public Endpoint Input Validation (most-recurring external-review finding)
 For every new or modified `@access.public` endpoint:
-- Any `.get()` / `len()` / `int()` / indexing on request data must be preceded by an inline `isinstance` type check that raises `RestException(code=400, ...)`. There is no shared validation helper module — guard inline (real example: `server/api/annotation.py::updateMultiple`). A malformed payload must produce a clean 400, never an uncaught 500.
-- Caller-supplied ObjectId strings converted with `except bson.errors.InvalidId` (NOT `except ValueError` — InvalidId is not a ValueError) at the API boundary.
+- Any `.get()` / `len()` / `int()` / indexing on request data must be validated at the API boundary via the shared helpers in `server/helpers/validation.py` (`requireObjectBody`, `requireList`, `requireObjectId`, `requireInt`, `validateListInputs`, ...), which raise `RestException(code=400, ...)`. Flag new/edited endpoints that hand-roll inline `isinstance` guards instead of calling these. A malformed payload must produce a clean 400, never an uncaught 500. (Applies to `@access.user` endpoints too, not only `@access.public`.)
+- Caller-supplied ObjectId strings converted with `except (bson.errors.InvalidId, TypeError)` at the API boundary (InvalidId for a bad hex string, TypeError for a non-string like `{"datasetId": 123}`; InvalidId is NOT a ValueError). `requireObjectId` already does this.
 - Counts/limits clamped to a `MAX_*` constant — unauthenticated callers must not be able to force unbounded DB or serialization work.
 - When one endpoint has the gap, check sibling public endpoints in the same file — this pattern recurs in clusters.
 

--- a/.agents/skills/nimbus-backend/SKILL.md
+++ b/.agents/skills/nimbus-backend/SKILL.md
@@ -275,29 +275,35 @@ Convert ids once at the API boundary and pass ObjectIds down — don't convert d
 
 ## Public Endpoint Input Validation
 
-This is the single most-recurring review finding in this plugin: an `@access.public` endpoint calls `.get()` / `len()` / `int()` / indexes request data **without first checking its type**, so a malformed payload (JSON-array body, `filters.tags: "bad"`, scalar `annotationIds`, oversized `limit`) raises an uncaught `AttributeError`/`TypeError` → 500 instead of a clean 400 — and unbounded limits let unauthenticated callers force huge DB/serialization work.
+This is the single most-recurring review finding in this plugin: an endpoint calls `.get()` / `len()` / `int()` / indexes request data **without first checking its type**, so a malformed payload (JSON-array body, `filters.tags: "bad"`, scalar `annotationIds`, non-string `datasetId`, oversized `limit`) raises an uncaught `AttributeError`/`TypeError` → 500 instead of a clean 400 — and unbounded limits let callers force huge DB/serialization work. Applies to `@access.user` endpoints too, not only `@access.public`: 400-not-500 is the house style regardless of auth.
 
-There is **no shared validation helper module** in this plugin — validate inline at the API boundary with `isinstance` checks that raise `RestException(code=400, ...)` *before* you touch the data. Real example, `server/api/annotation.py::updateMultiple`:
+**Use the shared validators in `server/helpers/validation.py`** (added by PR #1203). Do NOT hand-roll inline `isinstance` guards for new/edited endpoints — call the helpers, which raise `RestException(code=400)` at the boundary. Real example, `server/api/dataImport.py::importData`:
 
 ```python
-if not isinstance(bodyJson, list):
-    raise RestException("Request body must be a JSON array.", code=400)
-for update in bodyJson:
-    if not isinstance(update, dict):
-        raise RestException("Each item must be a JSON object.", code=400)
+from ..helpers.validation import (
+    requireObjectBody, requireList, requireObjectId,
+)
+
+body = requireObjectBody(kwargs["memoizedBodyJson"])
+datasetId = requireObjectId(body.get("datasetId"), "datasetId")
+annotations = requireList(body.get("annotations", []), "annotations")
+propertyValues = requireObjectBody(body.get("propertyValues", {}), "propertyValues")
 ```
 
-Guard each kind of request-data access before performing it:
+Match each kind of request-data access to its helper:
 
-| Access to guard | Guard before it |
+| Access to guard | Helper |
 |---|---|
-| `.get()` on a body/object | `isinstance(body, dict)` → 400 |
-| `len()` / iteration on a field | `isinstance(value, list)` → 400 |
-| `ObjectId(id)` on caller-supplied ids | `try / except InvalidId` → 400 (see the bson section above) |
-| `int(param)` on a query param | `try / except (TypeError, ValueError)` → 400 |
-| unbounded counts / `limit` | clamp against a module-level `MAX_*` constant (pattern: `MAX_ZENODO_FILES` / `MAX_ZENODO_SIZE` in `server/api/zenodo.py`) |
+| `.get()` on a body / nested object | `requireObjectBody(value, name)` → dict-or-400 |
+| `len()` / iteration on a field | `requireList(value, field)` → list-or-400 |
+| `ObjectId(id)` on caller-supplied ids | `requireObjectId(value, field)` → ObjectId-or-400 (handles None, `InvalidId`, AND non-string `TypeError`) |
+| `int(param)` on a query param | `requireInt(value, field)` → int-or-400 |
+| unbounded counts | `requireCountWithin(count, limit, name)` / module-level `MAX_*` consts (`MAX_ANNOTATION_IDS`, `MAX_LIST_LIMIT`, ...) read at call time (monkeypatchable in tests) |
+| filter / sort / propertyPaths shape | `validateListInputs(...)`, `validatePropertyPaths(...)`, `validateUncomputedCountsProperties(...)` |
 
-Rules: validation and `RestException` live in the API layer, never in models. Add a backend test per malformed-input case (malformed body → 400, not 500). When you fix one endpoint, sweep the other public endpoints in the same file for the identical gap — reviewers flag one instance per round.
+`requireObjectId` catches `TypeError` as well as `InvalidId` — a non-string id like `{"datasetId": 123}` is a clean 400, not a 500 (see the bson section above).
+
+Rules: validation and `RestException` live in the API layer, never in models. Validate NESTED elements, not just the top-level container — each list entry (`[123]`) and nested map (`propertyValues: {"a1": 5}`) is caller-supplied; `.get()`/`.items()` on a non-dict entry → 500. Add a backend test per malformed-input case (malformed body → 400, not 500); `test/test_validation.py` unit-tests the helpers directly, and endpoint tests assert the 400. When you fix one endpoint, sweep the other endpoints in the same file for the identical gap — reviewers flag one instance per round.
 
 ## Loading Plugin Changes Into the Running Backend
 


### PR DESCRIPTION
## Summary

The `sync` CI job (`.github/workflows/agent-skills.yaml`) runs `sync_skills.py --check`, which enforces that the generated `.agents/skills/*/SKILL.md` copies stay in sync with their `.claude/skills/*` sources. Two files had drifted, so **this check is currently red on `master`** (and therefore on every open PR that merges into it):

- `.agents/skills/branch-review/SKILL.md`
- `.agents/skills/nimbus-backend/SKILL.md`

The drift is in the "Public Endpoint Input Validation" section — the `.claude/skills/` sources were updated in an earlier change but the generated `.agents/skills/` copies weren't regenerated.

## Change

Ran `python3 plugins/nimbusimage/scripts/sync_skills.py --write` and committed the result. **No hand edits** — this is a purely mechanical, generated-file-only change. After it, `sync_skills.py --check` passes (`NimbusImage Claude and Codex skills are synchronized.`).

## Why a standalone PR

This drift pre-dates and is unrelated to any feature work; keeping it separate avoids bundling unrelated generated-file churn into feature PRs. Merging this turns the `sync` check green on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYGYhz81os7rxuW9xvM4ZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYGYhz81os7rxuW9xvM4ZZ)_