### PR TITLE
Record rawError, partial-write and review-loop learnings in skills

### DIFF
--- a/.agents/skills/branch-review/SKILL.md
+++ b/.agents/skills/branch-review/SKILL.md
@@ -104,6 +104,8 @@ This keeps every actionable item discoverable from the Findings Summary table by
 | **Frontend compensating for backend** | Frontend fallback logic that masks backend issues or duplicates backend access control |
 | **Store Organization** | New state added to `src/store/index.ts` instead of a focused store module |
 | **Naming** | Generic variable names or function names that no longer match their behavior |
+| **Partial Persistence** | One logical change issuing several writes of the same key, so a mid-sequence failure leaves the resource partially updated |
+| **Error Message Mangling** | Store action throwing or propagating without `rawError: true`, so callers get `ERR_ACTION_ACCESS_UNDEFINED` instead of the reason |
 
 ## Backend-Specific Checks
 
@@ -182,6 +184,17 @@ Flag diffs in generated or documentation trees the branch shouldn't touch (e.g. 
 ### 7. Stale Selection / State Feeding Bulk Actions
 For list/selection UIs: can a selected set survive a filter or mode change and then feed a bulk destructive action (delete/tag/hydrate)? Check that selection is scoped or cleared when the visible set's definition changes, and that select-all paths respect lazy-mode/budget caps instead of operating on the entire dataset.
 
+### 8. Partial Persistence: One Logical Change Writing the Same Key Twice
+`syncConfiguration(key)` PUTs the whole key, so N single-field calls in one operation = N writes of the same key, and a failure part-way leaves the shared collection partially updated **while the operation reports failure**. Distinct from the looped-call check (#2): the repeats here are sequential `await`s on *different* fields, not a `.map()`, so they don't look like a loop.
+
+For any handler that changes several fields of one resource, check:
+- Are all inputs **validated before** the first write? Interleaved validation is the easier half to miss — it produces a partial update with no backend failure involved, so backend-rejection tests can't catch it.
+- Do two different actions in the same handler both end up syncing the same key? (`changeLayer` and `saveContrastInConfiguration` both write `layers`.)
+- Writes to genuinely different resources (configuration vs dataset view) can't be merged — expect a comment saying so, don't flag it.
+
+### 9. Store Actions That Throw or Propagate Without `rawError: true`
+`vuex-module-decorators` replaces any error escaping a bare `@Action` with a generic `ERR_ACTION_ACCESS_UNDEFINED` message. Flag a new/edited action if it throws **or merely propagates** (awaits an API call or another action) and any caller reads `error.message`. Errors are re-wrapped at every boundary they cross, across modules, so check the whole chain, not just the action in the diff. `tsc`/lint/tests stay green either way, and a test that mocks the action bypasses the decorator entirely — so a real-dispatch test asserting the **exact** message is the only regression guard (substring assertions pass regardless; the wrapper embeds the original message in its stack). See nimbus-frontend skill.
+
 ## Example Output Format
 
 The output has exactly four sections, in this order: **Overall Assessment**, **Findings**, **Findings Summary**, **Checklist Coverage**. **Questions for Clarification** is optional and appears only if there are open questions. There is no separate "Minor Observations" section — small items become findings with Severity Nit.
@@ -250,6 +263,8 @@ The two tables are numbered and serve different purposes:
 | Frontend compensating for backend | pass | — |
 | Store Organization | pass | — |
 | Naming | pass | — |
+| Partial persistence (same key written twice) | pass | — |
+| Actions that throw/propagate without rawError | pass | — |
 
 ### Questions for Clarification
 [Only include this section if there are open questions. Otherwise omit it.]

--- a/.agents/skills/fixing-review-findings/SKILL.md
+++ b/.agents/skills/fixing-review-findings/SKILL.md
@@ -43,6 +43,24 @@ A reviewer flags **one instance** of a pattern per round. After fixing it, grep 
 | Stale selection driving bulk destructive actions | List/selection UIs with filters | Does the selected set survive a filter change and then feed a delete/tag/bulk action? |
 | Budget/lazy-mode bypass on select-all paths | Anything calling hydrate/fetch with a user-controlled id set | Is there a cap, or can one click request 700K items? |
 | Stale comments/tests describing pre-fix behavior | Wherever behavior changed | Grep for the old function contract in comments and test names |
+| Partial persistence: one change writing the same config key twice | Handlers that change several fields of one resource | All inputs validated *before* the first write? Two actions in the handler both syncing the same key? (see nimbus-frontend skill) |
+| Store action throws/propagates without `rawError: true` | Any `src/store/*.ts` | Audit **every** store module and the **whole** chain — errors re-wrap at each `@Action` boundary, and an action needs the flag when it merely propagates (no `throw` of its own) |
+
+When you generalize, check the *shape* of your sweep too, not just its target. A grep for `throw` in action bodies found the deliberate throwers and missed every pure propagator — so the sweep reported "clean" and the next Codex round flagged the one it missed. If a sweep comes back clean, ask what the query structurally cannot see.
+
+### Codex round mechanics
+
+Codex does **not** review on push. It reviews on PR open, on draft→ready, or on a `@codex review` comment — so pushing a fix and waiting will wait forever. Post the trigger comment (safe to do without asking if Codex has already reviewed that PR; otherwise ask first, since it's outward-facing).
+
+Its three response signals are easy to confuse when polling:
+
+| Signal | Meaning |
+|---|---|
+| 👀 on your trigger comment | Picked it up, working — **not** a verdict. Removed when done. |
+| 👍 | Reviewed, no suggestions. |
+| A plain PR comment ("Didn't find any major issues") | Also a clean result — arrives as an issue comment, *not* a review object with inline comments. |
+
+Poll for all three. Watching only for a new review object plus 👍 reports a false timeout when the answer arrived as a comment. Findings themselves come as inline review comments (`/pulls/{n}/comments`), not in the review body, which only holds boilerplate.
 
 ### 5. Gates before claiming done
 

--- a/.agents/skills/in-browser-testing/SKILL.md
+++ b/.agents/skills/in-browser-testing/SKILL.md
@@ -41,11 +41,62 @@ Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reaso
 
 Camera changes (`map.zoom(v)`, `map.center({x,y})`) do trigger the camera watcher but only after ~700 ms of debounces (250 ms camera + 200 ms fetch) — wait before reading resulting state. Memory: `window.__nimbusMem` (see nimbus-frontend skill).
 
+**An async IIFE's return value does not come back** — `javascript_tool` reports `{}` for anything that needs awaiting, including plain strings. Objects serialize to `{}` too. So: stash on `window`, read it synchronously in a second call, and return a **string** (join the fields yourself).
+
+```js
+// Call 1 — kick it off, poll for readiness inside, stash a string.
+window.__r = 'pending'; (async () => {
+  const s = () => document.querySelector('#app')?.__vue_app__
+    ?.config?.globalProperties?.$store;
+  for (let i = 0; i < 100; i++) {                 // wait for load/hydration
+    if (s()?.state?.main?.configuration?.layers?.length) break;
+    await new Promise(r => setTimeout(r, 400));
+  }
+  window.__r = ['mode=' + s().state.main.layerMode,
+                'tools=' + s().state.main.configuration.tools.length].join(' | ');
+})(); 'started'
+// Call 2
+window.__r
+```
+
+**All store actions dispatch un-namespaced, in every module** — `dispatch('createProperty')`, not `dispatch('properties/createProperty')`. A namespaced name silently resolves to nothing and the promise *resolves*, so you get a false "no throw" rather than an error. Confirm a name exists with `Object.keys(store._actions)` before trusting a negative result. Cross-module state lives under its own key (`store.state.properties.propertiesAPI`).
+
+**Verifying error propagation without touching real data.** Stub an API method to reject, dispatch, read `error.message`, restore in `finally` — this exercises the real built code (decorators included) and writes nothing, because the stub replaces the request:
+
+```js
+const api = store.state.main.api, orig = api.updateConfigurationKey;
+api.updateConfigurationKey = async () => { throw new Error('BACKEND_SAYS_NO'); };
+try { await store.dispatch('syncConfiguration', { key: 'layers', throwOnError: true }); }
+catch (e) { window.__r = e.message; } finally { api.updateConfigurationKey = orig; }
+```
+
+To exercise a **success** path without changing anything, re-save the values already in the store (read them, pass them straight back) and assert the write count rather than the value. Counting writes catches batching regressions a value check can't: wrap the API method to increment a counter and delegate to the original.
+
+**A live probe is only evidence if it can fail.** Before believing a passing probe, re-check out the pre-fix file (`git checkout <commit> -- src/store/index.ts`), `location.reload()`, and confirm the probe *fails*. That's what distinguished a real fix from a coincidence here — a 1081-char mangled message before vs a 21-char one after. Restore the file afterward.
+
 ## Driving GeoJS drawing tools
 
 CDP `left_click_drag` silently fails for freehand/continuous drawing: it emits mousedown + ONE move + up in ~7 ms, GeoJS ends with 2 vertices and discards the annotation with no error. Working recipe: dispatch synthetic `MouseEvent`s (`mousedown` / `mousemove`×N / `mouseup`, `bubbles: true`, correct `buttons`) on the `.geojs-map` canvas with **busy-wait** gaps (~40 ms) between steps — immune to background throttling and lets lodash-throttled handlers (100 ms in AnnotationViewer) fire mid-drag. Synthetic `clientX/Y` are offset from screen coords by the map node's page offset — fine for behavior testing; don't assert exact positions. Verify results through live handles (`layer.annotations()`, `annotation.options('vertices')`), not screenshots alone.
 
 Real `computer` clicks: this environment runs DPR 2 with a downscaled screenshot — the computer tool's coordinate space can differ from screenshot pixels. Read `window.innerWidth/innerHeight` and scale, or confirm the target with `elementFromPoint` first.
+
+The `computer` tool works in **screenshot** space, so convert from page coords and check hittability in one pass. Scale from the screenshot dimensions the tool reported (e.g. 1568×756) against `window.inner*` — they differ, and the window can be resized between calls, so recompute rather than reusing a factor:
+
+```js
+const sx = 1568 / window.innerWidth, sy = 756 / window.innerHeight;
+const el = [...document.querySelectorAll('input[type=radio]')]
+  .find(e => e.value === 'single');
+const r = el.getBoundingClientRect();
+const cx = Math.round(r.x + r.width / 2), cy = Math.round(r.y + r.height / 2);
+// hittable? -> is the intended element actually the topmost target?
+const top = document.elementFromPoint(cx, cy);
+return [Math.round(cx * sx), Math.round(cy * sy),
+        el === top || el.contains(top)].join(' / ');
+```
+
+Picking a target by eyeballing a screenshot lands on overlays: the coords that *looked* like a layer's toggle resolved to a `v-expansion-panel-title__overlay`, which would have toggled the panel instead. `elementFromPoint` returning the real `INPUT` is the go-ahead.
+
+If every browser call starts failing with `Cannot access contents of the page. Extension manifest must request permission to access the respective host` (and `javascript_tool` times out), the extension has lost host permission for the tab. Nothing you can do from here — confirm the dev server is still up from the shell (`curl -o /dev/null -w '%{http_code}' http://localhost:5173`) so you can say it's extension-side, then ask the user to re-grant site access and check the extension side panel for a pending prompt.
 
 ## Performance measurement
 

--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -98,6 +98,42 @@ async doThing() {
 
 When writing a test for an action's thrown-error message, `expect(...).rejects.toThrow("substring")` is not a reliable regression check here: the wrapped error's message embeds the original error's `.stack` (which starts with `"Error: <original message>"`), so a substring match can pass even when `rawError` is missing. Assert the exact `.message` instead. See `src/store/index.test.ts` for the pattern (dispatches the real action instead of mocking `@/store`).
 
+Two traps that let this ship a real bug even after the rule above was documented:
+
+- **An action needs the flag if it merely *propagates*, not only if it contains `throw`.** Awaiting an API call or another action re-throws through your own decorator. `createProperty` has no `throw` and still emitted the blob — so a "grep action bodies for `throw`" audit misses exactly these.
+- **Errors get re-wrapped at every `@Action` boundary they cross, across modules.** `createProperty → setProperties → updateConfigurationProperties → syncConfiguration` is four boundaries; one bare `@Action` anywhere on the path mangles the message. Audit every `src/store/*.ts`, not just `index.ts`.
+
+See `references/store-module-patterns.md` for the audit commands, how to tell which callers actually display the message, and the vitest setup details (accessor getters are non-configurable — set `store.state.main.*` directly).
+
+### One Logical Change → One Config Write
+
+`syncConfiguration(key)` PUTs the **whole** key. So a caller that changes three fields by calling a single-field action three times issues three writes of the same key, and a rejection part-way through leaves the shared collection **partially updated while reporting failure** — the same false-reporting `rawError` exists to prevent, one level up. Two instances shipped before this was caught (`set_scale` writing `scales` up to 3×, `update_layer` writing `layers` 2× via `changeLayer` + `saveContrastInConfiguration`).
+
+Validate everything first, then write once:
+
+```typescript
+// BAD: validates and persists per field. An invalid tStep leaves pixelSize
+// already written — a partial update with no backend failure involved.
+if (input.pixelSize) await apply("pixelSize", input.pixelSize);
+if (input.tStep) await apply("tStep", input.tStep); // throws on a bad unit
+
+// GOOD: validate all → assign all → one sync
+const scales = {};
+if (input.pixelSize) scales.pixelSize = validate("pixelSize", input.pixelSize);
+if (input.tStep) scales.tStep = validate("tStep", input.tStep);
+await main.saveScalesInConfiguration({ scales, throwOnError: true });
+```
+
+Interleaved *validation* is the easier half to miss: it fails with no backend involvement at all, so it can't be caught by testing backend rejections. When adding a batch action, keep the singular one — the interactive UI edits one field at a time and legitimately wants it (`ScaleSettings.vue`).
+
+Existing in-codebase idioms for writing once:
+
+- `changeLayer({ ..., sync: false })` per item, then a single `syncConfiguration({ key: "layers", throwOnError: true })` — see `set_layer_visibility`.
+- A plural action that assigns all entries then syncs once — `saveScalesInConfiguration`, `setViewContrastOverrides`.
+- An optional `delta` merged into an existing action's single write — `saveContrastInConfiguration({ layerId, contrast, delta })`.
+
+Writes to genuinely *different* resources can't be merged (the configuration vs the dataset view are separate endpoints); say so at the call site rather than leaving it looking like an oversight.
+
 ### Watching Getters That Rebuild Their Return Object
 
 `watch(() => someGetter, cb, { deep: true })` on a getter that returns a **new object on every read** fires on every dependency touch — including dependencies the getter reads but that don't change the output (`deep: true` skips the value comparison entirely). This shipped a real bug: a deep watch on `currentFilters` cleared the selection on every Z-scrub because the getter read `z` unconditionally. tsc/lint/reasoning all passed; only the live app caught it.

--- a/.agents/skills/nimbus-frontend/references/store-module-patterns.md
+++ b/.agents/skills/nimbus-frontend/references/store-module-patterns.md
@@ -182,6 +182,61 @@ async addMultiSourceMetadata(payload: IAddMultiSourceMetadataPayload) {
 
 Default to a bare `@Action` (log-and-return-null/false on failure) unless a caller specifically needs to branch on or display the failure reason. Reach for `rawError: true` only when the action throws on purpose.
 
+### Propagating counts as throwing
+
+An action does not need a `throw` of its own to need `rawError: true`. Any action that `await`s something that rejects — an API call, or another action — re-throws that rejection through its own decorator, which wraps it. `propertyStore.createProperty` has no `throw` anywhere in its body and still returned the `ERR_ACTION_ACCESS_UNDEFINED` blob:
+
+```typescript
+// Needs rawError: true — both awaits propagate on failure.
+@Action({ rawError: true })
+async createProperty(property: IAnnotationPropertyConfiguration) {
+  const newProperty = await this.propertiesAPI.createProperty(property); // rejects
+  if (newProperty) {
+    await this.setProperties([...this.properties, newProperty]); // also rejects
+  }
+  return newProperty;
+}
+```
+
+This is the blind spot that let a real defect through: an audit that greps action bodies for `throw` finds the deliberate throwers and misses every pure propagator. Grep for the *callers* that read a message instead (below).
+
+### Every boundary in the chain needs it
+
+`this.someOtherAction()` inside an `@Action` dispatches through the store again (these are dynamic modules), so it passes through that action's decorator too. An error therefore gets re-wrapped once per boundary it crosses, and **one missing `rawError` anywhere in the chain mangles the message** — fixing only the outermost or innermost action does nothing. The `create_property` chain crosses four:
+
+```
+createProperty → setProperties → updateConfigurationProperties → syncConfiguration
+(properties.ts)  (properties.ts)  (index.ts)                      (index.ts)
+```
+
+Chains cross module boundaries, so audit **every** `src/store/*.ts`, not just `index.ts`. A sweep limited to `index.ts` is what left `properties.ts` broken.
+
+### Deciding whether a caller actually needs the message
+
+`rawError: true` is safe to add — it never changes *whether* an action throws, only which error object escapes — but check the caller so the comment you write is true, and so you know the user impact:
+
+- **Renders it** → user-facing bug. `UserMenuLoginForm.vue` does `errorMessage.value = (error as Error).message` and shows it in a `v-alert`, so a failed `signUp` displayed the blob instead of "login already in use".
+- **Logs it** (`logError("...", error)`) → console/Sentry quality only.
+- **Shows generic text** ("See the console for details") → log quality only; the UI string is unaffected.
+
+One thing that looks like a gap but is not: `ServerStatus.vue` renders `sync.lastError.message`, yet the sync indicator was never affected by missing `rawError`. `setSaving(error)` is called from *inside* the action's own catch, so it receives the original error before any decorator wrapping. Don't "fix" that path.
+
+### Auditing
+
+```bash
+# 1. Bare @Action with a throw close below it — the deliberate throwers.
+#    Returns nothing as of this writing: every such action now has the flag,
+#    so any hit is a new one. Misses propagators (see above).
+grep -rn "@Action$" -A8 src/store/*.ts | grep "throw "
+
+# 2. Higher-signal, and catches propagators: callers that display a store
+#    error's message. Quote --include — zsh expands it bare and the command
+#    fails with "no matches found".
+grep -rn "as Error).message" src/ --include="*.vue"
+```
+
+Query 2 is the one that matters: trace each hit back through **every** action on the path and confirm each boundary is `{ rawError: true }`. Query 1 is a cheap supplement, not a substitute — it structurally cannot see the propagator case, which is how the last defect reached review.
+
 ### Testing the real dispatch path (not a mocked one)
 
 Most store tests mock `@/store`/`./index` entirely (see `aiPanel.test.ts`, `toolSuggestions.test.ts`, `MultiSourceConfiguration.test.ts`) because `Main` is heavy to construct. That's fine for testing *callers* of an action, but it can't catch a missing `rawError: true` — the mock just returns/throws whatever the test tells it to, bypassing vuex-module-decorators entirely.
@@ -203,6 +258,21 @@ async function messageOf(promise: Promise<unknown>): Promise<string> {
 const message = await messageOf(main.addMultiSourceMetadata({ ...payload }));
 expect(message).toBe("This operation needs 9.7 MB of storage, ...");
 ```
+
+Two setup details for these real-dispatch tests:
+
+**Getters and state on the accessor are non-configurable.** `vi.spyOn(main, "isLoggedIn", "get")` throws `TypeError: Cannot redefine property`, and `(main as any).girderUser = ...` throws `Cannot set property ... which has only a getter`. Set the underlying Vuex state instead:
+
+```typescript
+import store from "./root";
+function setLoggedIn(loggedIn: boolean) {
+  (store.state as any).main.girderUser = loggedIn ? { _id: "u1" } : null;
+}
+```
+
+Protected mutations are reachable for setup via a cast — `(main as any).setConfigurationImpl({ id, data })` — which is usually less work than driving the real load path.
+
+**Some actions can't be reached this way.** `signUp` builds its own `RestClient` internally, and `RestClient` assigns `post`/`get` as *own instance properties* in its constructor (not on the prototype), so there is no seam: `vi.spyOn(RestClient.prototype, "post")` doesn't exist to spy on, and mocking `@/girder` wholesale collides with `store/index.ts`'s module-level girder init. Don't sink time into it — verify that one by inspection and lean on the coverage of the sibling actions.
 
 ## Reference
 

--- a/.claude/skills/branch-review/SKILL.md
+++ b/.claude/skills/branch-review/SKILL.md
@@ -104,6 +104,8 @@ This keeps every actionable item discoverable from the Findings Summary table by
 | **Frontend compensating for backend** | Frontend fallback logic that masks backend issues or duplicates backend access control |
 | **Store Organization** | New state added to `src/store/index.ts` instead of a focused store module |
 | **Naming** | Generic variable names or function names that no longer match their behavior |
+| **Partial Persistence** | One logical change issuing several writes of the same key, so a mid-sequence failure leaves the resource partially updated |
+| **Error Message Mangling** | Store action throwing or propagating without `rawError: true`, so callers get `ERR_ACTION_ACCESS_UNDEFINED` instead of the reason |
 
 ## Backend-Specific Checks
 
@@ -182,6 +184,17 @@ Flag diffs in generated or documentation trees the branch shouldn't touch (e.g. 
 ### 7. Stale Selection / State Feeding Bulk Actions
 For list/selection UIs: can a selected set survive a filter or mode change and then feed a bulk destructive action (delete/tag/hydrate)? Check that selection is scoped or cleared when the visible set's definition changes, and that select-all paths respect lazy-mode/budget caps instead of operating on the entire dataset.
 
+### 8. Partial Persistence: One Logical Change Writing the Same Key Twice
+`syncConfiguration(key)` PUTs the whole key, so N single-field calls in one operation = N writes of the same key, and a failure part-way leaves the shared collection partially updated **while the operation reports failure**. Distinct from the looped-call check (#2): the repeats here are sequential `await`s on *different* fields, not a `.map()`, so they don't look like a loop.
+
+For any handler that changes several fields of one resource, check:
+- Are all inputs **validated before** the first write? Interleaved validation is the easier half to miss — it produces a partial update with no backend failure involved, so backend-rejection tests can't catch it.
+- Do two different actions in the same handler both end up syncing the same key? (`changeLayer` and `saveContrastInConfiguration` both write `layers`.)
+- Writes to genuinely different resources (configuration vs dataset view) can't be merged — expect a comment saying so, don't flag it.
+
+### 9. Store Actions That Throw or Propagate Without `rawError: true`
+`vuex-module-decorators` replaces any error escaping a bare `@Action` with a generic `ERR_ACTION_ACCESS_UNDEFINED` message. Flag a new/edited action if it throws **or merely propagates** (awaits an API call or another action) and any caller reads `error.message`. Errors are re-wrapped at every boundary they cross, across modules, so check the whole chain, not just the action in the diff. `tsc`/lint/tests stay green either way, and a test that mocks the action bypasses the decorator entirely — so a real-dispatch test asserting the **exact** message is the only regression guard (substring assertions pass regardless; the wrapper embeds the original message in its stack). See nimbus-frontend skill.
+
 ## Example Output Format
 
 The output has exactly four sections, in this order: **Overall Assessment**, **Findings**, **Findings Summary**, **Checklist Coverage**. **Questions for Clarification** is optional and appears only if there are open questions. There is no separate "Minor Observations" section — small items become findings with Severity Nit.
@@ -250,6 +263,8 @@ The two tables are numbered and serve different purposes:
 | Frontend compensating for backend | pass | — |
 | Store Organization | pass | — |
 | Naming | pass | — |
+| Partial persistence (same key written twice) | pass | — |
+| Actions that throw/propagate without rawError | pass | — |
 
 ### Questions for Clarification
 [Only include this section if there are open questions. Otherwise omit it.]

--- a/.claude/skills/fixing-review-findings/SKILL.md
+++ b/.claude/skills/fixing-review-findings/SKILL.md
@@ -43,6 +43,24 @@ A reviewer flags **one instance** of a pattern per round. After fixing it, grep 
 | Stale selection driving bulk destructive actions | List/selection UIs with filters | Does the selected set survive a filter change and then feed a delete/tag/bulk action? |
 | Budget/lazy-mode bypass on select-all paths | Anything calling hydrate/fetch with a user-controlled id set | Is there a cap, or can one click request 700K items? |
 | Stale comments/tests describing pre-fix behavior | Wherever behavior changed | Grep for the old function contract in comments and test names |
+| Partial persistence: one change writing the same config key twice | Handlers that change several fields of one resource | All inputs validated *before* the first write? Two actions in the handler both syncing the same key? (see nimbus-frontend skill) |
+| Store action throws/propagates without `rawError: true` | Any `src/store/*.ts` | Audit **every** store module and the **whole** chain — errors re-wrap at each `@Action` boundary, and an action needs the flag when it merely propagates (no `throw` of its own) |
+
+When you generalize, check the *shape* of your sweep too, not just its target. A grep for `throw` in action bodies found the deliberate throwers and missed every pure propagator — so the sweep reported "clean" and the next Codex round flagged the one it missed. If a sweep comes back clean, ask what the query structurally cannot see.
+
+### Codex round mechanics
+
+Codex does **not** review on push. It reviews on PR open, on draft→ready, or on a `@codex review` comment — so pushing a fix and waiting will wait forever. Post the trigger comment (safe to do without asking if Codex has already reviewed that PR; otherwise ask first, since it's outward-facing).
+
+Its three response signals are easy to confuse when polling:
+
+| Signal | Meaning |
+|---|---|
+| 👀 on your trigger comment | Picked it up, working — **not** a verdict. Removed when done. |
+| 👍 | Reviewed, no suggestions. |
+| A plain PR comment ("Didn't find any major issues") | Also a clean result — arrives as an issue comment, *not* a review object with inline comments. |
+
+Poll for all three. Watching only for a new review object plus 👍 reports a false timeout when the answer arrived as a comment. Findings themselves come as inline review comments (`/pulls/{n}/comments`), not in the review body, which only holds boilerplate.
 
 ### 5. Gates before claiming done
 

--- a/.claude/skills/in-browser-testing/SKILL.md
+++ b/.claude/skills/in-browser-testing/SKILL.md
@@ -41,11 +41,62 @@ Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reaso
 
 Camera changes (`map.zoom(v)`, `map.center({x,y})`) do trigger the camera watcher but only after ~700 ms of debounces (250 ms camera + 200 ms fetch) — wait before reading resulting state. Memory: `window.__nimbusMem` (see nimbus-frontend skill).
 
+**An async IIFE's return value does not come back** — `javascript_tool` reports `{}` for anything that needs awaiting, including plain strings. Objects serialize to `{}` too. So: stash on `window`, read it synchronously in a second call, and return a **string** (join the fields yourself).
+
+```js
+// Call 1 — kick it off, poll for readiness inside, stash a string.
+window.__r = 'pending'; (async () => {
+  const s = () => document.querySelector('#app')?.__vue_app__
+    ?.config?.globalProperties?.$store;
+  for (let i = 0; i < 100; i++) {                 // wait for load/hydration
+    if (s()?.state?.main?.configuration?.layers?.length) break;
+    await new Promise(r => setTimeout(r, 400));
+  }
+  window.__r = ['mode=' + s().state.main.layerMode,
+                'tools=' + s().state.main.configuration.tools.length].join(' | ');
+})(); 'started'
+// Call 2
+window.__r
+```
+
+**All store actions dispatch un-namespaced, in every module** — `dispatch('createProperty')`, not `dispatch('properties/createProperty')`. A namespaced name silently resolves to nothing and the promise *resolves*, so you get a false "no throw" rather than an error. Confirm a name exists with `Object.keys(store._actions)` before trusting a negative result. Cross-module state lives under its own key (`store.state.properties.propertiesAPI`).
+
+**Verifying error propagation without touching real data.** Stub an API method to reject, dispatch, read `error.message`, restore in `finally` — this exercises the real built code (decorators included) and writes nothing, because the stub replaces the request:
+
+```js
+const api = store.state.main.api, orig = api.updateConfigurationKey;
+api.updateConfigurationKey = async () => { throw new Error('BACKEND_SAYS_NO'); };
+try { await store.dispatch('syncConfiguration', { key: 'layers', throwOnError: true }); }
+catch (e) { window.__r = e.message; } finally { api.updateConfigurationKey = orig; }
+```
+
+To exercise a **success** path without changing anything, re-save the values already in the store (read them, pass them straight back) and assert the write count rather than the value. Counting writes catches batching regressions a value check can't: wrap the API method to increment a counter and delegate to the original.
+
+**A live probe is only evidence if it can fail.** Before believing a passing probe, re-check out the pre-fix file (`git checkout <commit> -- src/store/index.ts`), `location.reload()`, and confirm the probe *fails*. That's what distinguished a real fix from a coincidence here — a 1081-char mangled message before vs a 21-char one after. Restore the file afterward.
+
 ## Driving GeoJS drawing tools
 
 CDP `left_click_drag` silently fails for freehand/continuous drawing: it emits mousedown + ONE move + up in ~7 ms, GeoJS ends with 2 vertices and discards the annotation with no error. Working recipe: dispatch synthetic `MouseEvent`s (`mousedown` / `mousemove`×N / `mouseup`, `bubbles: true`, correct `buttons`) on the `.geojs-map` canvas with **busy-wait** gaps (~40 ms) between steps — immune to background throttling and lets lodash-throttled handlers (100 ms in AnnotationViewer) fire mid-drag. Synthetic `clientX/Y` are offset from screen coords by the map node's page offset — fine for behavior testing; don't assert exact positions. Verify results through live handles (`layer.annotations()`, `annotation.options('vertices')`), not screenshots alone.
 
 Real `computer` clicks: this environment runs DPR 2 with a downscaled screenshot — the computer tool's coordinate space can differ from screenshot pixels. Read `window.innerWidth/innerHeight` and scale, or confirm the target with `elementFromPoint` first.
+
+The `computer` tool works in **screenshot** space, so convert from page coords and check hittability in one pass. Scale from the screenshot dimensions the tool reported (e.g. 1568×756) against `window.inner*` — they differ, and the window can be resized between calls, so recompute rather than reusing a factor:
+
+```js
+const sx = 1568 / window.innerWidth, sy = 756 / window.innerHeight;
+const el = [...document.querySelectorAll('input[type=radio]')]
+  .find(e => e.value === 'single');
+const r = el.getBoundingClientRect();
+const cx = Math.round(r.x + r.width / 2), cy = Math.round(r.y + r.height / 2);
+// hittable? -> is the intended element actually the topmost target?
+const top = document.elementFromPoint(cx, cy);
+return [Math.round(cx * sx), Math.round(cy * sy),
+        el === top || el.contains(top)].join(' / ');
+```
+
+Picking a target by eyeballing a screenshot lands on overlays: the coords that *looked* like a layer's toggle resolved to a `v-expansion-panel-title__overlay`, which would have toggled the panel instead. `elementFromPoint` returning the real `INPUT` is the go-ahead.
+
+If every browser call starts failing with `Cannot access contents of the page. Extension manifest must request permission to access the respective host` (and `javascript_tool` times out), the extension has lost host permission for the tab. Nothing you can do from here — confirm the dev server is still up from the shell (`curl -o /dev/null -w '%{http_code}' http://localhost:5173`) so you can say it's extension-side, then ask the user to re-grant site access and check the extension side panel for a pending prompt.
 
 ## Performance measurement
 

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -98,6 +98,42 @@ async doThing() {
 
 When writing a test for an action's thrown-error message, `expect(...).rejects.toThrow("substring")` is not a reliable regression check here: the wrapped error's message embeds the original error's `.stack` (which starts with `"Error: <original message>"`), so a substring match can pass even when `rawError` is missing. Assert the exact `.message` instead. See `src/store/index.test.ts` for the pattern (dispatches the real action instead of mocking `@/store`).
 
+Two traps that let this ship a real bug even after the rule above was documented:
+
+- **An action needs the flag if it merely *propagates*, not only if it contains `throw`.** Awaiting an API call or another action re-throws through your own decorator. `createProperty` has no `throw` and still emitted the blob — so a "grep action bodies for `throw`" audit misses exactly these.
+- **Errors get re-wrapped at every `@Action` boundary they cross, across modules.** `createProperty → setProperties → updateConfigurationProperties → syncConfiguration` is four boundaries; one bare `@Action` anywhere on the path mangles the message. Audit every `src/store/*.ts`, not just `index.ts`.
+
+See `references/store-module-patterns.md` for the audit commands, how to tell which callers actually display the message, and the vitest setup details (accessor getters are non-configurable — set `store.state.main.*` directly).
+
+### One Logical Change → One Config Write
+
+`syncConfiguration(key)` PUTs the **whole** key. So a caller that changes three fields by calling a single-field action three times issues three writes of the same key, and a rejection part-way through leaves the shared collection **partially updated while reporting failure** — the same false-reporting `rawError` exists to prevent, one level up. Two instances shipped before this was caught (`set_scale` writing `scales` up to 3×, `update_layer` writing `layers` 2× via `changeLayer` + `saveContrastInConfiguration`).
+
+Validate everything first, then write once:
+
+```typescript
+// BAD: validates and persists per field. An invalid tStep leaves pixelSize
+// already written — a partial update with no backend failure involved.
+if (input.pixelSize) await apply("pixelSize", input.pixelSize);
+if (input.tStep) await apply("tStep", input.tStep); // throws on a bad unit
+
+// GOOD: validate all → assign all → one sync
+const scales = {};
+if (input.pixelSize) scales.pixelSize = validate("pixelSize", input.pixelSize);
+if (input.tStep) scales.tStep = validate("tStep", input.tStep);
+await main.saveScalesInConfiguration({ scales, throwOnError: true });
+```
+
+Interleaved *validation* is the easier half to miss: it fails with no backend involvement at all, so it can't be caught by testing backend rejections. When adding a batch action, keep the singular one — the interactive UI edits one field at a time and legitimately wants it (`ScaleSettings.vue`).
+
+Existing in-codebase idioms for writing once:
+
+- `changeLayer({ ..., sync: false })` per item, then a single `syncConfiguration({ key: "layers", throwOnError: true })` — see `set_layer_visibility`.
+- A plural action that assigns all entries then syncs once — `saveScalesInConfiguration`, `setViewContrastOverrides`.
+- An optional `delta` merged into an existing action's single write — `saveContrastInConfiguration({ layerId, contrast, delta })`.
+
+Writes to genuinely *different* resources can't be merged (the configuration vs the dataset view are separate endpoints); say so at the call site rather than leaving it looking like an oversight.
+
 ### Watching Getters That Rebuild Their Return Object
 
 `watch(() => someGetter, cb, { deep: true })` on a getter that returns a **new object on every read** fires on every dependency touch — including dependencies the getter reads but that don't change the output (`deep: true` skips the value comparison entirely). This shipped a real bug: a deep watch on `currentFilters` cleared the selection on every Z-scrub because the getter read `z` unconditionally. tsc/lint/reasoning all passed; only the live app caught it.

--- a/.claude/skills/nimbus-frontend/references/store-module-patterns.md
+++ b/.claude/skills/nimbus-frontend/references/store-module-patterns.md
@@ -182,6 +182,61 @@ async addMultiSourceMetadata(payload: IAddMultiSourceMetadataPayload) {
 
 Default to a bare `@Action` (log-and-return-null/false on failure) unless a caller specifically needs to branch on or display the failure reason. Reach for `rawError: true` only when the action throws on purpose.
 
+### Propagating counts as throwing
+
+An action does not need a `throw` of its own to need `rawError: true`. Any action that `await`s something that rejects — an API call, or another action — re-throws that rejection through its own decorator, which wraps it. `propertyStore.createProperty` has no `throw` anywhere in its body and still returned the `ERR_ACTION_ACCESS_UNDEFINED` blob:
+
+```typescript
+// Needs rawError: true — both awaits propagate on failure.
+@Action({ rawError: true })
+async createProperty(property: IAnnotationPropertyConfiguration) {
+  const newProperty = await this.propertiesAPI.createProperty(property); // rejects
+  if (newProperty) {
+    await this.setProperties([...this.properties, newProperty]); // also rejects
+  }
+  return newProperty;
+}
+```
+
+This is the blind spot that let a real defect through: an audit that greps action bodies for `throw` finds the deliberate throwers and misses every pure propagator. Grep for the *callers* that read a message instead (below).
+
+### Every boundary in the chain needs it
+
+`this.someOtherAction()` inside an `@Action` dispatches through the store again (these are dynamic modules), so it passes through that action's decorator too. An error therefore gets re-wrapped once per boundary it crosses, and **one missing `rawError` anywhere in the chain mangles the message** — fixing only the outermost or innermost action does nothing. The `create_property` chain crosses four:
+
+```
+createProperty → setProperties → updateConfigurationProperties → syncConfiguration
+(properties.ts)  (properties.ts)  (index.ts)                      (index.ts)
+```
+
+Chains cross module boundaries, so audit **every** `src/store/*.ts`, not just `index.ts`. A sweep limited to `index.ts` is what left `properties.ts` broken.
+
+### Deciding whether a caller actually needs the message
+
+`rawError: true` is safe to add — it never changes *whether* an action throws, only which error object escapes — but check the caller so the comment you write is true, and so you know the user impact:
+
+- **Renders it** → user-facing bug. `UserMenuLoginForm.vue` does `errorMessage.value = (error as Error).message` and shows it in a `v-alert`, so a failed `signUp` displayed the blob instead of "login already in use".
+- **Logs it** (`logError("...", error)`) → console/Sentry quality only.
+- **Shows generic text** ("See the console for details") → log quality only; the UI string is unaffected.
+
+One thing that looks like a gap but is not: `ServerStatus.vue` renders `sync.lastError.message`, yet the sync indicator was never affected by missing `rawError`. `setSaving(error)` is called from *inside* the action's own catch, so it receives the original error before any decorator wrapping. Don't "fix" that path.
+
+### Auditing
+
+```bash
+# 1. Bare @Action with a throw close below it — the deliberate throwers.
+#    Returns nothing as of this writing: every such action now has the flag,
+#    so any hit is a new one. Misses propagators (see above).
+grep -rn "@Action$" -A8 src/store/*.ts | grep "throw "
+
+# 2. Higher-signal, and catches propagators: callers that display a store
+#    error's message. Quote --include — zsh expands it bare and the command
+#    fails with "no matches found".
+grep -rn "as Error).message" src/ --include="*.vue"
+```
+
+Query 2 is the one that matters: trace each hit back through **every** action on the path and confirm each boundary is `{ rawError: true }`. Query 1 is a cheap supplement, not a substitute — it structurally cannot see the propagator case, which is how the last defect reached review.
+
 ### Testing the real dispatch path (not a mocked one)
 
 Most store tests mock `@/store`/`./index` entirely (see `aiPanel.test.ts`, `toolSuggestions.test.ts`, `MultiSourceConfiguration.test.ts`) because `Main` is heavy to construct. That's fine for testing *callers* of an action, but it can't catch a missing `rawError: true` — the mock just returns/throws whatever the test tells it to, bypassing vuex-module-decorators entirely.
@@ -203,6 +258,21 @@ async function messageOf(promise: Promise<unknown>): Promise<string> {
 const message = await messageOf(main.addMultiSourceMetadata({ ...payload }));
 expect(message).toBe("This operation needs 9.7 MB of storage, ...");
 ```
+
+Two setup details for these real-dispatch tests:
+
+**Getters and state on the accessor are non-configurable.** `vi.spyOn(main, "isLoggedIn", "get")` throws `TypeError: Cannot redefine property`, and `(main as any).girderUser = ...` throws `Cannot set property ... which has only a getter`. Set the underlying Vuex state instead:
+
+```typescript
+import store from "./root";
+function setLoggedIn(loggedIn: boolean) {
+  (store.state as any).main.girderUser = loggedIn ? { _id: "u1" } : null;
+}
+```
+
+Protected mutations are reachable for setup via a cast — `(main as any).setConfigurationImpl({ id, data })` — which is usually less work than driving the real load path.
+
+**Some actions can't be reached this way.** `signUp` builds its own `RestClient` internally, and `RestClient` assigns `post`/`get` as *own instance properties* in its constructor (not on the prototype), so there is no seam: `vi.spyOn(RestClient.prototype, "post")` doesn't exist to spy on, and mocking `@/girder` wholesale collides with `store/index.ts`'s module-level girder init. Don't sink time into it — verify that one by inspection and lean on the coverage of the sibling actions.
 
 ## Reference
 


### PR DESCRIPTION
Records the learnings from PR #1262 into the skills, so the next agent doesn't repeat them. Docs only — no `src/` changes.

Each item comes from something that shipped or was missed on that PR **despite `tsc`, lint, tests and reasoning all passing**.

## nimbus-frontend

The `rawError` section already existed (added in `7f4dea0b`) and still didn't prevent the bug. Two things were missing:

- **An action needs the flag when it merely *propagates*, not only when it contains `throw`.** `createProperty` has no `throw` and still emitted the `ERR_ACTION_ACCESS_UNDEFINED` blob. So an audit that greps action bodies for `throw` reports clean and misses it — which is exactly how the defect reached Codex.
- **Errors are re-wrapped at every `@Action` boundary they cross, across modules.** The `create_property` chain crosses four (`createProperty → setProperties → updateConfigurationProperties → syncConfiguration`); one bare `@Action` anywhere on the path mangles the message. A sweep limited to `index.ts` is what left `properties.ts` broken.

Also documented: how to tell which callers actually display the message (renders it → user-facing bug; logs it → console quality only), that `sync.lastError` / `ServerStatus.vue` is **not** affected even though it renders `.message` (because `setSaving` receives the error caught *inside* the action, pre-wrapping) so nobody "fixes" that path, and the vitest setup details — accessor getters are non-configurable, and `signUp` has no mockable seam so don't sink time into it.

Plus a new section on **partial persistence**: `syncConfiguration(key)` PUTs the whole key, so N single-field calls in one operation issue N writes of that key, and a mid-sequence failure leaves the shared collection partially updated *while reporting failure*. Two instances shipped (`set_scale`, `update_layer`). Interleaved *validation* is the easier half to miss because it fails with no backend involved at all.

## branch-review

Both patterns as numbered frontend checks, with rows added to the checklist table and issue categories so they're actually reported. Notes that the repeated writes are sequential `await`s on different fields — not a `.map()` — so the existing looped-call check doesn't catch them.

## fixing-review-findings

The two patterns in the sweep table, plus a note to check the **shape** of a sweep and not just its target when it comes back clean.

Also **Codex round mechanics**, which cost real time this session: Codex doesn't review on push (only PR open, draft→ready, or an `@codex review` comment), and its three signals are easy to confuse — 👀 means working, 👍 means clean, and a clean result can arrive as a *plain PR comment* rather than a review object. Polling for only a review object plus 👍 reported a false timeout.

## in-browser-testing

- `javascript_tool` never returns an async IIFE's value — stash on `window`, read in a second call, return a string.
- All store actions dispatch **un-namespaced** in every module, and a namespaced name *resolves* silently → a false "no throw" rather than an error.
- How to verify error propagation and write counts without touching real data (stub the API method to reject / re-save existing values and count writes).
- Page→screenshot coordinate conversion with an `elementFromPoint` hittability check, after eyeballed coords resolved to a `v-expansion-panel-title__overlay` instead of the toggle underneath.
- A live probe is only evidence once you've seen it fail against the pre-fix code.

## Verification

Audit commands are tested as written — `--include` needs quoting under zsh or the grep fails with `no matches found`. `.agents/` mirror regenerated via `sync_skills.py --write`; `--check` and the sync unit tests both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzqX5knspQjXKBJGUPVMpo
