### PR TITLE
Route large fully-loaded datasets to the server-paginated annotation list

### DIFF
--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -72,6 +72,10 @@ watch(() => JSON.stringify(annotationListServer.currentFilters), cb);
 
 Watch out for stringify cost on large objects.
 
+**This bug recurs even after being fixed once nearby — grep for it.** A second, separate `watch([...9 getters...], cb, { deep: true })` in the same file (`AnnotationList.vue`'s "server-mode reactive refetch" block, a few lines below the `currentFilters` watch above) had the identical bug, confirmed via live instrumentation firing every 30-80ms with **zero** of the 9 tracked values actually changing. Each spurious firing called `setOptions({ page: 1 })`, silently resetting the server-paginated annotation list's page after every click-to-row navigation — while the *rows* stayed correct (the accompanying debounced refetch never settled long enough to fire), so only the page number/footer/Index column were wrong. This looked exactly like "clicking an annotation goes to the wrong spot in the list," and a plausible-looking `VDataTableServer` `update:options` stale-echo race was chased first as the cause (it even reproduced once) before instrumenting the watcher itself proved it was actually firing with no real change. **When you find and fix one instance of this pattern, `grep -n "deep:\s*true" src` for siblings in the same or related files before considering it fixed — a documented fix comment next to one watcher does not protect a copy-pasted watcher elsewhere.**
+
+Not every `{ deep: true }` is this bug — it only applies when the watched source is a **getter function that rebuilds a fresh object/array on each call** (a Vuex/Pinia getter, a `computed`, or a plain function reading store state). A `ref()`/`reactive()` passed **directly** as the watch source (not wrapped in a function) is the correct, safe use of `deep: true` — Vue tracks its stable identity and only fires on genuine in-place mutations. Don't blanket-remove `deep: true` without checking which case you're in.
+
 ## Vuetify 4 Patterns
 
 ### CSS Cascade Layers

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -72,6 +72,10 @@ watch(() => JSON.stringify(annotationListServer.currentFilters), cb);
 
 Watch out for stringify cost on large objects.
 
+**This bug recurs even after being fixed once nearby — grep for it.** A second, separate `watch([...9 getters...], cb, { deep: true })` in the same file (`AnnotationList.vue`'s "server-mode reactive refetch" block, a few lines below the `currentFilters` watch above) had the identical bug, confirmed via live instrumentation firing every 30-80ms with **zero** of the 9 tracked values actually changing. Each spurious firing called `setOptions({ page: 1 })`, silently resetting the server-paginated annotation list's page after every click-to-row navigation — while the *rows* stayed correct (the accompanying debounced refetch never settled long enough to fire), so only the page number/footer/Index column were wrong. This looked exactly like "clicking an annotation goes to the wrong spot in the list," and a plausible-looking `VDataTableServer` `update:options` stale-echo race was chased first as the cause (it even reproduced once) before instrumenting the watcher itself proved it was actually firing with no real change. **When you find and fix one instance of this pattern, `grep -n "deep:\s*true" src` for siblings in the same or related files before considering it fixed — a documented fix comment next to one watcher does not protect a copy-pasted watcher elsewhere.**
+
+Not every `{ deep: true }` is this bug — it only applies when the watched source is a **getter function that rebuilds a fresh object/array on each call** (a Vuex/Pinia getter, a `computed`, or a plain function reading store state). A `ref()`/`reactive()` passed **directly** as the watch source (not wrapped in a function) is the correct, safe use of `deep: true` — Vue tracks its stable identity and only fires on genuine in-place mutations. Don't blanket-remove `deep: true` without checking which case you're in.
+
 ## Vuetify 4 Patterns
 
 ### CSS Cascade Layers

--- a/src/components/AnnotationBrowser/AnnotationList.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationList.test.ts
@@ -55,6 +55,8 @@ vi.mock("@/store/annotation", () => {
       mockDeleteUnselectedAnnotations(...args),
     deleteAnnotations: (...args: any[]) => mockDeleteAnnotations(...args),
     stubOnlyMode: false,
+    // Small stubThreshold keeps the over-the-limit list guard test fast.
+    visibilityConfig: { stubThreshold: 100 },
     tagSelectedAnnotations: (...args: any[]) =>
       mockTagSelectedAnnotations(...args),
     removeTagsFromSelectedAnnotations: (...args: any[]) =>
@@ -589,7 +591,7 @@ describe("AnnotationList", () => {
 
   function vm_listItemLimit() {
     const wrapper = mountComponent();
-    return (wrapper.vm as any).LIST_ITEM_LIMIT as number;
+    return (wrapper.vm as any).listItemLimit as number;
   }
 
   describe("hover", () => {

--- a/src/components/AnnotationBrowser/AnnotationList.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationList.test.ts
@@ -55,8 +55,6 @@ vi.mock("@/store/annotation", () => {
       mockDeleteUnselectedAnnotations(...args),
     deleteAnnotations: (...args: any[]) => mockDeleteAnnotations(...args),
     stubOnlyMode: false,
-    // Small stubThreshold keeps the over-the-limit list guard test fast.
-    visibilityConfig: { stubThreshold: 100 },
     tagSelectedAnnotations: (...args: any[]) =>
       mockTagSelectedAnnotations(...args),
     removeTagsFromSelectedAnnotations: (...args: any[]) =>
@@ -73,6 +71,11 @@ vi.mock("@/store/annotation", () => {
     annotationCentroids: {} as Record<string, any>,
     annotations: [],
     annotationIdToIdx: {} as Record<string, number>,
+    // Mirrors the real store getter: server list mode in stub-only mode OR when
+    // the fully-loaded set exceeds the list threshold.
+    get isListServerMode() {
+      return this.stubOnlyMode || this.annotations.length > 20000;
+    },
   };
   Object.defineProperty(state, "annotationsForIteration", {
     get() {
@@ -566,6 +569,23 @@ describe("AnnotationList", () => {
     });
   });
 
+  describe("server mode for large fully-loaded datasets", () => {
+    it("uses the client list at or below the threshold in non-stub mode", () => {
+      (annotationStore as any).annotations = new Array(20000);
+      const wrapper = mountComponent();
+      expect((wrapper.vm as any).isServerMode).toBe(false);
+      expect(mockFetchPage).not.toHaveBeenCalled();
+    });
+
+    it("switches to the server list above the threshold in non-stub mode", () => {
+      (annotationStore as any).annotations = new Array(20001);
+      const wrapper = mountComponent();
+      expect((wrapper.vm as any).isServerMode).toBe(true);
+      // onMounted fetches the first server page.
+      expect(mockFetchPage).toHaveBeenCalled();
+    });
+  });
+
   describe("list size guard", () => {
     it("tooManyToList is false and items build normally under the limit", () => {
       const ann = makeAnnotation({ id: "ann1" });
@@ -591,7 +611,7 @@ describe("AnnotationList", () => {
 
   function vm_listItemLimit() {
     const wrapper = mountComponent();
-    return (wrapper.vm as any).listItemLimit as number;
+    return (wrapper.vm as any).LIST_ITEM_LIMIT as number;
   }
 
   describe("hover", () => {

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -949,18 +949,26 @@ watch(localIdFilter, (value) => {
   debouncedServerRefetch();
 });
 
+// Watch a JSON-serialized snapshot rather than the raw getters with
+// { deep: true }: filterStore/propertyStore rebuild fresh array/object
+// references on every genuine mutation, so deep-watching them fires on every
+// unrelated reactive touch, not just real changes (same trap as the
+// currentFilters watch below — see its comment). That spurious refiring calls
+// setOptions({page: 1}) within tens of ms of any real click-to-row
+// navigation, silently resetting the page the user just navigated to.
 watch(
-  [
-    () => filterStore.tagFilter,
-    () => filterStore.propertyFilters,
-    () => filterStore.onlyCurrentFrame,
-    () => filterStore.selectionFilter,
-    () => filterStore.annotationIdFilters,
-    () => propertyStore.displayedPropertyPaths,
-    () => store.xy,
-    () => store.z,
-    () => store.time,
-  ],
+  () =>
+    JSON.stringify([
+      filterStore.tagFilter,
+      filterStore.propertyFilters,
+      filterStore.onlyCurrentFrame,
+      filterStore.selectionFilter,
+      filterStore.annotationIdFilters,
+      propertyStore.displayedPropertyPaths,
+      store.xy,
+      store.z,
+      store.time,
+    ]),
   () => {
     if (!isServerMode.value) {
       return;
@@ -968,7 +976,6 @@ watch(
     annotationListServer.setOptions({ page: 1 });
     debouncedServerRefetch();
   },
-  { deep: true },
 );
 
 // Scope server-mode selection to the current query. The selection set is

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -172,7 +172,8 @@
         class="mb-2"
       >
         Region (ROI) filters are not applied to this list while browsing a large
-        dataset. Use tag, property, or annotation ID filters to narrow results.
+        dataset (they still apply to the image view). Use tag, property, or
+        annotation ID filters to narrow results.
       </v-alert>
       <!-- Per-query feedback (B2): a server /list query can take ~1s+ at scale,
            so show a clear in-flight affordance with the matched count. The
@@ -249,7 +250,7 @@
         <div class="text-body-2">
           Too many to list. Narrow with tag, property, or ROI filters (or the
           annotation ID filter above) to under
-          {{ listItemLimit.toLocaleString() }} to browse them here.
+          {{ LIST_ITEM_LIMIT.toLocaleString() }} to browse them here.
         </div>
       </div>
       <!-- Server mode: backend-paginated table. Uses the SAME item markup.
@@ -341,6 +342,7 @@ import {
   IAnnotationListSort,
   IAnnotationPropertyValues,
   isHydratedAnnotation,
+  ANNOTATION_LIST_SERVER_THRESHOLD,
 } from "@/store/model";
 
 const allHeaders = [
@@ -428,7 +430,7 @@ const isDeletingAnnotations = computed(() => {
 // derived from it): that getter iterates ALL stubs client-side and applies
 // property filters without property values loaded, so it is both expensive and
 // wrong in server mode. Every shared computed has an isServerMode branch.
-const isServerMode = computed(() => annotationStore.stubOnlyMode);
+const isServerMode = computed(() => annotationStore.isListServerMode);
 
 const serverItemsLength = computed(() => annotationListServer.total);
 
@@ -558,19 +560,15 @@ const listedAnnotations = computed(() => {
   return annotations;
 });
 
-// Defensive scale guard, superseded in practice by stubOnlyMode (server mode):
-// stub-only mode activates above the configured stubThreshold, so client mode
-// never holds more than stubThreshold hydrated annotations and this branch is
-// effectively unreachable. Track the live config value (rather than a hardcoded
-// count) so the client list never refuses a dataset that stub mode chose to
-// load fully. Kept as a safety net for any client-mode path that materializes
-// one item per filtered annotation and sorts client-side.
-const listItemLimit = computed(
-  () => annotationStore.visibilityConfig.stubThreshold,
-);
+// Defensive scale guard, unreachable in practice: isListServerMode routes any
+// dataset above this same threshold to the server list, so the client path
+// never holds more than this many annotations. Kept as a safety net for any
+// client-mode path that materializes one item per filtered annotation and
+// sorts client-side (which would hang the tab above this many).
+const LIST_ITEM_LIMIT = ANNOTATION_LIST_SERVER_THRESHOLD;
 
 const tooManyToList = computed(
-  () => listedAnnotations.value.length > listItemLimit.value,
+  () => listedAnnotations.value.length > LIST_ITEM_LIMIT,
 );
 
 const filteredItems = computed(() => {
@@ -900,6 +898,32 @@ watch(
   },
 );
 
+// Server mode can now engage outside stub-only mode (fully-fetched dataset
+// above the list threshold), so the mode can flip mid-session: crossing the
+// threshold by creating/deleting annotations, or the initial fetch completing
+// after mount. Fetch page 1 on entry so the table isn't empty/stale.
+watch(isServerMode, (value) => {
+  if (value) {
+    annotationListServer.setOptions({ page: 1 });
+    annotationListServer.fetchPage();
+  }
+});
+
+// In non-stub server mode the dataset is fully loaded client-side, so
+// annotations can be created/edited/deleted locally (drawing tools, undo)
+// without going through this component's server-aware code paths. The server
+// rows would silently go stale; refetch when the client set changes. Stub mode
+// is excluded: annotations[] is empty there and stub-mode mutations already
+// refetch explicitly where needed.
+watch(
+  () => annotationStore.annotations.length,
+  () => {
+    if (isServerMode.value && !annotationStore.stubOnlyMode) {
+      debouncedServerRefetch();
+    }
+  },
+);
+
 onBeforeUnmount(() => {
   debouncedServerRefetch.cancel();
 });
@@ -1015,7 +1039,7 @@ defineExpose({
   tableItemClass,
   annotationFilteredDialog,
   localIdFilter,
-  listItemLimit,
+  LIST_ITEM_LIMIT,
   tooManyToList,
   addOrRemove,
   page,

--- a/src/components/AnnotationBrowser/AnnotationList.vue
+++ b/src/components/AnnotationBrowser/AnnotationList.vue
@@ -249,7 +249,7 @@
         <div class="text-body-2">
           Too many to list. Narrow with tag, property, or ROI filters (or the
           annotation ID filter above) to under
-          {{ LIST_ITEM_LIMIT.toLocaleString() }} to browse them here.
+          {{ listItemLimit.toLocaleString() }} to browse them here.
         </div>
       </div>
       <!-- Server mode: backend-paginated table. Uses the SAME item markup.
@@ -559,15 +559,18 @@ const listedAnnotations = computed(() => {
 });
 
 // Defensive scale guard, superseded in practice by stubOnlyMode (server mode):
-// server mode activates at maxVisible = 10,000, below this 20,000 threshold, so
-// the client-side `tooManyToList` branch is effectively unreachable now that the
-// server-driven list (Option B) handles large datasets. Kept as a safety net for
-// any client-mode path that materializes one item per filtered annotation and
-// sorts client-side (which would hang the tab above this many).
-const LIST_ITEM_LIMIT = 20000;
+// stub-only mode activates above the configured stubThreshold, so client mode
+// never holds more than stubThreshold hydrated annotations and this branch is
+// effectively unreachable. Track the live config value (rather than a hardcoded
+// count) so the client list never refuses a dataset that stub mode chose to
+// load fully. Kept as a safety net for any client-mode path that materializes
+// one item per filtered annotation and sorts client-side.
+const listItemLimit = computed(
+  () => annotationStore.visibilityConfig.stubThreshold,
+);
 
 const tooManyToList = computed(
-  () => listedAnnotations.value.length > LIST_ITEM_LIMIT,
+  () => listedAnnotations.value.length > listItemLimit.value,
 );
 
 const filteredItems = computed(() => {
@@ -1012,7 +1015,7 @@ defineExpose({
   tableItemClass,
   annotationFilteredDialog,
   localIdFilter,
-  LIST_ITEM_LIMIT,
+  listItemLimit,
   tooManyToList,
   addOrRemove,
   page,

--- a/src/components/AnnotationBrowser/ROIFilters.test.ts
+++ b/src/components/AnnotationBrowser/ROIFilters.test.ts
@@ -12,8 +12,15 @@ vi.mock("@/store/filters", () => ({
   },
 }));
 
+vi.mock("@/store/annotation", () => ({
+  default: {
+    isListServerMode: false,
+  },
+}));
+
 import ROIFilters from "./ROIFilters.vue";
 import filterStore from "@/store/filters";
+import annotationStore from "@/store/annotation";
 
 function mountComponent() {
   return mount(ROIFilters, {});
@@ -36,6 +43,19 @@ describe("ROIFilters", () => {
     const wrapper = mountComponent();
     wrapper.vm.removeFilter("Region Filter 0");
     expect(filterStore.removeROIFilter).toHaveBeenCalledWith("Region Filter 0");
+  });
+
+  it("hides the server-list warning when the list is client-side", () => {
+    (annotationStore as any).isListServerMode = false;
+    const wrapper = mountComponent();
+    expect(wrapper.text()).not.toContain("region filters will not be applied");
+  });
+
+  it("shows the server-list warning when the list is server-paginated", () => {
+    (annotationStore as any).isListServerMode = true;
+    const wrapper = mountComponent();
+    expect(wrapper.text()).toContain("region filters will not be applied");
+    (annotationStore as any).isListServerMode = false;
   });
 
   it("toggleEnabled calls filterStore.toggleRoiFilterEnabled with id", () => {

--- a/src/components/AnnotationBrowser/ROIFilters.vue
+++ b/src/components/AnnotationBrowser/ROIFilters.vue
@@ -8,6 +8,17 @@
     >
       Region filter
     </v-btn>
+    <v-alert
+      v-if="isListServerMode"
+      type="warning"
+      variant="tonal"
+      density="compact"
+      class="mt-2"
+    >
+      This dataset is too large to browse without server-side paging, so region
+      filters will not be applied to the annotation list. They still apply to
+      the image view.
+    </v-alert>
     <div class="d-flex flex-column">
       <div
         v-for="filter in filters"
@@ -37,8 +48,14 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import filterStore from "@/store/filters";
+import annotationStore from "@/store/annotation";
 
 const filters = computed(() => filterStore.roiFilters);
+
+// The server-paginated list cannot apply ROI filters (a client-side polygon
+// test); warn here — where the filters are created — so the user knows before
+// relying on one. The filters still apply to the image view (canvas).
+const isListServerMode = computed(() => annotationStore.isListServerMode);
 
 function addNewFilter() {
   filterStore.newROIFilter();

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -34,6 +34,7 @@ import {
   type THydrationMode,
   type IVisibilityConfig,
   resolveVisibilityConfig,
+  ANNOTATION_LIST_SERVER_THRESHOLD,
 } from "./model";
 import type AnnotationsAPI from "./AnnotationsAPI";
 
@@ -108,6 +109,20 @@ export class Annotations extends VuexModule {
 
   // When true, annotations[] is empty and all metadata lives in annotationStubs.
   stubOnlyMode: boolean = false;
+
+  // Whether the annotation browser list should use the backend-paginated
+  // (server) list instead of materializing a client-side v-data-table. True in
+  // stub-only mode (the client has no full annotations to list) and for
+  // fully-fetched datasets too large to sort/render as client table rows —
+  // possible because stubThreshold (a data-loading knob) can sit well above
+  // the table's materialization limit. Note: the server list cannot apply ROI
+  // filters (a client-side polygon test); the list UI surfaces a warning.
+  get isListServerMode() {
+    return (
+      this.stubOnlyMode ||
+      this.annotations.length > ANNOTATION_LIST_SERVER_THRESHOLD
+    );
+  }
 
   get allAnnotationIds() {
     if (this.stubOnlyMode) {

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1638,6 +1638,13 @@ export interface IVisibilityConfig {
   viewportRefreshFraction: number;
 }
 
+// Annotation count above which the annotation browser list switches to the
+// backend-paginated (server) list, independently of stub-only mode. This is a
+// UI materialization limit (one v-data-table row per annotation, client-side
+// sort), NOT a data-loading concern like stubThreshold — a fully-fetched
+// dataset can still be too large to sort/render as a client-side table.
+export const ANNOTATION_LIST_SERVER_THRESHOLD = 20000;
+
 export const DEFAULT_VISIBILITY_CONFIG: IVisibilityConfig = {
   stubThreshold: 100000,
   maxVisible: 50000,


### PR DESCRIPTION
## Summary

Datasets with more than `ANNOTATION_LIST_SERVER_THRESHOLD` (20,000) annotations now use the backend-paginated annotation list, even when fully loaded (not stub-only). Previously, a fully-fetched dataset in the 20K-100K band would build one `v-data-table` row per annotation and sort the whole array client-side — the same tab-hang the old hardcoded 20K cap was meant to prevent, just reachable again because `stubThreshold` (a data-*loading* knob) can sit well above the list's *materialization* limit.

Also fixes a page-number desync bug found and reproduced live while testing this change: clicking an annotation in a large server-paginated dataset correctly resolved and displayed the right row, but the page number/footer/Index column always reverted to page 1 — making every click look like it navigated to the wrong item.

## Changes

- **`src/store/model.ts` / `src/store/annotation.ts`** — new `ANNOTATION_LIST_SERVER_THRESHOLD` constant (20,000) and `annotationStore.isListServerMode` getter: server list engages in stub-only mode **or** when the fully-loaded annotation count exceeds the threshold.
- **`src/components/AnnotationBrowser/AnnotationList.vue`** — keys server mode off the new getter; fetches page 1 whenever the mode engages mid-session (e.g. crossing the threshold by creating/deleting annotations); refetches (debounced) when local edits change the annotation set in non-stub server mode. The client-side `LIST_ITEM_LIMIT` guard now reverts to the same constant as an unreachable safety net.
- **`src/components/AnnotationBrowser/ROIFilters.vue`** — the server list cannot apply ROI filters (a client-side polygon test), so this now warns when the list is server-paginated that region filters won't apply to the list (they still apply to the image view).
- **Bug fix (`AnnotationList.vue`)** — the "server-mode reactive refetch" watcher (`watch([9 getters...], cb, { deep: true })`) fired on every reactive touch of its dependencies, not just real changes, since `deep: true` skips Vue's value-equality check. Confirmed live it was refiring every 30-80ms with zero of the 9 values actually changing, each time synchronously resetting the list's page back to 1 — clobbering any just-completed click-to-navigate within milliseconds, while the row *content* stayed correct (the accompanying debounced refetch never settled long enough to actually run). Fixed by watching a JSON-serialized snapshot instead, matching the pattern the sibling `currentFilters` watch a few lines below already uses and documents.
- **`nimbus-frontend` skill** — documented this second occurrence of the "deep-watch on a rebuilding getter" pattern, since a fix comment next to one watcher didn't prevent the same bug in a copy-pasted sibling a few lines away. Audited all other `{ deep: true }` watchers in `src/` (5 remaining) and confirmed none share this pattern — they all watch a stable `ref()`/`reactive()` passed directly, which is the correct, safe use of `deep: true`.

## Test plan

- [x] `pnpm tsc`, `pnpm lint`, and `AnnotationList.test.ts` (77 tests) all pass
- [x] Live-verified in browser on a 26,142-annotation dataset ("HCR squares"): clicking annotations at true list positions 21,610 and 21,955 now correctly shows pages 2162/1956 (cross-checked against the backend's own anchor-position lookup) instead of always resetting to page 1
- [x] Confirmed a genuine frame change (`setZ`) still correctly resets the list to page 1, so the watcher's intended behavior is preserved — only the spurious refiring was removed

https://claude.ai/code/session_01N92Zx6tbPbCFczVMQJEmXR
