### PR TITLE
Show an active-filter count badge on the Filters button

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -28,6 +28,12 @@ vi.mock("@/store/properties", () => ({
   },
 }));
 
+vi.mock("@/store/filters", () => ({
+  default: {
+    activeFilterCount: 0,
+  },
+}));
+
 vi.mock("axios", () => ({
   default: {
     get: vi
@@ -52,6 +58,7 @@ import { routeProvider, routerProvider } from "@/test/helpers";
 import App from "./App.vue";
 import store from "@/store";
 import propertyStore from "@/store/properties";
+import filterStore from "@/store/filters";
 import axios from "axios";
 import { logError } from "@/utils/log";
 
@@ -64,7 +71,10 @@ const mockRouter = {
   push: vi.fn(),
 };
 
-function mountComponent(routeOverrides: Record<string, any> = {}) {
+function mountComponent(
+  routeOverrides: Record<string, any> = {},
+  extraStubs: Record<string, any> = {},
+) {
   return shallowMount(App, {
     global: {
       mocks: {
@@ -86,9 +96,25 @@ function mountComponent(routeOverrides: Record<string, any> = {}) {
         "bread-crumbs": true,
         "chat-component": true,
         "router-view": true,
+        ...extraStubs,
       },
     },
   });
+}
+
+// shallowMount stubs every Vuetify component, so App.vue's own app-bar markup
+// never renders. These pass-through stubs open up just the chain down to the
+// palette buttons (v-app > v-app-bar > v-tooltip activator slot) so the
+// filter-count badge is asserted against real rendered output.
+const renderAppBarStubs = {
+  VApp: { template: "<div><slot /></div>" },
+  VAppBar: { template: "<div><slot /></div>" },
+  VTooltip: { template: '<div><slot name="activator" :props="{}" /></div>' },
+};
+
+function mountWithAppBar() {
+  (store as any).dataset = { id: "ds1", name: "Dataset" };
+  return mountComponent({ name: "datasetview" }, renderAppBarStubs);
 }
 
 describe("App", () => {
@@ -104,6 +130,7 @@ describe("App", () => {
       getUserPrivateFolder: vi.fn().mockResolvedValue({ _id: "folder-1" }),
     };
     (propertyStore as any).uncomputedCountByProperty = {};
+    (filterStore as any).activeFilterCount = 0;
     (axios.get as any) = vi
       .fn()
       .mockResolvedValue({ data: [{ name: "Tool1", type: "create" }] });
@@ -253,6 +280,56 @@ describe("App", () => {
     const wrapper = mountComponent();
     const vm = wrapper.vm as any;
     expect(vm.hasUncomputedProperties).toBe(false);
+  });
+
+  // -- Computed: activeFilterCount / filtersTooltip --
+  it("activeFilterCount mirrors the filters store", () => {
+    (filterStore as any).activeFilterCount = 3;
+    const wrapper = mountComponent({ name: "datasetview" });
+    expect((wrapper.vm as any).activeFilterCount).toBe(3);
+  });
+
+  it("filtersTooltip omits the count when no filter is active", () => {
+    const wrapper = mountComponent({ name: "datasetview" });
+    expect((wrapper.vm as any).filtersTooltip).toBe(
+      "Filter objects by tags, scope, properties, ID and region",
+    );
+  });
+
+  it("filtersTooltip uses the singular form for one active filter", () => {
+    (filterStore as any).activeFilterCount = 1;
+    const wrapper = mountComponent({ name: "datasetview" });
+    expect((wrapper.vm as any).filtersTooltip).toContain("(1 active filter)");
+  });
+
+  it("filtersTooltip uses the plural form for several active filters", () => {
+    (filterStore as any).activeFilterCount = 4;
+    const wrapper = mountComponent({ name: "datasetview" });
+    expect((wrapper.vm as any).filtersTooltip).toContain("(4 active filters)");
+  });
+
+  // -- Filter-count badge on the Filters button --
+  it("renders no badge on the Filters button when no filter is active", () => {
+    const wrapper = mountWithAppBar();
+    expect(wrapper.find(".palette-ibtn-badge").exists()).toBe(false);
+  });
+
+  it("renders the active filter count on the Filters button", () => {
+    (filterStore as any).activeFilterCount = 3;
+    const wrapper = mountWithAppBar();
+    const badge = wrapper.find(".palette-ibtn-badge");
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe("3");
+    // The badge belongs to the Filters button, not a neighbouring palette one.
+    expect(
+      badge.element.closest("button")?.getAttribute("aria-label"),
+    ).toContain("Filter objects");
+  });
+
+  it("caps the badge at 9+ so it stays inside the icon button", () => {
+    (filterStore as any).activeFilterCount = 12;
+    const wrapper = mountWithAppBar();
+    expect(wrapper.find(".palette-ibtn-badge").text()).toBe("9+");
   });
 
   // -- Computed: filteredToursByCategory --

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -308,6 +308,14 @@ describe("App", () => {
     expect((wrapper.vm as any).filtersTooltip).toContain("(4 active filters)");
   });
 
+  it("filtersAriaLabel stays terse and gains the count when filters are on", () => {
+    let wrapper = mountComponent({ name: "datasetview" });
+    expect((wrapper.vm as any).filtersAriaLabel).toBe("Filters");
+    (filterStore as any).activeFilterCount = 2;
+    wrapper = mountComponent({ name: "datasetview" });
+    expect((wrapper.vm as any).filtersAriaLabel).toBe("Filters (2 active)");
+  });
+
   // -- Filter-count badge on the Filters button --
   it("renders no badge on the Filters button when no filter is active", () => {
     const wrapper = mountWithAppBar();
@@ -320,10 +328,12 @@ describe("App", () => {
     const badge = wrapper.find(".palette-ibtn-badge");
     expect(badge.exists()).toBe(true);
     expect(badge.text()).toBe("3");
-    // The badge belongs to the Filters button, not a neighbouring palette one.
-    expect(
-      badge.element.closest("button")?.getAttribute("aria-label"),
-    ).toContain("Filter objects");
+    // The badge belongs to the Filters button, not a neighbouring palette one,
+    // and the count is mirrored into the label so it is not hidden from
+    // assistive tech (aria-label overrides the button's rendered content).
+    expect(badge.element.closest("button")?.getAttribute("aria-label")).toBe(
+      "Filters (3 active)",
+    );
   });
 
   it("caps the badge at 9+ so it stays inside the icon button", () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -205,7 +205,7 @@
                 type="button"
                 class="palette-ibtn"
                 :class="{ active: filtersPanel }"
-                :aria-label="filtersTooltip"
+                :aria-label="filtersAriaLabel"
                 @click.stop="togglePalette('filtersPanel')"
               >
                 <v-icon size="18">mdi-filter-variant</v-icon>
@@ -878,6 +878,16 @@ const filtersTooltip = computed(() => {
   return `${base} (${count} active filter${count === 1 ? "" : "s"})`;
 });
 
+// The aria-label stays terse to match the sibling palette buttons ("Object
+// list", "Snapshots", "Settings"); the descriptive sentence belongs in the
+// hover tooltip. It carries the count because aria-label overrides the
+// button's content, which would otherwise hide the badge from assistive tech.
+const filtersAriaLabel = computed(() =>
+  activeFilterCount.value === 0
+    ? "Filters"
+    : `Filters (${activeFilterCount.value} active)`,
+);
+
 const hasUncomputedProperties = computed(() => {
   const counts = propertyStore.uncomputedCountByProperty;
   for (const id in counts) {
@@ -1043,6 +1053,7 @@ defineExpose({
   routeName,
   activeFilterCount,
   filtersTooltip,
+  filtersAriaLabel,
   hasUncomputedProperties,
   filteredToursByCategory,
   filtersStacked,
@@ -1066,6 +1077,10 @@ defineExpose({
   flex: 0 0 auto;
 }
 
+/* Base tone of the palette cluster, deliberately theme-independent. The badge
+   below reuses it opaque as a separating ring, so the two must stay in sync. */
+$palette-cluster-tone: #0f1217;
+
 /* Cluster of palette-toggle icon buttons in the app bar.
    Pill-shaped group with hairline border; each button is a 32px circle. */
 .palette-cluster {
@@ -1075,7 +1090,7 @@ defineExpose({
   padding: 4px;
   margin-left: 12px;
   border-radius: 100px;
-  background: rgba(15, 18, 23, 0.55);
+  background: rgba($palette-cluster-tone, 0.55);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border: 1px solid var(--nimbus-border, rgba(255, 255, 255, 0.08));
@@ -1134,7 +1149,7 @@ defineExpose({
   min-width: 15px;
   height: 15px;
   padding: 0 3px;
-  border: 1.5px solid #0f1217;
+  border: 1.5px solid $palette-cluster-tone;
   border-radius: 8px;
   background: rgb(var(--v-theme-primary));
   color: rgb(var(--v-theme-on-primary));

--- a/src/App.vue
+++ b/src/App.vue
@@ -196,9 +196,7 @@
               </button>
             </template>
           </v-tooltip>
-          <v-tooltip
-            text="Filter objects by tags, scope, properties, ID and region"
-          >
+          <v-tooltip :text="filtersTooltip">
             <template v-slot:activator="{ props: activatorProps }">
               <button
                 v-bind="activatorProps"
@@ -207,10 +205,15 @@
                 type="button"
                 class="palette-ibtn"
                 :class="{ active: filtersPanel }"
-                aria-label="Filters"
+                :aria-label="filtersTooltip"
                 @click.stop="togglePalette('filtersPanel')"
               >
                 <v-icon size="18">mdi-filter-variant</v-icon>
+                <!-- Count of active filters, so the user can tell filters are
+                     narrowing the object set even with the panel closed. -->
+                <span v-if="activeFilterCount > 0" class="palette-ibtn-badge">
+                  {{ activeFilterCount > 9 ? "9+" : activeFilterCount }}
+                </span>
               </button>
             </template>
           </v-tooltip>
@@ -482,6 +485,7 @@ import HelpPanel from "./components/HelpPanel.vue";
 import BreadCrumbs from "./layout/BreadCrumbs.vue";
 import store from "@/store";
 import propertyStore from "@/store/properties";
+import filterStore from "@/store/filters";
 import volumeViewStore from "@/store/volumeView";
 import aiPanelStore from "@/store/aiPanel";
 import { logError } from "@/utils/log";
@@ -863,6 +867,17 @@ function onShowInList() {
 const routeName = computed(() => route.name);
 const isDatasetView = computed(() => routeName.value === "datasetview");
 
+const activeFilterCount = computed(() => filterStore.activeFilterCount);
+
+const filtersTooltip = computed(() => {
+  const base = "Filter objects by tags, scope, properties, ID and region";
+  const count = activeFilterCount.value;
+  if (count === 0) {
+    return base;
+  }
+  return `${base} (${count} active filter${count === 1 ? "" : "s"})`;
+});
+
 const hasUncomputedProperties = computed(() => {
   const counts = propertyStore.uncomputedCountByProperty;
   for (const id in counts) {
@@ -1026,6 +1041,8 @@ defineExpose({
   helpPanelIsOpen,
   appHotkeys,
   routeName,
+  activeFilterCount,
+  filtersTooltip,
   hasUncomputedProperties,
   filteredToursByCategory,
   filtersStacked,
@@ -1102,6 +1119,33 @@ defineExpose({
     background: rgb(var(--v-theme-primary));
     box-shadow: 0 0 6px rgba(var(--v-theme-primary), 0.6);
   }
+}
+
+/* Count badge pinned to the top-right of a palette-toggle button (used by
+   Filters to surface the number of active filters while the panel is closed).
+   The ring reuses the cluster's own tone, opaque, so the count reads as
+   separate from the icon glyph it overlaps. It stays within the cluster's 4px
+   padding and its 2px inter-button gap, so it never covers a neighbour. */
+.palette-ibtn-badge {
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  box-sizing: border-box;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  border: 1.5px solid #0f1217;
+  border-radius: 8px;
+  background: rgb(var(--v-theme-primary));
+  color: rgb(var(--v-theme-on-primary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--nimbus-font);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  pointer-events: none;
 }
 </style>
 <style lang="scss">

--- a/src/store/__tests__/activeFilterCount.test.ts
+++ b/src/store/__tests__/activeFilterCount.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the `activeFilterCount` getter that drives the count badge on the
+ * app-bar Filters button. The badge exists so a user can tell filters are
+ * narrowing the object set even when the Filters panel is closed, so the count
+ * must include every filter kind the panel exposes and nothing else.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mainMock } = vi.hoisted(() => ({
+  mainMock: {
+    xy: 0,
+    z: 0,
+    time: 0,
+    dataset: null as { id: string } | null,
+    showAnnotationsFromHiddenLayers: true,
+    scheduleAnnotationBrowserSave: () => {},
+  },
+}));
+
+vi.mock("@/store/index", () => ({ default: mainMock }));
+vi.mock("@/store/annotation", () => ({
+  default: {
+    annotations: [],
+    selectedAnnotationIds: ["a", "b"],
+    annotationsForIteration: [],
+    annotationCentroids: {},
+    stubOnlyMode: false,
+  },
+}));
+vi.mock("@/store/properties", () => ({
+  default: {
+    propertyValues: {},
+    propertiesAPI: { getPropertyHistogram: () => Promise.resolve([]) },
+  },
+}));
+vi.mock("geojs", () => ({
+  default: { util: { pointInPolygon: () => false } },
+}));
+
+import filters from "@/store/filters";
+import { PropertyFilterMode } from "@/store/model";
+
+function addAreaFilter(enabled: boolean) {
+  filters.updatePropertyFilter({
+    id: "pf-area",
+    exclusive: false,
+    enabled,
+    propertyPath: ["p", "Area"],
+    range: { min: 0, max: 5 },
+    valuesOrRange: PropertyFilterMode.Range,
+    values: [],
+  });
+}
+
+describe("filters.activeFilterCount", () => {
+  beforeEach(() => {
+    filters.resetFilterState();
+    filters.setOnlyCurrentFrame(false);
+    mainMock.showAnnotationsFromHiddenLayers = true;
+  });
+
+  it("is 0 when no filter is active", () => {
+    expect(filters.activeFilterCount).toBe(0);
+  });
+
+  it("counts an enabled tag filter once", () => {
+    filters.setTagFilter({
+      id: "tagFilter",
+      exclusive: false,
+      enabled: true,
+      tags: ["nucleus"],
+    });
+    expect(filters.activeFilterCount).toBe(1);
+  });
+
+  it("does not count a disabled tag filter that still holds tags", () => {
+    filters.setTagFilter({
+      id: "tagFilter",
+      exclusive: false,
+      enabled: false,
+      tags: ["nucleus"],
+    });
+    expect(filters.activeFilterCount).toBe(0);
+  });
+
+  it("counts the current-frame scope toggle", () => {
+    filters.setOnlyCurrentFrame(true);
+    expect(filters.activeFilterCount).toBe(1);
+  });
+
+  it("counts hiding objects from hidden layers (non-default toggle)", () => {
+    mainMock.showAnnotationsFromHiddenLayers = false;
+    expect(filters.activeFilterCount).toBe(1);
+  });
+
+  it("counts only enabled property filters", () => {
+    addAreaFilter(true);
+    expect(filters.activeFilterCount).toBe(1);
+    addAreaFilter(false);
+    expect(filters.activeFilterCount).toBe(0);
+  });
+
+  it("counts each enabled region filter and ignores one still being drawn", () => {
+    filters.newROIFilter();
+    // Only the pending (empty) filter exists so far — nothing filters yet.
+    expect(filters.activeFilterCount).toBe(0);
+    filters.validateNewROIFilter([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: 1 },
+    ]);
+    expect(filters.activeFilterCount).toBe(1);
+    filters.toggleRoiFilterEnabled("Region Filter 0");
+    expect(filters.activeFilterCount).toBe(0);
+  });
+
+  it("counts each enabled annotation id filter", () => {
+    filters.newAnnotationIdFilter(["a"]);
+    filters.newAnnotationIdFilter(["b"]);
+    expect(filters.activeFilterCount).toBe(2);
+    filters.toggleAnnotationIdFilterEnabled("Annotation List Filter 0");
+    expect(filters.activeFilterCount).toBe(1);
+  });
+
+  it("counts the selection filter", () => {
+    filters.addSelectionAsFilter();
+    expect(filters.activeFilterCount).toBe(1);
+    filters.clearSelection();
+    expect(filters.activeFilterCount).toBe(0);
+  });
+
+  it("sums filters of different kinds", () => {
+    filters.setTagFilter({
+      id: "tagFilter",
+      exclusive: false,
+      enabled: true,
+      tags: ["nucleus"],
+    });
+    filters.setOnlyCurrentFrame(true);
+    addAreaFilter(true);
+    filters.addSelectionAsFilter();
+    mainMock.showAnnotationsFromHiddenLayers = false;
+    expect(filters.activeFilterCount).toBe(5);
+  });
+
+  it("returns to 0 after the per-dataset filter state is reset", () => {
+    filters.setTagFilter({
+      id: "tagFilter",
+      exclusive: false,
+      enabled: true,
+      tags: ["nucleus"],
+    });
+    addAreaFilter(true);
+    filters.addSelectionAsFilter();
+    filters.resetFilterState();
+    expect(filters.activeFilterCount).toBe(0);
+  });
+});

--- a/src/store/filters.ts
+++ b/src/store/filters.ts
@@ -21,6 +21,7 @@ import { createSequenceGuard } from "@/utils/sequenceGuard";
 
 import {
   TAnnotationOrStub,
+  IAnnotationFilter,
   ITagAnnotationFilter,
   IPropertyAnnotationFilter,
   IROIAnnotationFilter,
@@ -280,6 +281,27 @@ export class Filters extends VuexModule {
   get hasActivePropertyFilter() {
     return this.propertyFilters.some(
       (filter: IPropertyAnnotationFilter) => filter.enabled,
+    );
+  }
+
+  // How many filters are currently narrowing the set of visible objects.
+  // Drives the count badge on the app-bar Filters button, so active filters
+  // stay discoverable while the panel is closed. Each enabled filter row
+  // counts once; the boolean toggles count once when set away from their
+  // permissive default (showAnnotationsFromHiddenLayers defaults to true, so
+  // it only counts when off). `emptyROIFilter` is a region still being drawn
+  // and filters nothing yet, so it is excluded.
+  get activeFilterCount() {
+    const countEnabled = (filterList: IAnnotationFilter[]) =>
+      filterList.filter((filter: IAnnotationFilter) => filter.enabled).length;
+    return (
+      (this.tagFilter.enabled ? 1 : 0) +
+      (this.onlyCurrentFrame ? 1 : 0) +
+      (this.selectionFilter.enabled ? 1 : 0) +
+      (main.showAnnotationsFromHiddenLayers ? 0 : 1) +
+      countEnabled(this.propertyFilters) +
+      countEnabled(this.roiFilters) +
+      countEnabled(this.annotationIdFilters)
     );
   }
 


### PR DESCRIPTION
## What

Filters keep narrowing the visible object set after the Filters palette is closed, and nothing in the app bar says so — users can be left wondering why objects are missing. This adds a count badge to the app-bar Filters button.

## Changes

**`src/store/filters.ts`** — new `activeFilterCount` getter. It counts:

- each enabled tag / property / region / object-id filter
- the selection filter when enabled
- the two boolean toggles when set away from their permissive default: `onlyCurrentFrame` on, and `showAnnotationsFromHiddenLayers` off (it defaults to `true`)

`emptyROIFilter` — a region still being drawn — filters nothing yet and is excluded.

**`src/App.vue`** — a `.palette-ibtn-badge` span inside the Filters button, shown only when the count is non-zero and capped at `9+` so it stays inside the 32px icon button. The tooltip gains the count too (`… (3 active filters)`), and the `aria-label` becomes `Filters (3 active)` — it stays terse to match the sibling palette buttons, but carries the count because `aria-label` overrides the button's rendered content and would otherwise hide the badge from assistive tech.

The badge's separating ring and the palette cluster's background now share a `$palette-cluster-tone` SCSS variable instead of each hardcoding the same value.

## Testing

- `src/store/__tests__/activeFilterCount.test.ts` (new, 11 cases) covers each filter kind, disabled-but-populated filters, a region mid-draw, mixed sums, and the reset-on-dataset-switch path.
- `src/App.test.ts` covers the tooltip/aria-label strings and asserts the badge markup against real rendered output — this needed pass-through stubs for `v-app` / `v-app-bar` / `v-tooltip`, since `shallowMount` stubs the root `v-app` and App.vue's own app-bar markup never renders otherwise.
- `pnpm test` 2964 passed (178 files), `pnpm tsc` clean, `pnpm lint:ci` clean, `pnpm build` succeeds and the compiled CSS was checked to confirm the SCSS variable resolves to the same tone as before.

Not verified in a live browser: this environment has no Docker, so no Girder backend or dataset to load the app bar against. The badge markup and CSS are covered by the render test and a bundle-output check instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDmkc7um3o911eUYyXgzgj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDmkc7um3o911eUYyXgzgj)_