### PR TITLE
Surface storage quota errors during transcoding, worker jobs, and uploads

### DIFF
--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -57,6 +57,29 @@ For advanced store patterns (routeMapper, form change detection, caching with ba
 
 Editing any `src/store/*.ts` while `pnpm run dev` runs corrupts the store: vuex-module-decorators registers getters at import time with no HMR accept handler, so a hot re-import double-registers → `[vuex] duplicate getter key` cascade and broken state (e.g. annotations stuck at 0). **Hard-reload the page after every store-module edit** before trusting any in-browser behavior. Component `.vue` edits HMR fine — prefer putting temporary instrumentation in `.vue` files.
 
+### Actions That Throw Need `@Action({ rawError: true })`
+
+`vuex-module-decorators` wraps **any** error thrown from a bare `@Action` in a generic `Error("ERR_ACTION_ACCESS_UNDEFINED: Are you trying to access this.someMutation()...")`, discarding the original message — unless the action is declared `@Action({ rawError: true })`. This is a library-wide behavior, not specific to one module.
+
+Most actions in this codebase never throw (they log and return `null`/`false` on failure), so this rarely bites. It matters the moment an action is *designed* to throw so a caller can show the real failure reason (e.g. `addMultiSourceMetadata` throwing a storage-quota message for `MultiSourceConfiguration.vue` to display). Forgetting `rawError: true` silently replaces that message with the cryptic wrapper text — `tsc`/lint/tests all stay green because the action still rejects, just with the wrong message.
+
+```typescript
+// BAD: caller's catch block sees "ERR_ACTION_ACCESS_UNDEFINED: ..." instead
+// of the real message
+@Action
+async doThing() {
+  throw new Error("Helpful, specific reason");
+}
+
+// GOOD
+@Action({ rawError: true })
+async doThing() {
+  throw new Error("Helpful, specific reason");
+}
+```
+
+When writing a test for an action's thrown-error message, `expect(...).rejects.toThrow("substring")` is not a reliable regression check here: the wrapped error's message embeds the original error's `.stack` (which starts with `"Error: <original message>"`), so a substring match can pass even when `rawError` is missing. Assert the exact `.message` instead. See `src/store/index.test.ts` for the pattern (dispatches the real action instead of mocking `@/store`).
+
 ### Watching Getters That Rebuild Their Return Object
 
 `watch(() => someGetter, cb, { deep: true })` on a getter that returns a **new object on every read** fires on every dependency touch — including dependencies the getter reads but that don't change the output (`deep: true` skips the value comparison entirely). This shipped a real bug: a deep watch on `currentFilters` cleared the selection on every Z-scrub because the getter read `z` unconditionally. tsc/lint/reasoning all passed; only the live app caught it.

--- a/.agents/skills/nimbus-frontend/references/store-module-patterns.md
+++ b/.agents/skills/nimbus-frontend/references/store-module-patterns.md
@@ -144,6 +144,66 @@ async setSelectedProject(projectId: string | null) {
 }
 ```
 
+## Actions That Throw: `rawError: true` and How to Test Them
+
+`vuex-module-decorators` wraps every `@Action` body in its own try/catch. If the body throws and the action was declared as plain `@Action` (no options), the library **replaces** the caught error with a new one:
+
+```
+Error: ERR_ACTION_ACCESS_UNDEFINED: Are you trying to access this.someMutation()
+or this.someGetter inside an @Action?
+That works only in dynamic modules.
+If not dynamic use this.context.commit("mutationName", payload) and
+this.context.getters["getterName"]
+<stack of "Could not perform action <name>">
+<original error's stack>
+```
+
+This happens regardless of *why* the action threw — the message text is generic boilerplate about accessing mutations/getters, which is almost never the actual problem. It exists so that genuinely buggy `this.someMutation()` calls inside an action fail loudly, but it has the side effect of eating deliberate, meaningful `throw`s too.
+
+Opt out per-action with `{ rawError: true }`:
+
+```typescript
+// The action is *designed* to throw a specific, user-facing message on
+// failure, so callers must see it unmangled.
+@Action({ rawError: true })
+async addMultiSourceMetadata(payload: IAddMultiSourceMetadataPayload) {
+  try {
+    // ...
+    if (!success) {
+      throw new Error(quotaExceededMessage(jobLog) ?? "Failed to transcode...");
+    }
+    return itemId;
+  } catch (error) {
+    sync.setSaving(error as Error);
+    throw error; // rawError: true means this reaches the caller unchanged
+  }
+}
+```
+
+Default to a bare `@Action` (log-and-return-null/false on failure) unless a caller specifically needs to branch on or display the failure reason. Reach for `rawError: true` only when the action throws on purpose.
+
+### Testing the real dispatch path (not a mocked one)
+
+Most store tests mock `@/store`/`./index` entirely (see `aiPanel.test.ts`, `toolSuggestions.test.ts`, `MultiSourceConfiguration.test.ts`) because `Main` is heavy to construct. That's fine for testing *callers* of an action, but it can't catch a missing `rawError: true` — the mock just returns/throws whatever the test tells it to, bypassing vuex-module-decorators entirely.
+
+To regression-test the wrapping behavior itself, dispatch the **real** action from the real singleton (`import main from "./index"`), mocking only the leaf API calls it touches (`main.api.*` via `vi.spyOn`) and any other dynamic-module dependencies (e.g. `jobs.addJob`). Importing `store/index.ts` directly works fine in the vitest/jsdom environment — `Main`'s constructor only builds a `RestClient` and reads `localStorage`, no network calls — see `src/store/index.test.ts`.
+
+The key pitfall when writing the assertion: `expect(promise).rejects.toThrow("substring")` does a **substring** check against `error.message`. The wrapped `ERR_ACTION_ACCESS_UNDEFINED` message embeds the original error's `.stack` (whose first line is `"Error: <original message>"`), so a substring match can pass even when `rawError: true` is missing from the action — the test would never catch the regression it's meant to catch. Capture the message and assert it with `toBe(...)` (exact equality) instead:
+
+```typescript
+async function messageOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error("Expected the promise to reject, but it resolved");
+}
+
+const message = await messageOf(main.addMultiSourceMetadata({ ...payload }));
+expect(message).toBe("This operation needs 9.7 MB of storage, ...");
+```
+
 ## Reference
 
 For projects store implementation details, read: `codebaseDocumentation/PROJECTS.md`

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -57,6 +57,29 @@ For advanced store patterns (routeMapper, form change detection, caching with ba
 
 Editing any `src/store/*.ts` while `pnpm run dev` runs corrupts the store: vuex-module-decorators registers getters at import time with no HMR accept handler, so a hot re-import double-registers → `[vuex] duplicate getter key` cascade and broken state (e.g. annotations stuck at 0). **Hard-reload the page after every store-module edit** before trusting any in-browser behavior. Component `.vue` edits HMR fine — prefer putting temporary instrumentation in `.vue` files.
 
+### Actions That Throw Need `@Action({ rawError: true })`
+
+`vuex-module-decorators` wraps **any** error thrown from a bare `@Action` in a generic `Error("ERR_ACTION_ACCESS_UNDEFINED: Are you trying to access this.someMutation()...")`, discarding the original message — unless the action is declared `@Action({ rawError: true })`. This is a library-wide behavior, not specific to one module.
+
+Most actions in this codebase never throw (they log and return `null`/`false` on failure), so this rarely bites. It matters the moment an action is *designed* to throw so a caller can show the real failure reason (e.g. `addMultiSourceMetadata` throwing a storage-quota message for `MultiSourceConfiguration.vue` to display). Forgetting `rawError: true` silently replaces that message with the cryptic wrapper text — `tsc`/lint/tests all stay green because the action still rejects, just with the wrong message.
+
+```typescript
+// BAD: caller's catch block sees "ERR_ACTION_ACCESS_UNDEFINED: ..." instead
+// of the real message
+@Action
+async doThing() {
+  throw new Error("Helpful, specific reason");
+}
+
+// GOOD
+@Action({ rawError: true })
+async doThing() {
+  throw new Error("Helpful, specific reason");
+}
+```
+
+When writing a test for an action's thrown-error message, `expect(...).rejects.toThrow("substring")` is not a reliable regression check here: the wrapped error's message embeds the original error's `.stack` (which starts with `"Error: <original message>"`), so a substring match can pass even when `rawError` is missing. Assert the exact `.message` instead. See `src/store/index.test.ts` for the pattern (dispatches the real action instead of mocking `@/store`).
+
 ### Watching Getters That Rebuild Their Return Object
 
 `watch(() => someGetter, cb, { deep: true })` on a getter that returns a **new object on every read** fires on every dependency touch — including dependencies the getter reads but that don't change the output (`deep: true` skips the value comparison entirely). This shipped a real bug: a deep watch on `currentFilters` cleared the selection on every Z-scrub because the getter read `z` unconditionally. tsc/lint/reasoning all passed; only the live app caught it.

--- a/.claude/skills/nimbus-frontend/references/store-module-patterns.md
+++ b/.claude/skills/nimbus-frontend/references/store-module-patterns.md
@@ -144,6 +144,66 @@ async setSelectedProject(projectId: string | null) {
 }
 ```
 
+## Actions That Throw: `rawError: true` and How to Test Them
+
+`vuex-module-decorators` wraps every `@Action` body in its own try/catch. If the body throws and the action was declared as plain `@Action` (no options), the library **replaces** the caught error with a new one:
+
+```
+Error: ERR_ACTION_ACCESS_UNDEFINED: Are you trying to access this.someMutation()
+or this.someGetter inside an @Action?
+That works only in dynamic modules.
+If not dynamic use this.context.commit("mutationName", payload) and
+this.context.getters["getterName"]
+<stack of "Could not perform action <name>">
+<original error's stack>
+```
+
+This happens regardless of *why* the action threw — the message text is generic boilerplate about accessing mutations/getters, which is almost never the actual problem. It exists so that genuinely buggy `this.someMutation()` calls inside an action fail loudly, but it has the side effect of eating deliberate, meaningful `throw`s too.
+
+Opt out per-action with `{ rawError: true }`:
+
+```typescript
+// The action is *designed* to throw a specific, user-facing message on
+// failure, so callers must see it unmangled.
+@Action({ rawError: true })
+async addMultiSourceMetadata(payload: IAddMultiSourceMetadataPayload) {
+  try {
+    // ...
+    if (!success) {
+      throw new Error(quotaExceededMessage(jobLog) ?? "Failed to transcode...");
+    }
+    return itemId;
+  } catch (error) {
+    sync.setSaving(error as Error);
+    throw error; // rawError: true means this reaches the caller unchanged
+  }
+}
+```
+
+Default to a bare `@Action` (log-and-return-null/false on failure) unless a caller specifically needs to branch on or display the failure reason. Reach for `rawError: true` only when the action throws on purpose.
+
+### Testing the real dispatch path (not a mocked one)
+
+Most store tests mock `@/store`/`./index` entirely (see `aiPanel.test.ts`, `toolSuggestions.test.ts`, `MultiSourceConfiguration.test.ts`) because `Main` is heavy to construct. That's fine for testing *callers* of an action, but it can't catch a missing `rawError: true` — the mock just returns/throws whatever the test tells it to, bypassing vuex-module-decorators entirely.
+
+To regression-test the wrapping behavior itself, dispatch the **real** action from the real singleton (`import main from "./index"`), mocking only the leaf API calls it touches (`main.api.*` via `vi.spyOn`) and any other dynamic-module dependencies (e.g. `jobs.addJob`). Importing `store/index.ts` directly works fine in the vitest/jsdom environment — `Main`'s constructor only builds a `RestClient` and reads `localStorage`, no network calls — see `src/store/index.test.ts`.
+
+The key pitfall when writing the assertion: `expect(promise).rejects.toThrow("substring")` does a **substring** check against `error.message`. The wrapped `ERR_ACTION_ACCESS_UNDEFINED` message embeds the original error's `.stack` (whose first line is `"Error: <original message>"`), so a substring match can pass even when `rawError: true` is missing from the action — the test would never catch the regression it's meant to catch. Capture the message and assert it with `toBe(...)` (exact equality) instead:
+
+```typescript
+async function messageOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error("Expected the promise to reject, but it resolved");
+}
+
+const message = await messageOf(main.addMultiSourceMetadata({ ...payload }));
+expect(message).toBe("This operation needs 9.7 MB of storage, ...");
+```
+
 ## Reference
 
 For projects store implementation details, read: `codebaseDocumentation/PROJECTS.md`

--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -34,6 +34,7 @@ import {
   TJobType,
   IDatasetConfigurationCompatibility,
   IJob,
+  IUserStorageQuota,
   resolveVisibilityConfig,
 } from "@/store/model";
 import {
@@ -1118,6 +1119,23 @@ export default class GirderAPI {
     } catch (error) {
       logError("Failed to fetch user API keys");
       return [];
+    }
+  }
+
+  // Fetch the user's storage usage and quota from the girder-user-quota
+  // plugin. `quota` is null when the user has no quota (unlimited storage).
+  // Returns null if the quota information cannot be fetched (e.g. the
+  // user-quota plugin is not enabled on the backend).
+  async getUserStorageQuota(userId: string): Promise<IUserStorageQuota | null> {
+    try {
+      const response = await this.client.get(`user/${userId}/quota`);
+      return {
+        used: response.data.size ?? 0,
+        quota: response.data.quota?._currentFileSizeQuota ?? null,
+      };
+    } catch (error) {
+      logError("Failed to fetch user storage quota");
+      return null;
     }
   }
 

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// Regression tests for addMultiSourceMetadata's error propagation.
+//
+// This action deliberately throws on failure (e.g. a storage quota breach
+// during transcoding) so MultiSourceConfiguration.vue can show the real
+// reason instead of a frozen spinner. Unlike most store tests, this file
+// does NOT mock "@/store"/"./index": vuex-module-decorators wraps any error
+// thrown from an @Action in a generic "ERR_ACTION_ACCESS_UNDEFINED" message
+// unless the action is declared with { rawError: true } - a library quirk
+// that silently defeats this kind of error surfacing (see the fix that
+// added rawError: true to this action). These tests dispatch the REAL Vuex
+// action so a regression - e.g. someone removing rawError: true - fails
+// here instead of only showing up against a live backend.
+import main from "./index";
+import jobs from "./jobs";
+
+function mockSuccessfulUploadAndTiles() {
+  vi.spyOn(main.api, "uploadJSONFile").mockResolvedValue({
+    data: { itemId: "item1" },
+  } as any);
+  vi.spyOn(main.api, "getItems").mockResolvedValue([]);
+  vi.spyOn(main.api, "removeLargeImageForItem").mockResolvedValue({} as any);
+  vi.spyOn(main.api, "generateTiles").mockResolvedValue({
+    data: { _id: "job1" },
+  } as any);
+}
+
+// `.rejects.toThrow(string)` only checks that the message CONTAINS the
+// string. A vuex-module-decorators "ERR_ACTION_ACCESS_UNDEFINED" wrapper
+// embeds the original error's message as part of its own `.stack` text, so a
+// substring match would pass even when rawError is missing and the real
+// message never reaches the caller as `error.message`. Assert the exact
+// message instead so a regression is actually caught.
+async function messageOf(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error("Expected the promise to reject, but it resolved");
+}
+
+describe("addMultiSourceMetadata error propagation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces the friendly storage-quota message when the transcode job fails due to quota", async () => {
+    mockSuccessfulUploadAndTiles();
+    vi.spyOn(jobs, "addJob").mockImplementation(async (job: any) => {
+      job.eventCallback?.({
+        _id: "job1",
+        text:
+          "Upload would exceed file storage quota (need 9.7 MB, only 1.9 " +
+          "MB available - used 15.4 GB out of 15.4 GB)\n",
+      });
+      return false;
+    });
+
+    const message = await messageOf(
+      main.addMultiSourceMetadata({
+        parentId: "folder1",
+        metadata: "{}",
+        transcode: true,
+      }),
+    );
+
+    expect(message).toBe(
+      "This operation needs 9.7 MB of storage, but only 1.9 MB of your " +
+        "15.4 GB quota remains (15.4 GB used). Free up space by deleting " +
+        "datasets you no longer need, or upgrade your account for more " +
+        "storage.",
+    );
+  });
+
+  it("surfaces a plain transcode-failure message (not a mangled vuex-module-decorators error) when the job fails for an unrelated reason", async () => {
+    mockSuccessfulUploadAndTiles();
+    vi.spyOn(jobs, "addJob").mockResolvedValue(false);
+
+    const message = await messageOf(
+      main.addMultiSourceMetadata({
+        parentId: "folder1",
+        metadata: "{}",
+        transcode: true,
+      }),
+    );
+
+    expect(message).toBe(
+      "Failed to transcode the large image: the transcoding job failed. " +
+        "See the transcoding log for details.",
+    );
+  });
+
+  it("resolves with the item id when transcoding succeeds", async () => {
+    mockSuccessfulUploadAndTiles();
+    vi.spyOn(jobs, "addJob").mockResolvedValue(true);
+
+    await expect(
+      main.addMultiSourceMetadata({
+        parentId: "folder1",
+        metadata: "{}",
+        transcode: true,
+      }),
+    ).resolves.toBe("item1");
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1784,7 +1784,12 @@ export class Main extends VuexModule {
     }
   }
 
-  @Action
+  // rawError: true is required here because this action throws on failure
+  // (e.g. a storage quota breach) and callers rely on reading the original
+  // Error's message. Without it, vuex-module-decorators wraps any thrown
+  // error in a generic "ERR_ACTION_ACCESS_UNDEFINED" message, discarding the
+  // actual failure reason.
+  @Action({ rawError: true })
   async addMultiSourceMetadata({
     parentId,
     metadata,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -83,6 +83,7 @@ export { default as store } from "./root";
 // NOTE: router is imported lazily where needed to avoid circular dependency with main.ts
 
 import { Debounce } from "@/utils/debounce";
+import { quotaExceededMessage } from "@/utils/quota";
 import { memDiag } from "@/utils/memoryDiagnostics";
 import { TCompositionMode } from "@/utils/compositionModes";
 import {
@@ -1809,19 +1810,32 @@ export class Main extends VuexModule {
             "Failed to transcode the large image: no job received",
           );
         }
+        // Accumulate the job log so that on failure we can tell the user
+        // why the job failed (e.g. a storage quota breach during the
+        // server-side upload of the transcoded file).
+        let jobLog = "";
         const success = await jobs.addJob({
           jobId,
           datasetId: parentId,
-          eventCallback,
+          eventCallback: (jobData: IJobEventData) => {
+            if (typeof jobData.text === "string") {
+              jobLog += jobData.text;
+            }
+            eventCallback?.(jobData);
+          },
         });
         if (!success) {
-          throw new Error("Failed to transcode the large image: job failed");
+          throw new Error(
+            quotaExceededMessage(jobLog) ??
+              "Failed to transcode the large image: the transcoding job " +
+                "failed. See the transcoding log for details.",
+          );
         }
       }
       return itemId;
     } catch (error) {
       sync.setSaving(error as Error);
-      return null;
+      throw error;
     }
   }
 

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -19,6 +19,7 @@ import {
 import main from "./index";
 
 import { logError } from "@/utils/log";
+import { quotaExceededMessage } from "@/utils/quota";
 import { jobStates } from "./jobConstants";
 
 export { jobStates };
@@ -303,6 +304,24 @@ export class Jobs extends VuexModule {
           status === jobStates.cancelled ? "cancelled" : "failed"
         }`,
       );
+      if (status === jobStates.error) {
+        // Surface the failure to the user. In particular, detect storage
+        // quota breaches: server-side uploads (transcoding jobs, worker
+        // outputs) fail with a quota message that only appears in the job
+        // log, and would otherwise be invisible to the user.
+        const jobTitle = jobEvent.title || "Job";
+        const quotaMessage = quotaExceededMessage(jobInfo.log);
+        const { default: progress } = await import("./progress");
+        progress.createNotification({
+          type: NotificationType.ERROR,
+          title: quotaMessage ? "Storage Quota Exceeded" : "Job Failed",
+          message: quotaMessage ?? `${jobTitle} failed.`,
+          info: quotaMessage
+            ? undefined
+            : "See the job log for details about the failure.",
+          timeout: 0, // Requires manual dismissal
+        });
+      }
     } else {
       // Create success notification
       const jobTitle = jobEvent.title || "Job";

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1895,6 +1895,13 @@ export interface IAnnotationImportResult {
   propertyValueCount: number;
 }
 
+// Storage usage and quota for a user, as reported by the girder-user-quota
+// plugin. Sizes are in bytes; quota is null when unlimited.
+export interface IUserStorageQuota {
+  used: number;
+  quota: number | null;
+}
+
 export interface IJobEventData {
   _id: string;
   title?: string;

--- a/src/utils/quota.test.ts
+++ b/src/utils/quota.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { parseQuotaExceededError, quotaExceededMessage } from "./quota";
+
+const START_MESSAGE =
+  "Upload would exceed file storage quota (need 4.20 GB, only 1.10 GB " +
+  "available - used 8.90 GB out of 10.00 GB)";
+const FINALIZE_MESSAGE =
+  "Upload exceeded file storage quota (need 954.06 MB, only 100.00 MB " +
+  "available - used 9.90 GB out of 10.00 GB)";
+
+describe("parseQuotaExceededError", () => {
+  it("parses the upload-start quota message", () => {
+    expect(parseQuotaExceededError(START_MESSAGE)).toEqual({
+      needed: "4.20 GB",
+      available: "1.10 GB",
+      used: "8.90 GB",
+      total: "10.00 GB",
+    });
+  });
+
+  it("parses the upload-finalize quota message", () => {
+    expect(parseQuotaExceededError(FINALIZE_MESSAGE)).toEqual({
+      needed: "954.06 MB",
+      available: "100.00 MB",
+      used: "9.90 GB",
+      total: "10.00 GB",
+    });
+  });
+
+  it("finds the message inside a job log traceback", () => {
+    const log = [
+      "Started large image conversion",
+      "Processing frame 12/12",
+      "Created a file of size 123456789",
+      "Traceback (most recent call last):",
+      '  File "/opt/girder/upload.py", line 42, in finalize',
+      `girder.exceptions.ValidationException: ${FINALIZE_MESSAGE}`,
+    ].join("\n");
+    expect(parseQuotaExceededError(log)?.needed).toBe("954.06 MB");
+  });
+
+  it("returns null for unrelated errors", () => {
+    expect(parseQuotaExceededError("Some other failure")).toBeNull();
+    expect(parseQuotaExceededError("")).toBeNull();
+  });
+});
+
+describe("quotaExceededMessage", () => {
+  it("builds a user-facing message with the parsed sizes", () => {
+    const message = quotaExceededMessage(START_MESSAGE);
+    expect(message).toContain("4.20 GB");
+    expect(message).toContain("1.10 GB");
+    expect(message).toContain("10.00 GB");
+    expect(message).toContain("Free up space");
+  });
+
+  it("falls back to a generic message when the sizes cannot be parsed", () => {
+    const message = quotaExceededMessage(
+      "Error: file storage quota reached for user",
+    );
+    expect(message).toContain("storage quota was exceeded");
+  });
+
+  it("returns null for non-quota errors", () => {
+    expect(quotaExceededMessage("Connection reset by peer")).toBeNull();
+  });
+});

--- a/src/utils/quota.ts
+++ b/src/utils/quota.ts
@@ -1,0 +1,54 @@
+// Helpers for detecting storage-quota errors raised by the girder-user-quota
+// plugin. When an upload would push a user past their storage quota, the
+// plugin rejects it with a ValidationException whose message looks like:
+//   "Upload would exceed file storage quota (need 4.2 GB, only 1.1 GB
+//    available - used 8.9 GB out of 10.0 GB)"
+// (or "Upload exceeded file storage quota (...)" when caught at upload
+// finalization). For uploads performed server-side — large_image transcoding
+// jobs, worker jobs uploading their output — this message only ever appears
+// in the job log, so these helpers are used to recognize it there and turn it
+// into actionable user feedback.
+
+export interface IQuotaExceededInfo {
+  needed: string;
+  available: string;
+  used: string;
+  total: string;
+}
+
+const QUOTA_EXCEEDED_REGEX =
+  /file storage quota\s*\(need (.+?), only (.+?) available - used (.+?) out of (.+?)\)/i;
+
+export function parseQuotaExceededError(
+  text: string,
+): IQuotaExceededInfo | null {
+  const match = text.match(QUOTA_EXCEEDED_REGEX);
+  if (!match) {
+    return null;
+  }
+  const [, needed, available, used, total] = match;
+  return { needed, available, used, total };
+}
+
+// Returns a user-facing message if the text indicates a storage quota breach,
+// or null otherwise.
+export function quotaExceededMessage(text: string): string | null {
+  const info = parseQuotaExceededError(text);
+  if (info) {
+    return (
+      `This operation needs ${info.needed} of storage, but only ` +
+      `${info.available} of your ${info.total} quota remains ` +
+      `(${info.used} used). Free up space by deleting datasets you no ` +
+      `longer need, or upgrade your account for more storage.`
+    );
+  }
+  // Fallback in case the plugin message format changes but still mentions the
+  // quota.
+  if (/file storage quota/i.test(text)) {
+    return (
+      "Your storage quota was exceeded. Free up space by deleting datasets " +
+      "you no longer need, or upgrade your account for more storage."
+    );
+  }
+  return null;
+}

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -387,12 +387,24 @@
     </v-row>
 
     <!-- Progress bar and status for transcoding -->
-    <v-card class="mt-4" v-if="isUploading">
+    <v-card class="mt-4" v-if="isUploading || generationErrorMessage">
       <v-card-text>
         <div class="d-flex align-center mb-2">
-          <div class="text-body-2 text-medium-emphasis mr-3">
+          <div
+            v-if="!generationErrorMessage"
+            class="text-body-2 text-medium-emphasis mr-3"
+          >
             {{ progressStatusText }}
           </div>
+          <v-alert
+            v-else
+            type="error"
+            variant="tonal"
+            density="compact"
+            class="mr-3"
+          >
+            {{ generationErrorMessage }}
+          </v-alert>
           <v-spacer></v-spacer>
           <v-btn
             size="small"
@@ -406,7 +418,7 @@
           </v-btn>
         </div>
         <v-progress-linear
-          v-if="transcodeProgress !== undefined"
+          v-if="transcodeProgress !== undefined && !generationErrorMessage"
           :model-value="transcodeProgress"
           height="20"
           striped
@@ -607,6 +619,7 @@ const emit = defineEmits<{
   (e: "generatedJson", jsonId: string | null, config: any): void;
   (e: "configData", data: any): void;
   (e: "log", logs: string): void;
+  (e: "generationError", message: string): void;
 }>();
 
 const router = useRouter();
@@ -621,6 +634,7 @@ const transcode = ref(false);
 
 const isUploading = ref(false);
 const logs = ref("");
+const generationErrorMessage = ref<string | null>(null);
 
 const showLogDialog = ref(false);
 const showCopySnackbar = ref(false);
@@ -1800,6 +1814,7 @@ async function generateJson(): Promise<string | null> {
 
   logs.value = "";
   isUploading.value = true;
+  generationErrorMessage.value = null;
   transcodeProgress.value = undefined;
   if (transcode.value) {
     progressStatusText.value = "Preparing transcoding";
@@ -1856,7 +1871,14 @@ async function generateJson(): Promise<string | null> {
     return itemId;
   } catch (error) {
     logError("Failed to create multi source:", error);
+    generationErrorMessage.value =
+      error instanceof Error && error.message
+        ? error.message
+        : "Failed to configure the dataset. See the log for details.";
+    emit("generationError", generationErrorMessage.value);
     return null;
+  } finally {
+    isUploading.value = false;
   }
 }
 
@@ -2015,6 +2037,7 @@ defineExpose({
   assignmentItems,
   submitError,
   isRGBAssignmentValid,
+  generationErrorMessage,
   // Methods
   detectColorVsChannels,
   sliceAndJoin,

--- a/src/views/dataset/NewDataset.vue
+++ b/src/views/dataset/NewDataset.vue
@@ -130,6 +130,9 @@
         Cannot create datasets in this location. Please select a subfolder
         within your user directory or group folder.
       </v-alert>
+      <v-alert v-if="storageWarningMessage" variant="tonal" type="warning">
+        {{ storageWarningMessage }}
+      </v-alert>
 
       <div
         class="button-bar d-flex justify-space-between align-center"
@@ -141,6 +144,9 @@
           >
           <span v-if="maxApiKeyFileSize" class="mr-2">
             (using special permission code)</span
+          >
+          <span v-if="storageUsageString" class="mr-2">
+            {{ storageUsageString }}</span
           >
         </div>
         <div>
@@ -221,11 +227,25 @@
         :autoDatasetRoute="false"
         @log="configurationLogs = $event"
         @generatedJson="generationDone"
+        @generationError="generationFailed"
       />
     </template>
 
     <!-- Quick import and auto-processing batch mode -->
     <template v-if="(isQuickImport || isBatchMode) && !showConfigAtTop">
+      <v-alert v-if="processingError" type="error" variant="tonal" class="mb-4">
+        <div class="mb-2">{{ processingError }}</div>
+        <v-btn
+          v-if="configurationLogs"
+          size="small"
+          variant="text"
+          color="info"
+          @click="showLogDialog = true"
+        >
+          <v-icon size="small" start>mdi-text-box-outline</v-icon>
+          View Log
+        </v-btn>
+      </v-alert>
       <template v-if="configuring && datasetId">
         <!-- Mount MultiSourceConfiguration for auto-processing -->
         <multi-source-configuration
@@ -234,6 +254,7 @@
           :autoDatasetRoute="false"
           @log="configurationLogs = $event"
           @generatedJson="generationDone"
+          @generationError="generationFailed"
           class="d-none"
         />
         <!-- Show status text and spinner when auto-processing -->
@@ -392,7 +413,7 @@ import GirderLocationChooser from "@/components/GirderLocationChooser.vue";
 import { UploadManager } from "@girder/components";
 import FileDropzone from "@/components/Files/FileDropzone.vue";
 import { Upload as GirderUpload } from "@/girder/components";
-import { IDataset } from "@/store/model";
+import { IDataset, IUserStorageQuota } from "@/store/model";
 import { triggersPerCategory } from "@/utils/parsing";
 import { formatDate } from "@/utils/date";
 import MultiSourceConfiguration from "./MultiSourceConfiguration.vue";
@@ -533,6 +554,8 @@ const skippedDatasets = ref<number[]>([]);
 const fileSizeExceeded = ref(false);
 const fileSizeExceededMessage = ref("");
 const maxApiKeyFileSize = ref<number | null>(null);
+const processingError = ref<string | null>(null);
+const storageQuota = ref<IUserStorageQuota | null>(null);
 const allFiles = ref<File[]>([]);
 const currentDatasetIndex = ref(0);
 
@@ -624,6 +647,48 @@ const totalSizeString = computed(() => {
 const maxTotalFileSizeString = computed(() =>
   formatSize(maxTotalFileSize.value),
 );
+
+const storageUsageString = computed(() => {
+  const quotaInfo = storageQuota.value;
+  if (!quotaInfo || quotaInfo.quota == null) {
+    return null;
+  }
+  return `Storage used: ${formatSize(quotaInfo.used)} of ${formatSize(
+    quotaInfo.quota,
+  )}`;
+});
+
+// Warn ahead of the upload when the selected files won't fit in the user's
+// remaining storage quota (or when transcoding might not fit, since it
+// creates an additional optimized copy of the dataset). The actual
+// enforcement happens on the backend; this is advance feedback only.
+const storageWarningMessage = computed(() => {
+  const quotaInfo = storageQuota.value;
+  if (!quotaInfo || quotaInfo.quota == null || files.value.length === 0) {
+    return null;
+  }
+  const totalBytes = files.value.reduce((sum, file) => sum + file.size, 0);
+  const remaining = Math.max(0, quotaInfo.quota - quotaInfo.used);
+  if (totalBytes > remaining) {
+    return (
+      `The selected files (${formatSize(totalBytes)}) are larger than your ` +
+      `remaining storage (${formatSize(remaining)} of ` +
+      `${formatSize(quotaInfo.quota)}). The upload will fail unless you ` +
+      `free up space by deleting datasets you no longer need, or upgrade ` +
+      `your account for more storage.`
+    );
+  }
+  if (2 * totalBytes > remaining) {
+    return (
+      `The selected files (${formatSize(totalBytes)}) fit in your ` +
+      `remaining storage (${formatSize(remaining)}), but transcoding ` +
+      `creates an additional optimized copy of the dataset, which may ` +
+      `exceed your storage quota. If the import fails, free up space or ` +
+      `turn off the transcode option.`
+    );
+  }
+  return null;
+});
 
 const isQuickImport = computed((): boolean =>
   store.uploadWorkflow.active
@@ -920,6 +985,7 @@ async function advanceToNextDataset() {
   configuring.value = false;
   configurationLogs.value = "";
   transcodeProgress.value = undefined;
+  processingError.value = null;
 
   if (!store.uploadWorkflow.originalPath) {
     logError(
@@ -955,6 +1021,15 @@ function navigateToCollection() {
       name: "root",
     });
   }
+}
+
+// Called when MultiSourceConfiguration fails to configure/transcode the
+// dataset (e.g. the transcoding job failed because the storage quota was
+// exceeded). Stops the spinner and surfaces the reason to the user.
+function generationFailed(message: string) {
+  configuring.value = false;
+  processingError.value = message;
+  handleBatchError(message);
 }
 
 function handleBatchError(message: string) {
@@ -1241,6 +1316,12 @@ onMounted(async () => {
   }
 
   maxApiKeyFileSize.value = await getMaxUploadSize();
+
+  if (store.girderUser) {
+    storageQuota.value = await store.api.getUserStorageQuota(
+      store.girderUser._id,
+    );
+  }
 });
 
 // --- Expose for tests and external access ---
@@ -1277,6 +1358,11 @@ defineExpose({
   fileSizeExceeded,
   fileSizeExceededMessage,
   maxApiKeyFileSize,
+  processingError,
+  storageQuota,
+  storageUsageString,
+  storageWarningMessage,
+  generationFailed,
   allFiles,
   currentDatasetIndex,
   maxTotalFileSize,


### PR DESCRIPTION
## Problem

On free-tier (quota-limited) accounts, two operations failed with no feedback at all:

- **Time lapse registration**: nothing visibly happened after clicking "compute".
- **Upload with transcode on**: the progress UI froze at "Uploading file of size X", looking like a stalled connection.

Root cause is the same for both: these operations create a new large image **server-side** (the transcode local job, or the registration worker uploading its output). That server-side upload is rejected by the `girder-user-quota` plugin with an HTTP 400 `ValidationException` — `"Upload would exceed file storage quota (need X, only Y available - used Z out of W)"` — so the job goes to ERROR and the quota message lands only in the job log. The browser never saw the 400. On the frontend, job failures were only logged to the console (`jobs.ts` had a success notification but no failure notification), and the transcode failure path ended in `logError` with the spinner/progress bar left running forever.

## Changes

- **`src/utils/quota.ts`** (new, with tests): recognizes the quota plugin's error message in job logs and turns it into a user-facing message with the parsed sizes ("needs 4.2 GB, only 1.1 GB of your 10 GB quota remains…").
- **`src/store/jobs.ts`**: every job that ends in ERROR now creates an error notification (mirroring the existing success notification). If the job log contains a quota breach, the notification is titled "Storage Quota Exceeded" with the specific sizes and advice; otherwise a generic "Job Failed" pointing at the job log. This covers time lapse registration and **all** other worker/local jobs.
- **`src/store/index.ts`** (`addMultiSourceMetadata`): accumulates the transcode job log and, on failure, throws a quota-aware error instead of silently returning null.
- **`src/views/dataset/MultiSourceConfiguration.vue`**: on failure the spinner stops, the frozen progress bar is replaced by an error alert (View Log still available), and a new `generationError` event is emitted.
- **`src/views/dataset/NewDataset.vue`**: handles `generationError` — quick import shows an error alert with a View Log button instead of spinning forever; batch mode routes it into the existing skip/stop batch error dialog. Also adds proactive quota feedback (below).
- **`src/store/GirderAPI.ts`**: new `getUserStorageQuota(userId)` calling `GET /user/{id}/quota` (users can read their own quota; returns null if the endpoint is unavailable).
- **Proactive feedback on the upload page**: shows "Storage used: X of Y" next to the file size limit (only for quota-limited accounts), and a warning alert before uploading when (a) the selected files exceed remaining storage, or (b) they fit but transcoding — which creates an additional optimized copy — might not. The warning is advisory; enforcement stays on the backend.

## How to test

All scenarios need a quota-limited user. On a local stack you can simulate one:

1. Log in as `admin`, then create a test user (or pick an existing non-admin user).
2. Set a small quota on that user (site admin credentials required). Either in the Girder admin UI (user page → Policies → user quota), or via curl:
   ```bash
   # get the admin token
   TOKEN=$(curl -s -u admin:password -X GET "http://localhost:8080/api/v1/user/authentication" | python3 -c "import sys,json; print(json.load(sys.stdin)['authToken']['token'])")
   # set a 200 MB quota on the test user (fileSizeQuota is in bytes)
   curl -s -X PUT "http://localhost:8080/api/v1/user/<TEST_USER_ID>/quota" \
     -H "Girder-Token: $TOKEN" \
     --data-urlencode 'policy={"fileSizeQuota": 209715200, "useQuotaDefault": false}'
   ```
   Pick a quota size relative to your test images — e.g. with a 200 MB quota, a ~120 MB image fits raw but fails when transcoding doubles it.

Then, logged in as the quota-limited user:

**1. Transcode over quota (the "stalled upload" bug)**
- Upload an image whose size fits within the remaining quota but whose transcoded copy won't (e.g. ~120 MB image with ~80 MB of quota headroom), with **Transcode into optimized TIFF** checked.
- Expected: instead of a frozen progress bar, the progress card shows a red error alert saying the storage quota was exceeded with the sizes involved, the spinner stops, and a persistent "Storage Quota Exceeded" notification appears. The View Log button still opens the transcoding log (the raw traceback with the quota message should be at the bottom).
- Also try via **quick import** (drag-and-drop from the homepage) — same expectation, with the error alert replacing the "Configuring the dataset" spinner.
- Also try a **batch upload** of 2+ datasets where one fails: the batch error dialog should appear with the quota message and offer Skip and Continue / Stop and Review.

**2. Worker job over quota (the "nothing happens on compute" bug)**
- With most of the quota already consumed, run the time lapse registration tool (or any worker that writes a new large image) and click Compute.
- Expected: when the job fails, a persistent error notification appears — "Storage Quota Exceeded" with sizes if the quota message is in the job log, otherwise "Job Failed" pointing at the job log. Previously: nothing.
- Sanity check: run any worker on an account with room to spare — you should still get the normal success notification and no error.

**3. Proactive warning before upload**
- On the New Dataset page as the quota-limited user, check that "Storage used: X of Y" appears next to the file size limit.
- Select files larger than the remaining quota → a yellow warning alert should say the upload will fail unless space is freed.
- Select files that fit but are more than half the remaining quota → a softer warning that transcoding may exceed the quota and can be turned off.
- As an unlimited user (e.g. admin with no quota), neither the storage line nor any warning should appear, and everything should behave as before.

**4. Direct upload over quota**
- Select files far larger than the remaining quota and upload anyway (the warning is non-blocking). The upload itself gets the 400 from Girder; verify the upload component reports the failure rather than hanging.

Notes for testing: I verified `pnpm tsc`, `pnpm lint:ci`, and `pnpm test` (2859 tests) pass, but I could not exercise the live UI against a quota-limited backend in this environment — the in-browser scenarios above are exactly what needs human verification. The quota-message parser was written against girder-user-quota 5.0.13's exact message format ("need X, only Y available - used Z out of W"); if production runs a different version, scenario 1's notification should still fall back to the generic quota message (it matches on "file storage quota").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXQXnn1hbsNQpaJgFSRvYv

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXQXnn1hbsNQpaJgFSRvYv)_