### PR TITLE
Reposition progress bars above the bottom-left button cluster

### DIFF
--- a/src/components/ProgressBarGroup.vue
+++ b/src/components/ProgressBarGroup.vue
@@ -156,14 +156,30 @@ defineExpose({ hasNotifications, dismissNotification, progressGroups });
 <style lang="scss" scoped>
 .progress-container {
   position: absolute;
-  bottom: 50px;
-  left: 20px;
+  // Sit just above the bottom-left button cluster (palette / lock / fit-to-window
+  // at bottom:10px in ImageViewer) and align to its left edge, so progress bars
+  // and notifications never land on top of the left palette stack (Tools panel).
+  bottom: 56px;
+  left: 10px;
   z-index: 2000;
   display: flex;
   flex-direction: column;
   gap: 8px;
   min-width: 400px;
   max-width: 400px;
+  // Animate the palette-driven shift via transform (GPU-composited, doesn't
+  // trigger layout) rather than `left`.
+  transition: transform 0.2s ease;
+}
+
+/* When the whole left palette stack is open it reaches the bottom-left corner
+   and would cover this stack; slide it right of the column, mirroring the
+   bottom-left button cluster (same 10 px gap to the palette's right edge via
+   `--nimbus-left-palette-clear-x`). `.left-palettes-open` is set on `<v-app>`
+   by App.vue (an ancestor); scoped CSS adds the data-v attribute to the last
+   compound selector only, so the ancestor class still matches. */
+.left-palettes-open .progress-container {
+  transform: translateX(calc(var(--nimbus-left-palette-clear-x) - 10px));
 }
 
 .progress-group {


### PR DESCRIPTION
## Problem

On initial dataset load, the tile-load progress bars (`[Image #1]`, etc.) and notification toasts were anchored at `bottom:50px / left:20px` and never shifted. When the left palette stack was open — the default on load — they landed on top of the **Tools** panel, making them hard to read (and they're transient, so easy to miss).

## Fix

Re-anchor the progress/notification container (`.progress-container` in `ProgressBarGroup.vue`) so it:

- Sits **just above** the bottom-left palette / lock / fit-to-window button cluster (`left:10px`, `bottom:56px`), aligned to the cluster's left edge.
- **Slides right of the left-palette column** when all left palettes are open, mirroring the button cluster exactly via the shared `--nimbus-left-palette-clear-x` variable and the `.left-palettes-open` ancestor class set on `<v-app>`.

The stack now clears the Tools panel and tracks the button cluster in both the open and closed states. This reuses the established pattern already used by `AnnotationActionPanel.vue` and the button cluster in `ImageViewer.vue` (same variable, same scoped-CSS ancestor selector).

## Verification

- Verified live in-browser on the HCR dataset:
  - **All palettes open:** container shifts to `left:446px`, exactly aligned with the palette button's left edge, sitting ~6px above the icons and fully clear of the Tools panel.
  - **Tools closed:** `.left-palettes-open` drops to false and the container snaps back to `left:10px` in lockstep with the buttons.
- `pnpm tsc` — clean
- `pnpm lint:ci` — clean

## Notes

- CSS-only change to one file; no TypeScript/API/store/backend changes.
- The shift gates on all-three-palettes-open (matching the existing button cluster), which is correct because the left palettes are top-anchored and only reach the bottom-left corner when the full stack is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)