### PR TITLE
Let the AI agent set worker parameters, normalized and validated

### DIFF
--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -53,6 +53,24 @@ Store modules still use `vuex-module-decorators` with `@Module`, `@Mutation`, an
 
 For advanced store patterns (routeMapper, form change detection, caching with batch loading): read `references/store-module-patterns.md`
 
+### Driving the AI panel (agent) from the console
+
+To test the Nimbus AI panel (`src/store/aiPanel.ts`, `AiPanel.vue`) end-to-end without clicking, dispatch its actions on the live store. Two traps:
+
+- **The actions register UNNAMESPACED.** `vuex-module-decorators` puts them in the global action map as `sendUserMessage`, `handleAuthenticatedUserChange`, etc. — NOT `aiPanel/sendUserMessage`. A namespaced dispatch is silently dropped (Vuex warns, resolves a no-op promise, nothing runs). Confirm with `store._actions['sendUserMessage']`.
+- `sendUserMessage` runs the whole agent loop and only resolves when the turn ends — **don't await it** if you want to poll progress; fire it and read `store.state.aiPanel.items` / `.running` on a timer.
+
+```js
+const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store;
+store.commit('setAutoApprove', true);              // skip gated-action approval clicks
+await store.dispatch('clearConversationAndStorage'); // full reset (memory + IndexedDB)
+store.dispatch('sendUserMessage', 'Find the nuclei in this image.'); // fire, don't await
+```
+
+**Send exactly once, from a clean/hydrated state.** Two `sendUserMessage`s in quick succession start two overlapping runs that both push to the module-level `wireMessages`, nesting the tool-result blocks (`content: [[tool_result,…]]`). The next request then fails with Anthropic `400 … messages.N.content.0: Input should be an object`. This is not a create/run bug — it's conversation corruption from concurrent turns. (The UI's `send()` and the `sendUserMessage` guard both check `running`, but a stale in-flight run or leftover persisted conversation can still bite; a hard reload + `clearConversationAndStorage` gives a truly clean slate.) Related: `hydrating` (module var) blocks sends until a reloaded conversation finishes restoring — a dispatch right after reload can no-op; wait a beat. `clearConversation()` (no `force`) no-ops while `running`; use `clearConversationAndStorage`.
+
+Agent tool executors live in `src/agent/executors.ts` (`executeAgentTool(name, input, ctx)`), importable in the Vite dev page for isolated testing: `await import('/src/agent/executors.ts?t=' + Date.now())` (the query-bust avoids a stale module cache). Worker tools save parameters under `tool.values.workerInterfaceValues`; `channelCheckboxes` values are `{channelIndex: true}` maps (a `true` value selects — key-presence alone does not).
+
 ### Store Edits Break HMR — Hard-Reload
 
 Editing any `src/store/*.ts` while `pnpm run dev` runs corrupts the store: vuex-module-decorators registers getters at import time with no HMR accept handler, so a hot re-import double-registers → `[vuex] duplicate getter key` cascade and broken state (e.g. annotations stuck at 0). **Hard-reload the page after every store-module edit** before trusting any in-browser behavior. Component `.vue` edits HMR fine — prefer putting temporary instrumentation in `.vue` files.

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -53,6 +53,24 @@ Store modules still use `vuex-module-decorators` with `@Module`, `@Mutation`, an
 
 For advanced store patterns (routeMapper, form change detection, caching with batch loading): read `references/store-module-patterns.md`
 
+### Driving the AI panel (agent) from the console
+
+To test the Nimbus AI panel (`src/store/aiPanel.ts`, `AiPanel.vue`) end-to-end without clicking, dispatch its actions on the live store. Two traps:
+
+- **The actions register UNNAMESPACED.** `vuex-module-decorators` puts them in the global action map as `sendUserMessage`, `handleAuthenticatedUserChange`, etc. — NOT `aiPanel/sendUserMessage`. A namespaced dispatch is silently dropped (Vuex warns, resolves a no-op promise, nothing runs). Confirm with `store._actions['sendUserMessage']`.
+- `sendUserMessage` runs the whole agent loop and only resolves when the turn ends — **don't await it** if you want to poll progress; fire it and read `store.state.aiPanel.items` / `.running` on a timer.
+
+```js
+const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store;
+store.commit('setAutoApprove', true);              // skip gated-action approval clicks
+await store.dispatch('clearConversationAndStorage'); // full reset (memory + IndexedDB)
+store.dispatch('sendUserMessage', 'Find the nuclei in this image.'); // fire, don't await
+```
+
+**Send exactly once, from a clean/hydrated state.** Two `sendUserMessage`s in quick succession start two overlapping runs that both push to the module-level `wireMessages`, nesting the tool-result blocks (`content: [[tool_result,…]]`). The next request then fails with Anthropic `400 … messages.N.content.0: Input should be an object`. This is not a create/run bug — it's conversation corruption from concurrent turns. (The UI's `send()` and the `sendUserMessage` guard both check `running`, but a stale in-flight run or leftover persisted conversation can still bite; a hard reload + `clearConversationAndStorage` gives a truly clean slate.) Related: `hydrating` (module var) blocks sends until a reloaded conversation finishes restoring — a dispatch right after reload can no-op; wait a beat. `clearConversation()` (no `force`) no-ops while `running`; use `clearConversationAndStorage`.
+
+Agent tool executors live in `src/agent/executors.ts` (`executeAgentTool(name, input, ctx)`), importable in the Vite dev page for isolated testing: `await import('/src/agent/executors.ts?t=' + Date.now())` (the query-bust avoids a stale module cache). Worker tools save parameters under `tool.values.workerInterfaceValues`; `channelCheckboxes` values are `{channelIndex: true}` maps (a `true` value selects — key-presence alone does not).
+
 ### Store Edits Break HMR — Hard-Reload
 
 Editing any `src/store/*.ts` while `pnpm run dev` runs corrupts the store: vuex-module-decorators registers getters at import time with no HMR accept handler, so a hot re-import double-registers → `[vuex] duplicate getter key` cascade and broken state (e.g. annotations stuck at 0). **Hard-reload the page after every store-module edit** before trusting any in-browser behavior. Component `.vue` edits HMR fine — prefer putting temporary instrumentation in `.vue` files.

--- a/codebaseDocumentation/AI_PANEL_SPEC.md
+++ b/codebaseDocumentation/AI_PANEL_SPEC.md
@@ -11,7 +11,9 @@
 > **Tool surface as built (~28 tools)** — beyond the original Tier tables
 > below, the following were since implemented and verified live:
 > - **`create_tool`** — add a manual (blob/point/line) or worker tool to the
->   toolset (gated).
+>   toolset (gated). Worker tools accept `workerInterfaceValues`; the resolved
+>   values (overrides on top of interface defaults) are saved on the tool as
+>   `tool.values.workerInterfaceValues`.
 > - **Property chain** — `list_properties`, `create_property` (gated),
 >   `compute_property` (gated), `get_property_values` (summary stats).
 > - **`set_display_options`** (draw/opacity/scalebar/background/connections),

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
@@ -35,6 +35,17 @@ How to work:
   analyzed later, so an untagged tool breaks downstream workflows. It adds the
   tool but does not activate it — use select_tool afterward, or run_worker for
   a worker tool.
+- Workers have parameters (model choice, channels, diameter, thresholds, ...).
+  Before creating a worker tool (create_tool), defining a property
+  (create_property) or running a worker (run_worker), call get_worker_interface
+  for its image and fill in workerInterfaceValues deliberately: always set
+  every required parameter and any channel/select parameter — built-in
+  defaults (channel 0, an empty selection) are usually wrong for the user's
+  dataset. Match channel parameters to the dataset's channel names in the
+  interface state, and pick other values from what the user asked for (e.g.
+  which stain marks nuclei vs cytoplasm). Values passed to create_tool are
+  saved with the tool and used whenever it runs; run_worker can still override
+  them for a single run.
 - You can compute measurements (properties) on annotations. list_properties
   shows what is defined; create_property defines one from a property worker
   (a list_workers image whose isPropertyWorker is true) for a given shape/tags;

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
@@ -41,11 +41,24 @@ How to work:
   for its image and fill in workerInterfaceValues deliberately: always set
   every required parameter and any channel/select parameter — built-in
   defaults (channel 0, an empty selection) are usually wrong for the user's
-  dataset. Match channel parameters to the dataset's channel names in the
-  interface state, and pick other values from what the user asked for (e.g.
-  which stain marks nuclei vs cytoplasm). Values passed to create_tool are
-  saved with the tool and used whenever it runs; run_worker can still override
-  them for a single run.
+  dataset. Pick values from what the user asked for (e.g. which stain marks
+  nuclei vs cytoplasm). Values passed to create_tool are saved with the tool
+  and used whenever it runs; run_worker can still override them for a single
+  run.
+- get_worker_interface returns, alongside each parameter's `type`, a
+  `valueFormats` guide (the exact shape each type's value must take) and a
+  `channels` list (the dataset's channel index↔name mapping). READ BOTH and
+  format every value accordingly. In particular:
+  - "channel": a single 0-based channel index NUMBER (not a name). Look up the
+    index in `channels` — e.g. if DAPI is index 0, pass 0.
+  - "channelCheckboxes" (used for the model's input "slots"): an ARRAY of
+    0-based channel indices to select, e.g. [0] to use the DAPI channel in
+    channels. Do NOT pass the index as a map value like {"0": 0} — that
+    selects nothing and the worker fails with "No channel selected".
+  - "select": exactly one string from that parameter's `items`.
+  - "notes": informational only — never set a value for it.
+  A worker with input slots (e.g. Cellpose "Channel for Slot 1/2/3") needs at
+  least the required first slot set to the right channel.
 - You can compute measurements (properties) on annotations. list_properties
   shows what is defined; create_property defines one from a property worker
   (a list_workers image whose isPropertyWorker is true) for a given shape/tags;

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
@@ -502,7 +502,7 @@
   },
   {
     "name": "create_tool",
-    "description": "Add a new annotation tool to the current collection's toolset (e.g. 'set up a DAPI blob tool'). Provide EITHER manualShape for a hand-drawing tool OR workerImage for an automated worker tool (from list_workers), not both. ALWAYS provide tags: annotations the tool creates carry these tags, and tags are how annotations are filtered, measured and analyzed downstream — an untagged tool produces annotations that are hard to work with. Optionally bind it to a channel with channelName and give it a name. Gated: the user approves before the tool is created. The tool is added but NOT activated; use select_tool to make it active, or run_worker to run a worker tool.",
+    "description": "Add a new annotation tool to the current collection's toolset (e.g. 'set up a DAPI blob tool'). Provide EITHER manualShape for a hand-drawing tool OR workerImage for an automated worker tool (from list_workers), not both. ALWAYS provide tags: annotations the tool creates carry these tags, and tags are how annotations are filtered, measured and analyzed downstream — an untagged tool produces annotations that are hard to work with. For a worker tool, FIRST call get_worker_interface for the image and pass workerInterfaceValues: the values are saved with the tool (used when it is run from the UI, pipelines, or run_worker), and unset parameters fall back to defaults that are often wrong for the dataset. Optionally bind it to a channel with channelName and give it a name. Gated: the user approves before the tool is created. The tool is added but NOT activated; use select_tool to make it active, or run_worker to run a worker tool.",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -527,6 +527,10 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Tags applied to every annotation the tool creates (e.g. [\"nucleus\"]). Always provide at least one tag describing what the tool annotates."
+        },
+        "workerInterfaceValues": {
+          "type": "object",
+          "description": "For worker tools only: parameter values keyed by parameter name, saved with the tool (call get_worker_interface first for the schema). Set every required parameter and any channel/select parameter — their built-in defaults (channel 0, empty selection) are usually wrong for the dataset. Anything omitted uses the interface default."
         }
       },
       "additionalProperties": false

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
@@ -99,7 +99,7 @@
   },
   {
     "name": "get_worker_interface",
-    "description": "Get the parameter schema (name, type, default, min/max) for a worker image. Call before run_worker to know which workerInterfaceValues can be set. May take a few seconds if the interface is not cached. Read-only.",
+    "description": "Get the parameter schema for a worker image: each parameter's name, type, default, and min/max, plus a `valueFormats` guide describing the exact value shape each type expects and a `channels` list giving the dataset's channel index↔name mapping. Call before run_worker or create_tool to know which workerInterfaceValues can be set and how to format them (channels are 0-based indices; channelCheckboxes slots take an array of indices like [0], not a map). May take a few seconds if the interface is not cached. Read-only.",
     "input_schema": {
       "type": "object",
       "properties": {
@@ -530,7 +530,7 @@
         },
         "workerInterfaceValues": {
           "type": "object",
-          "description": "For worker tools only: parameter values keyed by parameter name, saved with the tool (call get_worker_interface first for the schema). Set every required parameter and any channel/select parameter — their built-in defaults (channel 0, empty selection) are usually wrong for the dataset. Anything omitted uses the interface default."
+          "description": "For worker tools only: parameter values keyed by parameter name, saved with the tool (call get_worker_interface first for the schema, valueFormats and channels list). Set every required parameter and any channel/select parameter — their built-in defaults (channel 0, empty selection) are usually wrong for the dataset. Format values per valueFormats: a channel parameter takes a 0-based channel index number; a channelCheckboxes 'slot' takes an array of channel indices to select, e.g. [0] (NOT a map like {\"0\": 0}, which selects nothing); a select takes one of its items. Anything omitted uses the interface default."
         }
       },
       "additionalProperties": false
@@ -575,7 +575,7 @@
         },
         "workerInterfaceValues": {
           "type": "object",
-          "description": "Worker parameter overrides (see get_worker_interface); defaults are used for anything omitted."
+          "description": "Worker parameter overrides, formatted per get_worker_interface's valueFormats (channel = 0-based index number; channelCheckboxes slot = array of indices like [0]; select = one of its items); defaults are used for anything omitted."
         }
       },
       "required": ["propertyWorkerImage", "shape"],
@@ -783,7 +783,7 @@
         "toolId": { "type": "string" },
         "workerInterfaceValues": {
           "type": "object",
-          "description": "Parameter overrides keyed by parameter name.",
+          "description": "Parameter overrides keyed by parameter name, formatted per get_worker_interface's valueFormats (channel = 0-based index number; channelCheckboxes slot = array of indices like [0]; select = one of its items). Unspecified parameters use the tool's saved value or the interface default.",
           "additionalProperties": true
         }
       },

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -646,6 +646,55 @@ describe("executeAgentTool", () => {
     expect(result.type).toBe("segmentation");
   });
 
+  it("saves resolved worker parameters on a created worker tool", async () => {
+    const { buildToolConfiguration } = await import(
+      "@/tools/creation/toolFromCatalog"
+    );
+    // Overrides land on top of interface defaults, so the saved tool has a
+    // concrete value for every parameter slot.
+    mockProperties.getWorkerInterface = vi.fn(() => ({
+      Channel: { type: "channel", required: true },
+      Diameter: { type: "number", default: 30 },
+    }));
+    const { result } = await executeAgentTool(
+      "create_tool",
+      { workerImage: "img:1", workerInterfaceValues: { Channel: 2 } },
+      context,
+    );
+    expect(buildToolConfiguration).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        workerInterfaceValues: { Channel: 2, Diameter: 30 },
+      }),
+    );
+    expect(result.parameters).toEqual({ Channel: 2, Diameter: 30 });
+  });
+
+  it("rejects unknown worker parameters on create_tool", async () => {
+    mockProperties.getWorkerInterface = vi.fn(() => ({
+      Diameter: { type: "number", default: 30 },
+    }));
+    await expect(
+      executeAgentTool(
+        "create_tool",
+        { workerImage: "img:1", workerInterfaceValues: { Bogus: 1 } },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockMain.addToolToConfiguration).not.toHaveBeenCalled();
+  });
+
+  it("rejects workerInterfaceValues on a manual tool", async () => {
+    await expect(
+      executeAgentTool(
+        "create_tool",
+        { manualShape: "point", workerInterfaceValues: { Diameter: 30 } },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockMain.addToolToConfiguration).not.toHaveBeenCalled();
+  });
+
   it("rejects providing both or neither of manualShape/workerImage", async () => {
     await expect(
       executeAgentTool(

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -658,16 +658,59 @@ describe("executeAgentTool", () => {
     }));
     const { result } = await executeAgentTool(
       "create_tool",
-      { workerImage: "img:1", workerInterfaceValues: { Channel: 2 } },
+      { workerImage: "img:1", workerInterfaceValues: { Channel: 1 } },
       context,
     );
     expect(buildToolConfiguration).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        workerInterfaceValues: { Channel: 2, Diameter: 30 },
+        workerInterfaceValues: { Channel: 1, Diameter: 30 },
       }),
     );
-    expect(result.parameters).toEqual({ Channel: 2, Diameter: 30 });
+    expect(result.parameters).toEqual({ Channel: 1, Diameter: 30 });
+  });
+
+  it("resolves a channel name and normalizes channelCheckboxes", async () => {
+    // The mock dataset has channels 0 (DAPI) and 1 (Cy3). The agent may pass a
+    // channel name, an index, or an array; all normalize to the on-disk shape.
+    mockProperties.getWorkerInterface = vi.fn(() => ({
+      Channel: { type: "channel", required: true },
+      "Channel for Slot 1": { type: "channelCheckboxes" },
+    }));
+    const { result } = await executeAgentTool(
+      "create_tool",
+      {
+        workerImage: "img:1",
+        workerInterfaceValues: {
+          Channel: "DAPI",
+          "Channel for Slot 1": ["DAPI"],
+        },
+      },
+      context,
+    );
+    expect(result.parameters).toEqual({
+      Channel: 0,
+      "Channel for Slot 1": { 0: true, 1: false },
+    });
+  });
+
+  it("rejects a channelCheckboxes value that selects nothing", async () => {
+    // The original bug: {"0": 0} means "channel 0" to the model but 0 is falsy,
+    // so no channel is selected and the worker fails with "No channel selected".
+    mockProperties.getWorkerInterface = vi.fn(() => ({
+      "Channel for Slot 1": { type: "channelCheckboxes" },
+    }));
+    await expect(
+      executeAgentTool(
+        "create_tool",
+        {
+          workerImage: "img:1",
+          workerInterfaceValues: { "Channel for Slot 1": { 0: 0 } },
+        },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockMain.addToolToConfiguration).not.toHaveBeenCalled();
   });
 
   it("rejects unknown worker parameters on create_tool", async () => {

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -1329,6 +1329,7 @@ const registry: { [name: string]: IAgentToolEntry } = {
       channelName?: string;
       name?: string;
       tags?: string[];
+      workerInterfaceValues?: IWorkerInterfaceValues;
     }) => {
       requireLogin();
       if (!main.configuration) {
@@ -1339,6 +1340,11 @@ const registry: { [name: string]: IAgentToolEntry } = {
       if (hasManual === hasWorker) {
         throw new ToolExecutionError(
           "Provide exactly one of manualShape or workerImage",
+        );
+      }
+      if (hasManual && input.workerInterfaceValues != null) {
+        throw new ToolExecutionError(
+          "workerInterfaceValues only applies to worker tools",
         );
       }
       let entry;
@@ -1384,10 +1390,21 @@ const registry: { [name: string]: IAgentToolEntry } = {
           }`,
         );
       }
+      // Worker tools are saved with fully-resolved parameter values (model
+      // overrides on top of interface defaults), so the tool is runnable from
+      // the UI and pipelines with the intended parameters, not blank slots.
+      let workerInterfaceValues: IWorkerInterfaceValues | undefined;
+      if (input.workerImage != null) {
+        workerInterfaceValues = await resolveWorkerInterfaceValues(
+          input.workerImage,
+          input.workerInterfaceValues ?? {},
+        );
+      }
       const tool = buildToolConfiguration(entry, {
         channelName: input.channelName,
         name: input.name,
         tags: input.tags,
+        workerInterfaceValues,
       });
       if (!tool) {
         throw new ToolExecutionError(
@@ -1402,6 +1419,7 @@ const registry: { [name: string]: IAgentToolEntry } = {
           type: tool.type,
           channelName: input.channelName ?? null,
           tags: input.tags ?? [],
+          parameters: workerInterfaceValues ?? null,
         },
       };
     },
@@ -2094,7 +2112,14 @@ export function describeAgentToolCall(name: string, input: any): string {
         Array.isArray(input?.tags) && input.tags.length
           ? ` tagging ${joinList(input.tags)}`
           : "";
-      return `Set up a ${kind} tool${channel}${tags}`;
+      const parameterNames =
+        typeof input?.workerInterfaceValues === "object"
+          ? Object.keys(input.workerInterfaceValues ?? {})
+          : [];
+      const parameters = parameterNames.length
+        ? ` (setting ${joinList(parameterNames)})`
+        : "";
+      return `Set up a ${kind} tool${channel}${tags}${parameters}`;
     }
     case "set_display_options":
       return "Change viewer display options";

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -25,7 +25,12 @@ import {
   captureInterfaceScreenshot,
   captureViewportScreenshot,
 } from "@/utils/interfaceCapture";
-import { getDefault } from "@/utils/workerInterface";
+import {
+  getDefault,
+  normalizeWorkerInterfaceValue,
+  WORKER_INTERFACE_VALUE_FORMATS,
+  type IChannelContext,
+} from "@/utils/workerInterface";
 import { registerPlot, type IAgentPlot } from "./plotRegistry";
 import {
   MAX_BOX_POINTS,
@@ -364,10 +369,26 @@ async function resolveWorkerInterfaceValues(
         `Valid parameters: ${Object.keys(workerInterface).join(", ")}`,
     );
   }
+  const channelContext = buildChannelContext();
   const values: IWorkerInterfaceValues = {};
   for (const id in workerInterface) {
     if (id in overrides) {
-      values[id] = overrides[id];
+      // Normalize the agent-supplied value into the canonical shape (channel
+      // names/indices -> the {index: boolean} map the worker expects, etc.).
+      // A bad value throws here as a ToolExecutionError so the agent gets
+      // actionable feedback instead of saving a tool that fails at run time.
+      try {
+        values[id] = normalizeWorkerInterfaceValue(
+          workerInterface[id],
+          overrides[id],
+          channelContext,
+          id,
+        );
+      } catch (error: any) {
+        throw new ToolExecutionError(
+          error?.message ?? `Invalid value for worker parameter "${id}"`,
+        );
+      }
     } else if (id in saved) {
       values[id] = saved[id];
     } else {
@@ -378,6 +399,23 @@ async function resolveWorkerInterfaceValues(
     }
   }
   return values;
+}
+
+// Channel index<->name context for resolving agent-supplied channel references
+// against the open dataset. Empty when no dataset is open (channel refs then
+// pass through unvalidated).
+function buildChannelContext(): IChannelContext {
+  const dataset = main.dataset;
+  const nameToIndex = new Map<string, number>();
+  if (dataset) {
+    for (const channel of dataset.channels) {
+      const name = dataset.channelNames.get(channel);
+      if (name) {
+        nameToIndex.set(name.toLowerCase(), channel);
+      }
+    }
+  }
+  return { channels: dataset ? dataset.channels.slice() : [], nameToIndex };
 }
 
 // The viewer display options the agent can toggle (all local view state,
@@ -784,7 +822,32 @@ const registry: { [name: string]: IAgentToolEntry } = {
           `Could not fetch the interface for worker "${input.image}"`,
         );
       }
-      return { result: { image: input.image, interface: workerInterface } };
+      // The interface only carries a `type` per parameter, not the shape its
+      // value must take — so the agent gets a per-type format guide (limited to
+      // the types actually present) plus the dataset's channel index↔name list,
+      // which it needs to fill channel parameters correctly.
+      const typesPresent = new Set(
+        Object.values(workerInterface).map((element) => element.type),
+      );
+      const valueFormats: { [type: string]: string } = {};
+      for (const type of typesPresent) {
+        valueFormats[type] = WORKER_INTERFACE_VALUE_FORMATS[type];
+      }
+      const dataset = main.dataset;
+      const channels = dataset
+        ? dataset.channels.map((channel) => ({
+            index: channel,
+            name: dataset.channelNames.get(channel) ?? `Channel ${channel}`,
+          }))
+        : [];
+      return {
+        result: {
+          image: input.image,
+          interface: workerInterface,
+          valueFormats,
+          channels,
+        },
+      };
     },
   },
 

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -402,8 +402,9 @@ async function resolveWorkerInterfaceValues(
 }
 
 // Channel index<->name context for resolving agent-supplied channel references
-// against the open dataset. Empty when no dataset is open (channel refs then
-// pass through unvalidated).
+// against the open dataset. Empty when no dataset is open: index references
+// then pass through unvalidated, and name references can't resolve at all
+// (create_tool does not require a dataset, so this path is reachable).
 function buildChannelContext(): IChannelContext {
   const dataset = main.dataset;
   const nameToIndex = new Map<string, number>();

--- a/src/tools/creation/toolFromCatalog.ts
+++ b/src/tools/creation/toolFromCatalog.ts
@@ -6,6 +6,7 @@ import {
   IToolConfiguration,
   IToolSuggestionCatalogEntry,
   IToolTemplate,
+  IWorkerInterfaceValues,
 } from "@/store/model";
 import { IAnnotationSetup } from "@/tools/creation/templates/AnnotationConfiguration.vue";
 
@@ -118,6 +119,9 @@ export interface IBuildToolOptions {
   name?: string;
   // Tags applied to annotations the tool creates.
   tags?: string[];
+  // Worker parameter values saved with the tool (worker entries only); read
+  // back by run_worker and submitAnnotationWorkerJob as the saved values.
+  workerInterfaceValues?: IWorkerInterfaceValues;
 }
 
 // Build a concrete IToolConfiguration from a catalog entry.
@@ -156,6 +160,9 @@ export function buildToolConfiguration(
         image: { image: entry.image },
         annotation: annotationSetup,
         jobDateTag: false,
+        ...(options.workerInterfaceValues
+          ? { workerInterfaceValues: options.workerInterfaceValues }
+          : {}),
       },
     };
   }

--- a/src/utils/workerInterface.test.ts
+++ b/src/utils/workerInterface.test.ts
@@ -55,12 +55,36 @@ describe("normalizeWorkerInterfaceValue — channelCheckboxes", () => {
     // The bug: model wrote {"0": 0} meaning channel 0, but 0 is falsy.
     expect(() =>
       normalizeWorkerInterfaceValue(checkboxes, { 0: 0 } as any, ctx, "Slot 1"),
-    ).toThrow(/no channel is selected/);
+    ).toThrow(/used as a map value/);
+  });
+
+  it("throws on an index-as-value even when another channel is selected", () => {
+    expect(() =>
+      normalizeWorkerInterfaceValue(
+        checkboxes,
+        { 0: 0, 1: true } as any,
+        ctx,
+        "Slot 1",
+      ),
+    ).toThrow(/used as a map value/);
   });
 
   it("allows an explicit empty selection for optional slots", () => {
     expect(
       normalizeWorkerInterfaceValue(checkboxes, [], ctx, "Slot 2"),
+    ).toEqual({ 0: false, 1: false, 2: false, 3: false });
+  });
+
+  it("allows an explicit all-false map (the canonical UI shape)", () => {
+    // Distinct from {"0": 0}: boolean false is a deliberate "not selected", so
+    // an optional slot the agent explicitly cleared must not error.
+    expect(
+      normalizeWorkerInterfaceValue(
+        checkboxes,
+        { 0: false, 1: false, 2: false, 3: false } as any,
+        ctx,
+        "Slot 2",
+      ),
     ).toEqual({ 0: false, 1: false, 2: false, 3: false });
   });
 
@@ -99,17 +123,28 @@ describe("normalizeWorkerInterfaceValue — other types", () => {
     );
   });
 
-  it("coerces checkbox values to boolean", () => {
+  it("accepts real booleans for checkbox but rejects stringy ones", () => {
     const el = { type: "checkbox" } as TWorkerInterfaceElement;
-    expect(normalizeWorkerInterfaceValue(el, 1 as any, ctx, "Flag")).toBe(true);
+    expect(normalizeWorkerInterfaceValue(el, true, ctx, "Flag")).toBe(true);
+    expect(normalizeWorkerInterfaceValue(el, false, ctx, "Flag")).toBe(false);
+    // Boolean("false") is true — coercing here would enable the option.
+    for (const bad of ["false", "true", 1, 0, null]) {
+      expect(() =>
+        normalizeWorkerInterfaceValue(el, bad as any, ctx, "Flag"),
+      ).toThrow(/expected true or false/);
+    }
   });
 
-  it("rejects a non-numeric number value", () => {
+  it("rejects values that would silently coerce to a wrong number", () => {
     const el = { type: "number" } as TWorkerInterfaceElement;
     expect(normalizeWorkerInterfaceValue(el, 5, ctx, "Diameter")).toBe(5);
-    expect(() =>
-      normalizeWorkerInterfaceValue(el, "abc" as any, ctx, "Diameter"),
-    ).toThrow(/expected a number/);
+    expect(normalizeWorkerInterfaceValue(el, "7.5" as any, ctx, "D")).toBe(7.5);
+    // Number("") / Number(" ") / Number([]) are all 0, and Number(null) is 0.
+    for (const bad of ["abc", "", "   ", [], null, Infinity]) {
+      expect(() =>
+        normalizeWorkerInterfaceValue(el, bad as any, ctx, "Diameter"),
+      ).toThrow(/expected a number/);
+    }
   });
 });
 

--- a/src/utils/workerInterface.test.ts
+++ b/src/utils/workerInterface.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  IChannelContext,
+  normalizeWorkerInterfaceValue,
+  WORKER_INTERFACE_VALUE_FORMATS,
+} from "@/utils/workerInterface";
+import { TWorkerInterfaceElement } from "@/store/model";
+
+// DAPI=0, FITC=1, TRITC=2, Cy5=3 — mirrors the sample HCR dataset.
+const ctx: IChannelContext = {
+  channels: [0, 1, 2, 3],
+  nameToIndex: new Map([
+    ["dapi", 0],
+    ["fitc", 1],
+    ["tritc", 2],
+    ["cy5", 3],
+  ]),
+};
+
+const checkboxes: TWorkerInterfaceElement = {
+  type: "channelCheckboxes",
+} as TWorkerInterfaceElement;
+
+describe("normalizeWorkerInterfaceValue — channelCheckboxes", () => {
+  it("normalizes an array of indices to a full boolean map", () => {
+    expect(
+      normalizeWorkerInterfaceValue(checkboxes, [0], ctx, "Slot 1"),
+    ).toEqual({ 0: true, 1: false, 2: false, 3: false });
+  });
+
+  it("resolves channel names to indices", () => {
+    expect(
+      normalizeWorkerInterfaceValue(checkboxes, ["DAPI"], ctx, "Slot 1"),
+    ).toEqual({ 0: true, 1: false, 2: false, 3: false });
+  });
+
+  it("accepts a single index number", () => {
+    expect(normalizeWorkerInterfaceValue(checkboxes, 2, ctx, "Slot 1")).toEqual(
+      { 0: false, 1: false, 2: true, 3: false },
+    );
+  });
+
+  it("respects a canonical {index: boolean} map", () => {
+    expect(
+      normalizeWorkerInterfaceValue(
+        checkboxes,
+        { 0: true, 1: false } as any,
+        ctx,
+        "Slot 1",
+      ),
+    ).toEqual({ 0: true, 1: false, 2: false, 3: false });
+  });
+
+  it("throws on the classic {index: index} mistake (all falsy)", () => {
+    // The bug: model wrote {"0": 0} meaning channel 0, but 0 is falsy.
+    expect(() =>
+      normalizeWorkerInterfaceValue(checkboxes, { 0: 0 } as any, ctx, "Slot 1"),
+    ).toThrow(/no channel is selected/);
+  });
+
+  it("allows an explicit empty selection for optional slots", () => {
+    expect(
+      normalizeWorkerInterfaceValue(checkboxes, [], ctx, "Slot 2"),
+    ).toEqual({ 0: false, 1: false, 2: false, 3: false });
+  });
+
+  it("throws on an unknown channel index", () => {
+    expect(() =>
+      normalizeWorkerInterfaceValue(checkboxes, [9], ctx, "Slot 1"),
+    ).toThrow(/does not exist/);
+  });
+
+  it("throws on an unknown channel name", () => {
+    expect(() =>
+      normalizeWorkerInterfaceValue(checkboxes, ["GFP"], ctx, "Slot 1"),
+    ).toThrow(/unknown channel/);
+  });
+});
+
+describe("normalizeWorkerInterfaceValue — other types", () => {
+  it("resolves a channel name to an index for the channel type", () => {
+    const el = { type: "channel", required: true } as TWorkerInterfaceElement;
+    expect(normalizeWorkerInterfaceValue(el, "Cy5", ctx, "Channel")).toBe(3);
+  });
+
+  it("passes a valid channel index through unchanged", () => {
+    const el = { type: "channel" } as TWorkerInterfaceElement;
+    expect(normalizeWorkerInterfaceValue(el, 1, ctx, "Channel")).toBe(1);
+  });
+
+  it("validates select options", () => {
+    const el = {
+      type: "select",
+      items: ["a", "b"],
+    } as TWorkerInterfaceElement;
+    expect(normalizeWorkerInterfaceValue(el, "a", ctx, "Model")).toBe("a");
+    expect(() => normalizeWorkerInterfaceValue(el, "c", ctx, "Model")).toThrow(
+      /not a valid option/,
+    );
+  });
+
+  it("coerces checkbox values to boolean", () => {
+    const el = { type: "checkbox" } as TWorkerInterfaceElement;
+    expect(normalizeWorkerInterfaceValue(el, 1 as any, ctx, "Flag")).toBe(true);
+  });
+
+  it("rejects a non-numeric number value", () => {
+    const el = { type: "number" } as TWorkerInterfaceElement;
+    expect(normalizeWorkerInterfaceValue(el, 5, ctx, "Diameter")).toBe(5);
+    expect(() =>
+      normalizeWorkerInterfaceValue(el, "abc" as any, ctx, "Diameter"),
+    ).toThrow(/expected a number/);
+  });
+});
+
+describe("WORKER_INTERFACE_VALUE_FORMATS", () => {
+  it("documents every worker-interface type", () => {
+    for (const type of [
+      "number",
+      "notes",
+      "text",
+      "tags",
+      "layer",
+      "select",
+      "channel",
+      "channelCheckboxes",
+      "checkbox",
+    ]) {
+      expect(WORKER_INTERFACE_VALUE_FORMATS[type as never]).toBeTruthy();
+    }
+  });
+});

--- a/src/utils/workerInterface.ts
+++ b/src/utils/workerInterface.ts
@@ -1,4 +1,8 @@
-import { TWorkerInterfaceType, TWorkerInterfaceValue } from "@/store/model";
+import {
+  TWorkerInterfaceElement,
+  TWorkerInterfaceType,
+  TWorkerInterfaceValue,
+} from "@/store/model";
 
 export function getDefault(
   type: TWorkerInterfaceType,
@@ -34,5 +38,197 @@ export function getDefault(
 
     case "checkbox":
       return false;
+  }
+}
+
+// Human-readable description of the value each worker-interface parameter type
+// expects. Surfaced to the AI agent by get_worker_interface so it fills every
+// parameter in the right shape (see AI_PANEL_SPEC.md). The wording assumes the
+// agent also has the dataset's channel index↔name list for channel params.
+export const WORKER_INTERFACE_VALUE_FORMATS: Record<
+  TWorkerInterfaceType,
+  string
+> = {
+  number: "A number. Respect this parameter's min/max/step if given.",
+  notes:
+    "Informational text shown to the user — NOT an input. Do not set a value " +
+    "for a notes parameter.",
+  text: "A string.",
+  tags: 'An array of tag strings, e.g. ["nucleus"].',
+  layer: "A layer id string, or null for none.",
+  select:
+    'Exactly one of the strings listed in this parameter\'s "items" array.',
+  channel:
+    'A single 0-based channel index number (see the "channels" list for the ' +
+    "index↔name mapping). Pass a number, not a channel name.",
+  channelCheckboxes:
+    "The channel(s) to use for this slot, as an ARRAY of 0-based channel " +
+    'indices — e.g. [0] selects the first channel (see the "channels" list ' +
+    "for the index↔name mapping). To select the DAPI channel, pass the index " +
+    "DAPI has in that list. You may also pass an object mapping channel index " +
+    'to true/false, e.g. {"0": true, "1": false}, but the value MUST be true ' +
+    "to select a channel — the key alone does not select it.",
+  checkbox: "A boolean: true or false.",
+};
+
+// Context for resolving channel references (indices or names) against the open
+// dataset. `channels` is every channel index present (e.g. [0, 1, 2, 3]);
+// `nameToIndex` maps a lower-cased channel name to its index.
+export interface IChannelContext {
+  channels: number[];
+  nameToIndex: Map<string, number>;
+}
+
+// Resolve one channel reference — a 0-based index number, a numeric string, or
+// a channel name — to a channel index. Throws a descriptive Error when it does
+// not correspond to a channel in the dataset.
+function resolveChannelRef(
+  ref: unknown,
+  ctx: IChannelContext,
+  paramId: string,
+): number {
+  const available =
+    ctx.channels.length > 0
+      ? ` Available channels: ${ctx.channels
+          .map((c) => {
+            const name = [...ctx.nameToIndex.entries()].find(
+              ([, idx]) => idx === c,
+            )?.[0];
+            return name ? `${c} (${name})` : `${c}`;
+          })
+          .join(", ")}.`
+      : "";
+  const validate = (index: number): number => {
+    if (ctx.channels.length > 0 && !ctx.channels.includes(index)) {
+      throw new Error(
+        `"${paramId}": channel index ${index} does not exist in this ` +
+          `dataset.${available}`,
+      );
+    }
+    return index;
+  };
+  if (typeof ref === "number") {
+    if (!Number.isInteger(ref)) {
+      throw new Error(
+        `"${paramId}": channel index ${ref} must be a whole number.`,
+      );
+    }
+    return validate(ref);
+  }
+  if (typeof ref === "string") {
+    const trimmed = ref.trim();
+    if (/^\d+$/.test(trimmed)) {
+      return validate(parseInt(trimmed, 10));
+    }
+    const byName = ctx.nameToIndex.get(trimmed.toLowerCase());
+    if (byName == null) {
+      throw new Error(`"${paramId}": unknown channel "${ref}".${available}`);
+    }
+    return byName;
+  }
+  throw new Error(
+    `"${paramId}": expected a channel index or name, got ${JSON.stringify(
+      ref,
+    )}.`,
+  );
+}
+
+// Normalize a value the agent provided for one worker-interface parameter into
+// the canonical shape the worker and UI expect. Channel selections may be given
+// as indices, names, or arrays and are normalized to the on-disk forms (a
+// number for `channel`, a {index: boolean} map for `channelCheckboxes`). Throws
+// a descriptive Error for values that can't be made valid, so the agent gets
+// actionable feedback instead of silently producing a broken tool.
+export function normalizeWorkerInterfaceValue(
+  element: TWorkerInterfaceElement,
+  value: unknown,
+  ctx: IChannelContext,
+  paramId: string,
+): TWorkerInterfaceValue {
+  switch (element.type) {
+    case "channel": {
+      if (value == null) {
+        if (element.required) {
+          throw new Error(`"${paramId}": a channel is required.`);
+        }
+        return null;
+      }
+      return resolveChannelRef(value, ctx, paramId);
+    }
+    case "channelCheckboxes": {
+      const selected = new Set<number>();
+      let provided = false;
+      if (value == null) {
+        provided = false;
+      } else if (Array.isArray(value)) {
+        provided = value.length > 0;
+        for (const ref of value) {
+          selected.add(resolveChannelRef(ref, ctx, paramId));
+        }
+      } else if (typeof value === "number" || typeof value === "string") {
+        provided = true;
+        selected.add(resolveChannelRef(value, ctx, paramId));
+      } else if (typeof value === "object") {
+        const entries = Object.entries(value as Record<string, unknown>);
+        provided = entries.length > 0;
+        for (const [key, selectedFlag] of entries) {
+          if (selectedFlag) {
+            selected.add(resolveChannelRef(key, ctx, paramId));
+          }
+        }
+      } else {
+        throw new Error(
+          `"${paramId}": expected an array of channel indices, e.g. [0].`,
+        );
+      }
+      // A value was supplied but nothing ended up selected — almost always the
+      // agent passed the channel index as the map value (e.g. {"0": 0}) instead
+      // of true. Surface it so the agent retries rather than saving a tool that
+      // fails at run time with "No channel selected".
+      if (provided && selected.size === 0) {
+        throw new Error(
+          `"${paramId}": you provided a value but no channel is selected. ` +
+            "Pass the channel indices to select as an array, e.g. [0] for the " +
+            "first channel.",
+        );
+      }
+      const result: { [channel: number]: boolean } = {};
+      const channels =
+        ctx.channels.length > 0 ? ctx.channels : [...selected].sort();
+      for (const channel of channels) {
+        result[channel] = selected.has(channel);
+      }
+      for (const channel of selected) {
+        if (!(channel in result)) {
+          result[channel] = true;
+        }
+      }
+      return result;
+    }
+    case "select": {
+      if (value == null) {
+        return getDefault(element.type, element.default) ?? "";
+      }
+      const items = element.items ?? [];
+      if (items.length > 0 && !items.includes(value as string)) {
+        throw new Error(
+          `"${paramId}": "${value}" is not a valid option. Choose one of: ` +
+            `${items.join(", ")}.`,
+        );
+      }
+      return value as TWorkerInterfaceValue;
+    }
+    case "checkbox":
+      return Boolean(value);
+    case "number": {
+      const asNumber = typeof value === "number" ? value : Number(value);
+      if (Number.isNaN(asNumber)) {
+        throw new Error(`"${paramId}": expected a number, got ${value}.`);
+      }
+      return asNumber;
+    }
+    default:
+      // text, notes, tags, layer — pass through unchanged.
+      return value as TWorkerInterfaceValue;
   }
 }

--- a/src/utils/workerInterface.ts
+++ b/src/utils/workerInterface.ts
@@ -65,9 +65,10 @@ export const WORKER_INTERFACE_VALUE_FORMATS: Record<
     "The channel(s) to use for this slot, as an ARRAY of 0-based channel " +
     'indices — e.g. [0] selects the first channel (see the "channels" list ' +
     "for the index↔name mapping). To select the DAPI channel, pass the index " +
-    "DAPI has in that list. You may also pass an object mapping channel index " +
-    'to true/false, e.g. {"0": true, "1": false}, but the value MUST be true ' +
-    "to select a channel — the key alone does not select it.",
+    "DAPI has in that list; pass [] to select nothing (optional slots only). " +
+    "An object mapping channel index to a true/false BOOLEAN also works, e.g. " +
+    '{"0": true, "1": false} — but the value must be literally true to select ' +
+    'a channel: {"0": 0} selects nothing and is rejected.',
   checkbox: "A boolean: true or false.",
 };
 
@@ -79,6 +80,23 @@ export interface IChannelContext {
   nameToIndex: Map<string, number>;
 }
 
+// "Available channels: 0 (dapi), 1 (fitc)." for error messages, or "" when the
+// dataset's channels are unknown. Called only on failure paths — building it
+// eagerly would walk the channel list on every successful resolution.
+function describeAvailableChannels(ctx: IChannelContext): string {
+  if (ctx.channels.length === 0) {
+    return "";
+  }
+  const indexToName = new Map(
+    [...ctx.nameToIndex.entries()].map(([name, index]) => [index, name]),
+  );
+  const described = ctx.channels.map((channel) => {
+    const name = indexToName.get(channel);
+    return name ? `${channel} (${name})` : `${channel}`;
+  });
+  return ` Available channels: ${described.join(", ")}.`;
+}
+
 // Resolve one channel reference — a 0-based index number, a numeric string, or
 // a channel name — to a channel index. Throws a descriptive Error when it does
 // not correspond to a channel in the dataset.
@@ -87,22 +105,11 @@ function resolveChannelRef(
   ctx: IChannelContext,
   paramId: string,
 ): number {
-  const available =
-    ctx.channels.length > 0
-      ? ` Available channels: ${ctx.channels
-          .map((c) => {
-            const name = [...ctx.nameToIndex.entries()].find(
-              ([, idx]) => idx === c,
-            )?.[0];
-            return name ? `${c} (${name})` : `${c}`;
-          })
-          .join(", ")}.`
-      : "";
   const validate = (index: number): number => {
     if (ctx.channels.length > 0 && !ctx.channels.includes(index)) {
       throw new Error(
         `"${paramId}": channel index ${index} does not exist in this ` +
-          `dataset.${available}`,
+          `dataset.${describeAvailableChannels(ctx)}`,
       );
     }
     return index;
@@ -122,7 +129,10 @@ function resolveChannelRef(
     }
     const byName = ctx.nameToIndex.get(trimmed.toLowerCase());
     if (byName == null) {
-      throw new Error(`"${paramId}": unknown channel "${ref}".${available}`);
+      throw new Error(
+        `"${paramId}": unknown channel "${ref}".` +
+          describeAvailableChannels(ctx),
+      );
     }
     return byName;
   }
@@ -157,23 +167,28 @@ export function normalizeWorkerInterfaceValue(
     }
     case "channelCheckboxes": {
       const selected = new Set<number>();
-      let provided = false;
+      // Set when a map value is falsy but NOT boolean false (e.g. {"0": 0}):
+      // the agent put the channel index in the value slot, so it meant to
+      // select that channel and selected nothing. An explicit all-`false` map
+      // (the canonical UI shape) and an empty array are deliberate "select
+      // nothing" — legitimate for the optional slots — and must not throw.
+      let indexUsedAsValue = false;
       if (value == null) {
-        provided = false;
+        // Treated as "nothing selected"; the caller omitted the parameter.
       } else if (Array.isArray(value)) {
-        provided = value.length > 0;
         for (const ref of value) {
           selected.add(resolveChannelRef(ref, ctx, paramId));
         }
       } else if (typeof value === "number" || typeof value === "string") {
-        provided = true;
         selected.add(resolveChannelRef(value, ctx, paramId));
       } else if (typeof value === "object") {
-        const entries = Object.entries(value as Record<string, unknown>);
-        provided = entries.length > 0;
-        for (const [key, selectedFlag] of entries) {
-          if (selectedFlag) {
+        for (const [key, isSelected] of Object.entries(
+          value as Record<string, unknown>,
+        )) {
+          if (isSelected) {
             selected.add(resolveChannelRef(key, ctx, paramId));
+          } else if (isSelected !== false) {
+            indexUsedAsValue = true;
           }
         }
       } else {
@@ -181,33 +196,29 @@ export function normalizeWorkerInterfaceValue(
           `"${paramId}": expected an array of channel indices, e.g. [0].`,
         );
       }
-      // A value was supplied but nothing ended up selected — almost always the
-      // agent passed the channel index as the map value (e.g. {"0": 0}) instead
-      // of true. Surface it so the agent retries rather than saving a tool that
-      // fails at run time with "No channel selected".
-      if (provided && selected.size === 0) {
+      // Surface the misuse so the agent retries, rather than saving a tool that
+      // fails at run time with the worker's "No channel selected for Slot 1".
+      if (indexUsedAsValue) {
         throw new Error(
-          `"${paramId}": you provided a value but no channel is selected. ` +
-            "Pass the channel indices to select as an array, e.g. [0] for the " +
-            "first channel.",
+          `"${paramId}": a channel index was used as a map value (e.g. ` +
+            '{"0": 0}), which selects nothing. Pass the channel indices to ' +
+            "select as an array, e.g. [0] for the first channel.",
         );
       }
+      // Every channel gets an explicit boolean, matching what the checkbox UI
+      // writes. resolveChannelRef already rejected indices outside
+      // ctx.channels, so `selected` never adds keys beyond this loop's range.
       const result: { [channel: number]: boolean } = {};
       const channels =
         ctx.channels.length > 0 ? ctx.channels : [...selected].sort();
       for (const channel of channels) {
         result[channel] = selected.has(channel);
       }
-      for (const channel of selected) {
-        if (!(channel in result)) {
-          result[channel] = true;
-        }
-      }
       return result;
     }
     case "select": {
       if (value == null) {
-        return getDefault(element.type, element.default) ?? "";
+        return getDefault(element.type, element.default);
       }
       const items = element.items ?? [];
       if (items.length > 0 && !items.includes(value as string)) {
@@ -219,11 +230,30 @@ export function normalizeWorkerInterfaceValue(
       return value as TWorkerInterfaceValue;
     }
     case "checkbox":
-      return Boolean(value);
+      // Deliberately strict: Boolean("false") is true, so coercing would turn a
+      // stringy "false" into an enabled option the caller never asked for.
+      if (typeof value !== "boolean") {
+        throw new Error(
+          `"${paramId}": expected true or false, got ` +
+            `${JSON.stringify(value)}.`,
+        );
+      }
+      return value;
     case "number": {
-      const asNumber = typeof value === "number" ? value : Number(value);
-      if (Number.isNaN(asNumber)) {
-        throw new Error(`"${paramId}": expected a number, got ${value}.`);
+      // Also deliberately strict: Number("") and Number([]) are 0, so coercing
+      // would silently substitute 0 for a value that was never a number.
+      let asNumber: number;
+      if (typeof value === "number") {
+        asNumber = value;
+      } else if (typeof value === "string" && value.trim() !== "") {
+        asNumber = Number(value);
+      } else {
+        asNumber = NaN;
+      }
+      if (!Number.isFinite(asNumber)) {
+        throw new Error(
+          `"${paramId}": expected a number, got ${JSON.stringify(value)}.`,
+        );
       }
       return asNumber;
     }


### PR DESCRIPTION
## Problem

When the AI panel chatbot created a worker tool (e.g. Cellpose SAM), the worker parameter slots were left unfilled. `create_tool` had no `workerInterfaceValues` input, so agent-created worker tools were saved with no parameters at all — opening the worker menu showed blank/default slots (empty channel and select parameters, `0` numbers), and the system prompt never told the model to inspect or fill worker parameters.

Letting the model pass values exposed a second, quieter problem. The interface only tells the model each parameter's `type`, never the **shape** its value must take, so for a `channelCheckboxes` slot the model guessed:

```json
"Channel for Slot 1": { "0": 0, "1": false, "2": false, "3": false }
```

It meant "channel 0" — but the value slot is a boolean, and `0` is falsy. The worker selects channels by truthiness (`[k for k, v in slot.items() if v]`), saw an empty selection, and raised **`No channel selected for Slot 1`**. The tool looked correctly configured and the job failed every time. Nothing caught it, because validation only checked that override *keys* were real parameter names — never the values.

## Changes

**Agent tool surface** (`src/agent/executors.ts`)
- `create_tool` accepts `workerInterfaceValues` for worker tools. Values are resolved on top of interface defaults via the existing `resolveWorkerInterfaceValues` helper and saved as `tool.values.workerInterfaceValues` — the same slot `run_worker`, `submitAnnotationWorkerJob`, and the pipeline runner already read. Passing them with a manual tool errors. The result echoes the saved `parameters` so the model can confirm them.
- `resolveWorkerInterfaceValues` now **normalizes and validates** every agent-supplied override against the open dataset's channel index↔name map. Because it is shared, `run_worker` and `create_property` overrides get the same treatment.
- `get_worker_interface` returns two new fields alongside the interface: a per-type **`valueFormats`** guide (limited to the types actually present) and a **`channels`** index↔name list, which is what the model needs to fill channel parameters at all.
- `buildToolConfiguration` (`src/tools/creation/toolFromCatalog.ts`) gains a `workerInterfaceValues` option; the gated-approval description lists which parameters the call sets.

**Normalization** (`src/utils/workerInterface.ts`) — new `normalizeWorkerInterfaceValue` + `WORKER_INTERFACE_VALUE_FORMATS`:
- Channel selections may be given as indices, names, or arrays, and are normalized to the canonical on-disk forms: a number for `channel`, a `{index: boolean}` map for `channelCheckboxes`.
- The `{"0": 0}` misuse is rejected — discriminated on the map value being *falsy but not boolean `false`*, so an explicit all-`false` map (the shape the checkbox UI itself writes) and `[]` still work as a deliberate "select nothing" on the optional slots.
- `select` values must be one of the parameter's `items`. `checkbox` and `number` **reject rather than coerce**: `Boolean("false")` is `true` and `Number("")`/`Number([])`/`Number(null)` are all `0`, so coercion could silently substitute a value nobody asked for — the same class of bug as the one above.
- Unknown channel indices/names produce an actionable error listing what the dataset actually has.

**Agent prompt / schema** (girder-claude-chat plugin)
- `agent_system_prompt.txt`: before `create_tool`, `create_property`, or `run_worker`, call `get_worker_interface` and deliberately fill required and channel/select parameters (defaults like channel 0 or an empty selection are usually wrong), reading `valueFormats` and `channels` to format them.
- `agent_tools.json`: `create_tool`, `run_worker`, and `create_property` document the exact formats — channel = 0-based index number, `channelCheckboxes` slot = array of indices like `[0]` (**not** a map like `{"0": 0}`), `select` = one of its `items`.

**Docs / skills**: `AI_PANEL_SPEC.md` note updated. The `nimbus-frontend` skill gains a section on driving the AI panel from the console for testing (the actions register **unnamespaced** — `sendUserMessage`, not `aiPanel/sendUserMessage`; `setAutoApprove`; `clearConversationAndStorage`; and the double-send `wireMessages` corruption that surfaces as an Anthropic `400 … messages.N.content.0: Input should be an object`). Mirrored to `.agents/skills/` via `plugins/nimbusimage/scripts/sync_skills.py --write`.

## Testing

Verified end-to-end through the **live chatbot** (not just the executors), against the real Cellpose worker:
- *"Find the nuclei in this image"* → the model calls `list_workers` → `get_worker_interface` → `create_tool` → `run_worker`, saving `Channel for Slot 1 = {0: true, 1: false, 2: false, 3: false}` (DAPI). Job status **SUCCESS**, 1261 nuclei created, no `No channel selected` in the job log.
- *"Can you find the nuclei in DAPI and give me a histogram of their areas?"* → creates a `polygon` / `tags:[nucleus]` morphology property, computes values for all 1261 nuclei, and plots the histogram.
- Adversarial cases produce actionable errors instead of a broken tool: `{"0": 0}` → *"a channel index was used as a map value (e.g. {"0": 0}), which selects nothing. Pass the channel indices to select as an array, e.g. [0]…"*; `["GFP"]` → *"unknown channel "GFP". Available channels: 0 (dapi), 1 (fitc), …"*; `""` for a number → *"expected a number, got """*.
- An all-`false` map on an optional slot is accepted (previously it would have errored).

Unit tests: new `src/utils/workerInterface.test.ts` (16 — channel normalization by index/name/array, the index-as-value mistake with and without a sibling selection, all-`false` maps, and the coercion-rejection cases) plus additions to `src/agent/executors.test.ts` (channel-name resolution, `channelCheckboxes` normalization, rejection of the empty selection). Full suite green (**2920 tests**); `pnpm tsc` and `pnpm lint:ci` clean.

## Notes for review

- Normalization applies only to values the agent explicitly passes. Interface defaults still flow through `getDefault` untouched, and values already saved on a tool are read back as-is, so no existing tool changes behavior.
- The stricter `checkbox`/`number` handling is a deliberate behavior change from an earlier revision of this branch that coerced instead. Rationale is in the commit message for `9855088`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8MSjz6dcz9r8mpYBMUc56
