### PR TITLE
Label unrolled frames and make the labels navigate (#151)

### DIFF
--- a/.agents/skills/in-browser-testing/SKILL.md
+++ b/.agents/skills/in-browser-testing/SKILL.md
@@ -9,12 +9,18 @@ description: "Use when verifying NimbusImage changes in a live browser tab (loca
 
 Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reasoning — and only broke in the live app (pointer-events layering, deep-watch over-firing, HMR-corrupted store, background-tab false-passes). For any user-facing change, in-browser verification is a required gate, and it must be done in a way that can actually fail. The traps below each produced a false "it works" at least once.
 
-## The four false-pass traps
+## The five false-pass traps
 
 1. **Synthetic clicks lie.** `element.dispatchEvent(new MouseEvent('click'))` bypasses hit-testing, `pointer-events`, z-index, and overlays. A synthetic-click walkthrough once reported a tour "working" while real user clicks did nothing. Verify clickability with `document.elementFromPoint(cx, cy)` (is the intended element the topmost hit target?), then click with the real `computer` tool. Reserve synthetic dispatch for *driving* flows fast only after clickability is independently confirmed.
 2. **Background tabs lie.** A hidden tab pauses `requestAnimationFrame`, throttles `setTimeout` to ~1 Hz, and never composites — perf probes report 0 long tasks and event loops stall/time out. The tab must be foreground/visible for any timing or rendering claim. If a paced loop must survive a background tab, use busy-wait gaps (`while (performance.now() < end) {}`), not setTimeout.
 3. **A stale store lies.** Editing any `src/store/*.ts` while `pnpm run dev` runs breaks HMR (`[vuex] duplicate getter key`, annotations stuck at 0). Hard-reload the page after every store-module edit before trusting anything. (Component `.vue` edits HMR fine.)
 4. **A stale backend lies.** After backend plugin edits, `docker compose restart girder` does NOT load the new code (plugin is baked into the image) — new routes 404 while tox passes. Rebuild: `docker compose build girder && docker compose up -d girder`.
+5. **Screenshots lie about the image itself.** The tile layers are WebGL canvases without `preserveDrawingBuffer`, so a captured screenshot can show the image area **solid black** while the page renders it normally for the user — DOM overlays in the same shot look fine, which makes it read as "the image failed to load". Don't debug that; confirm pixels through GeoJS's own compositing instead:
+   ```js
+   const dataUrl = await map.screenshot(undefined, 'image/png');  // re-renders into a 2D canvas
+   // draw to an offscreen canvas, then getImageData → report max/mean channel value
+   ```
+   A non-zero max means the tiles are there. Note that a fluorescence dataset is *legitimately* near-black at fit-to-view zoom (sparse bright cells, `hist.max` pinned to 65535 by a few saturated pixels), so a low mean is not evidence of a bug either. Verify tile health from `statusCode`s in `read_network_requests` (`/tiles/zxy/` → 200) plus the layers' `idle`/`_imageUrls`, and verify overlays from live DOM state — not from the picture.
 
 ## Console handles (javascript_tool)
 

--- a/.agents/skills/nimbus-geojs/SKILL.md
+++ b/.agents/skills/nimbus-geojs/SKILL.md
@@ -31,6 +31,36 @@ The image map has `ingcs !== gcs` (y-flipped/scaled pixel system from `geojs.uti
 
 `_update` (the WebGL feature-data rebuild) only runs when the layer's `modified()` timestamp advanced. `clearOldAnnotations` marks modified only when it *removes* something; a pure add pass with `update=false` marks nothing → invisible features. Debugging tell: run `layer.modified(); layer.draw()` in the console — if features appear instantly, it's this, not missing data. Guard the `modified()` call on "count actually grew" so pure pans keep the incremental-draw optimization.
 
+## Clickable overlays anchored to image coordinates (ui-layer dom widgets)
+
+For UI that must sit at a fixed *image* position and be clickable (frame labels on the
+unrolled grid, `ImageViewer.vue`), a `dom` widget on a `ui` layer beats a text feature or a
+Vue overlay — GeoJS does the coordinate tracking and you get a real element to style and bind:
+
+```ts
+const widget = uiLayer.createWidget("dom", { position: { x, y } });  // map coords
+const element = widget.canvas();   // a real <div>
+element.onclick = ...;
+```
+
+- Passing `position: {x, y}` **to the constructor** binds the `geo_event.pan` reposition handler
+  (last lines of `geojs/src/ui/widget.js`). `map.zoom()` ends in a `pan()` and `map.size()` ends in a
+  `center()`, so one binding covers pan, zoom and container resize — no watcher needed.
+  A position of `{top, left, …}` instead pins the widget to the viewport (that's the scalebar).
+- `domWidget._init` calls `stopPropagation` on `mousedown`, so a click on the widget never reaches
+  the GeoJS interactor — **this is what keeps an armed drawing tool from creating an annotation
+  when the user clicks the overlay.** Verify it with a tool selected, not just with no tool.
+- Widget elements are direct children of an active `.geojs-layer`, which is `pointer-events: none`
+  with `&.active > * { pointer-events: auto }` — so the widget is clickable and the rest of the
+  layer stays transparent to map interaction. Layers are `active` by default.
+- Style widget elements from an **unscoped** `<style>` block; scoped CSS can't reach GeoJS-created
+  DOM (no `data-v-` attribute). Same reason `.scale-widget` lives in ImageViewer's unscoped block.
+- One element per cell is repositioned on every pan, so cap the count for big grids
+  (`MAX_UNROLL_LABEL_CELLS`) and rebuild only on a signature change, not on every `draw()`.
+- Teardown: `uiLayer.deleteWidget(w)` → `widget._exit()` unbinds the pan handler and removes the
+  element; `map.exit()` cascades to child widgets. Key per-map widget bookkeeping off the map
+  object (a `WeakMap`), so a map reset naturally drops the stale entry.
+
 ## Testing AnnotationViewer (unit)
 
 Full guide: `codebaseDocumentation/FRONTEND_COMPONENT_TESTING.md`. Non-obvious conventions in `src/components/AnnotationViewer.test.ts`:

--- a/.claude/skills/in-browser-testing/SKILL.md
+++ b/.claude/skills/in-browser-testing/SKILL.md
@@ -9,12 +9,18 @@ description: "Use when verifying NimbusImage changes in a live browser tab (loca
 
 Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reasoning — and only broke in the live app (pointer-events layering, deep-watch over-firing, HMR-corrupted store, background-tab false-passes). For any user-facing change, in-browser verification is a required gate, and it must be done in a way that can actually fail. The traps below each produced a false "it works" at least once.
 
-## The four false-pass traps
+## The five false-pass traps
 
 1. **Synthetic clicks lie.** `element.dispatchEvent(new MouseEvent('click'))` bypasses hit-testing, `pointer-events`, z-index, and overlays. A synthetic-click walkthrough once reported a tour "working" while real user clicks did nothing. Verify clickability with `document.elementFromPoint(cx, cy)` (is the intended element the topmost hit target?), then click with the real `computer` tool. Reserve synthetic dispatch for *driving* flows fast only after clickability is independently confirmed.
 2. **Background tabs lie.** A hidden tab pauses `requestAnimationFrame`, throttles `setTimeout` to ~1 Hz, and never composites — perf probes report 0 long tasks and event loops stall/time out. The tab must be foreground/visible for any timing or rendering claim. If a paced loop must survive a background tab, use busy-wait gaps (`while (performance.now() < end) {}`), not setTimeout.
 3. **A stale store lies.** Editing any `src/store/*.ts` while `pnpm run dev` runs breaks HMR (`[vuex] duplicate getter key`, annotations stuck at 0). Hard-reload the page after every store-module edit before trusting anything. (Component `.vue` edits HMR fine.)
 4. **A stale backend lies.** After backend plugin edits, `docker compose restart girder` does NOT load the new code (plugin is baked into the image) — new routes 404 while tox passes. Rebuild: `docker compose build girder && docker compose up -d girder`.
+5. **Screenshots lie about the image itself.** The tile layers are WebGL canvases without `preserveDrawingBuffer`, so a captured screenshot can show the image area **solid black** while the page renders it normally for the user — DOM overlays in the same shot look fine, which makes it read as "the image failed to load". Don't debug that; confirm pixels through GeoJS's own compositing instead:
+   ```js
+   const dataUrl = await map.screenshot(undefined, 'image/png');  // re-renders into a 2D canvas
+   // draw to an offscreen canvas, then getImageData → report max/mean channel value
+   ```
+   A non-zero max means the tiles are there. Note that a fluorescence dataset is *legitimately* near-black at fit-to-view zoom (sparse bright cells, `hist.max` pinned to 65535 by a few saturated pixels), so a low mean is not evidence of a bug either. Verify tile health from `statusCode`s in `read_network_requests` (`/tiles/zxy/` → 200) plus the layers' `idle`/`_imageUrls`, and verify overlays from live DOM state — not from the picture.
 
 ## Console handles (javascript_tool)
 

--- a/.claude/skills/nimbus-geojs/SKILL.md
+++ b/.claude/skills/nimbus-geojs/SKILL.md
@@ -31,6 +31,36 @@ The image map has `ingcs !== gcs` (y-flipped/scaled pixel system from `geojs.uti
 
 `_update` (the WebGL feature-data rebuild) only runs when the layer's `modified()` timestamp advanced. `clearOldAnnotations` marks modified only when it *removes* something; a pure add pass with `update=false` marks nothing → invisible features. Debugging tell: run `layer.modified(); layer.draw()` in the console — if features appear instantly, it's this, not missing data. Guard the `modified()` call on "count actually grew" so pure pans keep the incremental-draw optimization.
 
+## Clickable overlays anchored to image coordinates (ui-layer dom widgets)
+
+For UI that must sit at a fixed *image* position and be clickable (frame labels on the
+unrolled grid, `ImageViewer.vue`), a `dom` widget on a `ui` layer beats a text feature or a
+Vue overlay — GeoJS does the coordinate tracking and you get a real element to style and bind:
+
+```ts
+const widget = uiLayer.createWidget("dom", { position: { x, y } });  // map coords
+const element = widget.canvas();   // a real <div>
+element.onclick = ...;
+```
+
+- Passing `position: {x, y}` **to the constructor** binds the `geo_event.pan` reposition handler
+  (last lines of `geojs/src/ui/widget.js`). `map.zoom()` ends in a `pan()` and `map.size()` ends in a
+  `center()`, so one binding covers pan, zoom and container resize — no watcher needed.
+  A position of `{top, left, …}` instead pins the widget to the viewport (that's the scalebar).
+- `domWidget._init` calls `stopPropagation` on `mousedown`, so a click on the widget never reaches
+  the GeoJS interactor — **this is what keeps an armed drawing tool from creating an annotation
+  when the user clicks the overlay.** Verify it with a tool selected, not just with no tool.
+- Widget elements are direct children of an active `.geojs-layer`, which is `pointer-events: none`
+  with `&.active > * { pointer-events: auto }` — so the widget is clickable and the rest of the
+  layer stays transparent to map interaction. Layers are `active` by default.
+- Style widget elements from an **unscoped** `<style>` block; scoped CSS can't reach GeoJS-created
+  DOM (no `data-v-` attribute). Same reason `.scale-widget` lives in ImageViewer's unscoped block.
+- One element per cell is repositioned on every pan, so cap the count for big grids
+  (`MAX_UNROLL_LABEL_CELLS`) and rebuild only on a signature change, not on every `draw()`.
+- Teardown: `uiLayer.deleteWidget(w)` → `widget._exit()` unbinds the pan handler and removes the
+  element; `map.exit()` cascades to child widgets. Key per-map widget bookkeeping off the map
+  object (a `WeakMap`), so a map reset naturally drops the stale entry.
+
 ## Testing AnnotationViewer (unit)
 
 Full guide: `codebaseDocumentation/FRONTEND_COMPONENT_TESTING.md`. Non-obvious conventions in `src/components/AnnotationViewer.test.ts`:

--- a/codebaseDocumentation/UNROLL-FRAME-LABELS-REVIEW.md
+++ b/codebaseDocumentation/UNROLL-FRAME-LABELS-REVIEW.md
@@ -1,0 +1,107 @@
+# Unroll frame labels (#151 / PR #1276) — review findings
+
+Round 1: Codex review of `claude/issue-151-unroll-frame-labels`, plus one
+follow-up request from Arjun.
+
+| # | Severity | Location | Summary | Status |
+|---|---|---|---|---|
+| 1 | Medium | `ImageViewer.vue:489`, `utils/unroll.ts:85` | Axis indices ranked over one layer's frames, and that one layer's cells reused for every map — a sparse layer navigates to the wrong frame | fixed |
+| 2 | Low | `ImageViewer.vue:934` | Clickable label is a `<div>`: no keyboard access, no button semantics | fixed |
+| 3 | — (request) | `utils/unroll.ts` | Also show the dataset's dimension label — `XY 1 (19263, -6626)` | fixed |
+| 4 | Low | `ImageViewer.vue:499` | Round 2: toggling "Show XY/Z/Time labels" while unrolled left the existing widgets stale until the next `draw()` | fixed |
+
+## Finding 1 — verified real
+
+`getUnrollCells` ranked each axis value among the distinct values of the images
+it was handed, and it was handed one layer's images (`layerStackImages.find(lsi
+=> lsi.images[0])`). But `store.xy` / `.z` / `.time` index into `dataset.xy` /
+`.z` / `.time`, which `parseTiles` builds from **every** frame of the dataset.
+So for a channel present only at XY 0 and 5 in a dataset whose frames cover
+XY 0, 2, 5:
+
+- rank within the layer: `5 → 1` → navigates to `dataset.xy[1]` = XY **2**
+- correct: `5 → 2`
+
+The label was wrong the same way (`XY 2` on the cell showing XY 5). Complete
+Cartesian datasets — the normal case — hide it, because rank within one layer
+equals rank within the dataset.
+
+Second half of the finding: `updateUnrollLabels` computed one cells array and
+applied it to every map, but in `layerMode: "unroll"` each map draws its own
+layer group, so a group with different frame coverage got another group's
+labels.
+
+**Fix.** `getUnrollCells` takes a single options object: `cellImages` (grid
+order, per map) and `axisImages` (the frames the ranks come from —
+`dataset.allImages`). `ImageViewer` computes cells per map from that map's own
+`mapLayerList` group.
+
+Not done, deliberately: extracting the axis-array construction out of
+`parseTiles` to share it literally. `parseTiles` builds `z`/`time` through the
+`zs`/`ts` map machinery that also does the unroll `-1` collapsing; pulling that
+apart is a bigger, riskier change than this fix needs. `sortedAxisValues` in
+`unroll.ts` mirrors it instead, with a comment saying so.
+
+## Finding 2 — verified real
+
+The widget element was a `div` with an `onclick`, so keyboard users could not
+reach it and screen readers saw no control. GeoJS's `domWidget` honours
+`arg.el`, so the element is now a real `<button type="button">` with an
+`aria-label`, and the mousedown-stopPropagation behaviour that keeps clicks away
+from the drawing tools is unchanged (it is bound on the widget canvas whatever
+the tag is).
+
+## Finding 3 — follow-up request
+
+Labels now read `XY 1 (19263, -6626)` when the dataset has
+`meta.dimensionLabels` for that axis, and plain `XY 1` when it doesn't. Gated
+per axis on the existing viewer settings (`showXYLabels` / `showZLabels` /
+`showTimeLabels`), which is what the navigator sliders already use to decide
+whether to show a dimension label — so one switch controls both.
+
+## Finding 4 — verified real (round 2)
+
+Nothing consumed the cells until the next `draw()`, and the label settings never
+cause one, so flipping "Show XY position labels" while unrolled left the old
+text on screen. Fixed with `watch(unrollCellsByMap, () => updateUnrollLabels())`
+— watching the cells rather than the settings covers every input that only
+changes label text, now and later. `updateUnrollLabels` lost its `someImage`
+parameter (it derives it from the same layer the cells come from) so it can be
+called from the watcher, and it still no-ops on an unchanged signature, so the
+extra calls from the draw path cost a string compare.
+
+Verified live, not just in vitest: `commit('setShowXYLabels', false)` on the
+unrolled `normmedia` dataset rewrote the six labels from
+`XY 1 (19263, -6626)` to `XY 1` with no redraw, and back again.
+
+### Test-harness fixes this round exposed
+
+Both were pre-existing and made the new test fail for reasons unrelated to the
+code under test:
+
+- `afterEach` had an empty `if (wrapper) {}` block, so every mounted
+  `ImageViewer` stayed alive and kept reacting to the shared `reactive()` store
+  mock. A store change in a later test therefore ran ~90 earlier components'
+  watchers, all writing widgets onto the same `mockedStore.maps` entry (183
+  labels where 2 were expected). Now it unmounts.
+- The label assertions read `createWidget.mock.results`, i.e. the creation log,
+  which also counts labels a later rebuild deleted — and `draw()` replaces a map
+  entry every time in the harness, because `needReset` keys off
+  `!mapElement.firstChild` and the mocked map never appends a child. Assertions
+  now read created-minus-deleted widgets from the *current* map entry.
+
+## Pattern sweep
+
+- **Ranks/indices derived from a subset of frames**: the only other place that
+  maps a frame to a store index is `AnnotationViewer.unrollIndex` →
+  `unrollIndexFromImages`, which resolves a *cell position* (`keyOffset`) from
+  `dataset.images(...)`, not an axis index — different quantity, correct as is.
+- **Per-map state computed once from the first layer**: `unrollW` / `unrollH`
+  and the map bounds in `draw()` are also derived from the first layer with
+  images and shared across maps. That is pre-existing and deliberate (every map
+  shows the same grid geometry); labels now describe each map's own frames
+  within that shared geometry.
+- **Click-only affordances on GeoJS-created DOM**: the scale widgets
+  (`updateScaleWidget` / `updateScalePixelWidget`) have the same issue as
+  finding 2 — an `onclick` on an SVG element. Out of scope for this branch;
+  noted here rather than fixed silently.

--- a/docs/superpowers/specs/2026-07-25-unroll-frame-labels-design.md
+++ b/docs/superpowers/specs/2026-07-25-unroll-frame-labels-design.md
@@ -1,0 +1,72 @@
+# Unroll frame labels with click-to-navigate (issue #151)
+
+## Goal
+
+When a dimension is unrolled (XY / Z / Time), label each cell of the unrolled
+grid in its upper-left corner, and make the label a control: clicking it turns
+unroll off and jumps the viewer to that frame.
+
+## Behavior
+
+- Labels appear only while `store.unroll` is true (any of `unrollXY`,
+  `unrollZ`, `unrollT`). No new setting; they disappear with unroll.
+- Text mirrors the Navigator sliders' 1-based display (`:offset="1"`):
+  `XY 3`, `Z 2`, `T 7`. When several axes are unrolled at once the label joins
+  them: `XY 3 · Z 2`.
+- Clicking a label:
+  1. sets `store.xy` / `store.z` / `store.time` to that cell's indices for the
+     unrolled axes (non-unrolled axes keep their current value), then
+  2. clears the unroll flags that are on.
+  The dataset reload that turns the grid back into a single frame is the
+  existing `NavigatorPanel` watcher on the three flags — the same mechanism
+  snapshot restore (`Snapshots.vue`) and the AI panel (`agent/executors.ts`)
+  rely on. Nothing here calls `refreshDataset` itself, which would double the
+  reload.
+- Only the label is clickable. The rest of each cell keeps today's behavior so
+  annotation tools still work in unroll mode.
+
+## Grid → frame mapping
+
+`ImageViewer.draw()` lays the grid out with `unrollW`/`unrollH`, and cell _i_ is
+`someImages.images[i]` (`keyOffset === i`). Cell _i_'s top-left in map gcs is
+`(sizeX * (i % unrollW), sizeY * floor(i / unrollW))` — the same convention
+`AnnotationViewer.unrolledCoordinates` uses.
+
+The index to navigate to is **not** the raw frame value. `store.xy` / `z` /
+`time` are indices into `dataset.xy` / `.z` / `.time`, which `parseTiles` builds
+as the sorted distinct axis values (and `z` falls back to `PositionZ`, which can
+be a non-index float). So for each unrolled axis we rank the cell's frame value
+among the sorted distinct values of that axis across the grid's images. That
+reproduces `parseTiles`' array without needing the post-reload dataset, and it
+keeps the label (`rank + 1`) consistent with where the slider lands.
+
+## Components
+
+- **`src/utils/unroll.ts`** (new, pure, unit-tested): `getUnrollCells(images,
+  flags)` → `{ index, label, location: { xy?, z?, time? } }[]`. Holds the
+  ranking and label-formatting rules; no GeoJS, no store.
+- **`src/components/ImageViewer.vue`**: renders the labels as GeoJS
+  `dom` widgets on a ui layer, one per cell, positioned with a gcs
+  `{x, y}` position so GeoJS repositions them on pan and zoom (its `zoom()`
+  ends in a `pan()`, so the `geo_event.pan` handler widgets bind covers both).
+  A `domWidget` stops `mousedown` propagation, so a label click cannot reach
+  the GeoJS interactor and start an annotation. Labels are rebuilt only when a
+  signature (labels + grid width + cell size) changes, and are created on every
+  map so the multi-map `layerMode: "unroll"` view labels each grid.
+- Navigation handler lives in `ImageViewer.vue` next to the widget code and
+  calls the existing store actions (`setXY`/`setZ`/`setTime`,
+  `setUnrollXY`/`setUnrollZ`/`setUnrollT`).
+
+## Bounds
+
+Grids larger than 400 cells get no labels: one DOM node per cell repositioned
+on every pan stops being reasonable, and at that density the text is unreadable
+anyway.
+
+## Testing
+
+- Unit (`src/utils/unroll.test.ts`): ranking with dense and sparse axis values,
+  `PositionZ` fallback, single- and multi-axis labels, empty input.
+- Browser: unroll XY on the `normmedia…` dataset, confirm corner labels on each
+  cell, click one and confirm the view returns to the rolled single frame at
+  that XY (slider value, URL query) with no annotation created.

--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -226,6 +226,7 @@ vi.mock("@/pipelines/computePipeline", () => ({
 import store from "@/store";
 import annotationStore from "@/store/annotation";
 import progressStore from "@/store/progress";
+import { logWarning } from "@/utils/log";
 import ImageViewer from "./ImageViewer.vue";
 
 const mockedStore = vi.mocked(store);
@@ -1266,10 +1267,11 @@ describe("ImageViewer", () => {
   // ---- 14b. Unroll frame labels ----
 
   describe("unroll frame labels", () => {
-    // A 2x2 grid of XY frames: unrollW is ceil(sqrt(4)) = 2 for square images.
-    function unrolledXYStack() {
+    // A grid of XY frames: unrollW is ceil(sqrt(count)) for square images, so
+    // the default 4 frames lay out 2x2.
+    function unrolledXYStack(count = 4) {
       const baseImage = createLayerStackImage().images[0];
-      const images = [0, 1, 2, 3].map((IndexXY) => ({
+      const images = Array.from({ length: count }, (_unused, IndexXY) => ({
         ...baseImage,
         frameIndex: IndexXY,
         frame: { IndexXY },
@@ -1284,18 +1286,21 @@ describe("ImageViewer", () => {
       });
     }
 
-    function mountUnrolled() {
+    function mountUnrolled(frameCount = 4) {
       mockedStore.unroll = true;
       mockedStore.unrollXY = true;
-      mockedStore.layerStackImages = [unrolledXYStack()];
+      mockedStore.layerStackImages = [unrolledXYStack(frameCount)];
       wrapper = mountComponent();
       return (mockedStore.maps[0] as any).uiLayer;
     }
 
+    // The ui layer also hosts the scale widgets, so pick out the labels.
     function labelElements(uiLayer: any): HTMLElement[] {
-      return uiLayer.createWidget.mock.results.map((result: any) =>
-        result.value.canvas(),
-      );
+      return uiLayer.createWidget.mock.results
+        .map((result: any) => result.value.canvas())
+        .filter((element: HTMLElement) =>
+          element.classList.contains("unroll-frame-label"),
+        );
     }
 
     it("labels each cell of the grid at its upper-left corner", () => {
@@ -1359,6 +1364,17 @@ describe("ImageViewer", () => {
       (wrapper.vm as any).clearUnrollLabels();
 
       expect(uiLayer.deleteWidget).toHaveBeenCalledTimes(4);
+    });
+
+    it("labels nothing, and says so, for a grid past the label limit", () => {
+      const uiLayer = mountUnrolled(401);
+
+      expect(uiLayer.createWidget).not.toHaveBeenCalled();
+      // The cells still exist; only the labels are dropped.
+      expect((wrapper.vm as any).unrollCells).toHaveLength(401);
+      expect(vi.mocked(logWarning)).toHaveBeenCalledWith(
+        expect.stringContaining("401 frames exceeds"),
+      );
     });
   });
 

--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -61,16 +61,18 @@ const mockMap = () => {
 };
 
 // GeoJS dom widget: a real element so the label code can set its class, text
-// and click handler.
-const mockDomWidget = () => {
-  const element = document.createElement("div");
+// and click handler. GeoJS builds it from `arg.el`, defaulting to a div.
+const mockDomWidget = (el?: string) => {
+  const element = document.createElement(el || "div");
   return { canvas: vi.fn(() => element) };
 };
 
 const mockLayer = () => ({
   node: vi.fn().mockReturnValue({ css: vi.fn() }),
   createFeature: vi.fn().mockReturnValue({}),
-  createWidget: vi.fn(() => mockDomWidget()),
+  createWidget: vi.fn((_widgetName: string, arg?: any) =>
+    mockDomWidget(arg?.el),
+  ),
   deleteWidget: vi.fn(),
   moveToTop: vi.fn(),
   zIndex: vi.fn().mockReturnValue(0),
@@ -118,6 +120,9 @@ vi.mock("@/store", () => {
       unrollXY: false,
       unrollZ: false,
       unrollT: false,
+      showXYLabels: true,
+      showZLabels: true,
+      showTimeLabels: true,
       selectedTool: null as any,
       layerStackImages: [] as any[],
       layerMode: "multiple",
@@ -319,6 +324,9 @@ describe("ImageViewer", () => {
     mockedStore.unrollXY = false;
     mockedStore.unrollZ = false;
     mockedStore.unrollT = false;
+    mockedStore.showXYLabels = true;
+    mockedStore.showZLabels = true;
+    mockedStore.showTimeLabels = true;
     mockedStore.selectedTool = null;
     mockedStore.layerStackImages = [];
     mockedStore.layerMode = "multiple" as any;
@@ -352,8 +360,11 @@ describe("ImageViewer", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    if (wrapper) {
-    }
+    // Unmount, or every mounted instance keeps reacting to the shared reactive
+    // store mock: a store change in a later test then runs the watchers of
+    // every earlier test's component, all of them writing to the same
+    // mockedStore.maps entries.
+    wrapper?.unmount();
   });
 
   // ---- 1. Mounting & Lifecycle ----
@@ -1269,7 +1280,7 @@ describe("ImageViewer", () => {
   describe("unroll frame labels", () => {
     // A grid of XY frames: unrollW is ceil(sqrt(count)) for square images, so
     // the default 4 frames lay out 2x2.
-    function unrolledXYStack(count = 4) {
+    function unrolledXYStack(count = 4, overrides: any = {}) {
       const baseImage = createLayerStackImage().images[0];
       const images = Array.from({ length: count }, (_unused, IndexXY) => ({
         ...baseImage,
@@ -1277,6 +1288,7 @@ describe("ImageViewer", () => {
         frame: { IndexXY },
       }));
       return createLayerStackImage({
+        ...overrides,
         images,
         urls: images.map((_image, i) => `http://localhost/${i}/{z}/{x}/{y}`),
         fullUrls: images.map(
@@ -1294,13 +1306,28 @@ describe("ImageViewer", () => {
       return (mockedStore.maps[0] as any).uiLayer;
     }
 
-    // The ui layer also hosts the scale widgets, so pick out the labels.
+    // The labels a layer still has: created minus deleted. The creation log
+    // alone would also count labels a rebuild has since removed — and the ui
+    // layer hosts the scale widgets too, hence the class filter.
     function labelElements(uiLayer: any): HTMLElement[] {
+      const deleted = new Set(
+        uiLayer.deleteWidget.mock.calls.map((call: any[]) => call[0]),
+      );
       return uiLayer.createWidget.mock.results
-        .map((result: any) => result.value.canvas())
+        .map((result: any) => result.value)
+        .filter((widget: any) => !deleted.has(widget))
+        .map((widget: any) => widget.canvas())
         .filter((element: HTMLElement) =>
           element.classList.contains("unroll-frame-label"),
         );
+    }
+
+    // Labels on the map as it exists now: draw() can replace a map entry, and
+    // with it the layer the labels live on.
+    function labelTexts(mapIndex = 0): (string | null)[] {
+      return labelElements((mockedStore.maps[mapIndex] as any).uiLayer).map(
+        (element) => element.textContent,
+      );
     }
 
     it("labels each cell of the grid at its upper-left corner", () => {
@@ -1345,7 +1372,116 @@ describe("ImageViewer", () => {
       expect(
         (mockedStore.maps[0] as any).uiLayer.createWidget,
       ).not.toHaveBeenCalled();
-      expect((wrapper.vm as any).unrollCells).toEqual([]);
+      expect((wrapper.vm as any).unrollCellsByMap).toEqual([]);
+    });
+
+    it("makes each label a real button", () => {
+      const uiLayer = mountUnrolled();
+
+      expect(uiLayer.createWidget).toHaveBeenCalledWith(
+        "dom",
+        expect.objectContaining({ el: "button" }),
+      );
+      const [label] = labelElements(uiLayer);
+      expect(label.getAttribute("type")).toBe("button");
+      expect(label.getAttribute("aria-label")).toBe("Show XY 1 on its own");
+    });
+
+    it("ranks frames over the dataset, not over the drawn layer", () => {
+      // The layer covers XY 0 and 5; the dataset's frames cover 0, 2 and 5, and
+      // store.xy indexes into that. So the second cell is dataset index 2.
+      const cellFrames = [0, 5];
+      const stack = unrolledXYStack(2);
+      stack.images.forEach((image: any, i: number) => {
+        image.frame = { IndexXY: cellFrames[i] };
+      });
+      mockedStore.dataset = {
+        ...(mockedStore.dataset as any),
+        allImages: [0, 2, 5].map((IndexXY) => ({ frame: { IndexXY } })),
+      } as any;
+      mockedStore.unroll = true;
+      mockedStore.unrollXY = true;
+      mockedStore.layerStackImages = [stack];
+
+      wrapper = mountComponent();
+      const uiLayer = (mockedStore.maps[0] as any).uiLayer;
+
+      expect(
+        labelElements(uiLayer).map((element) => element.textContent),
+      ).toEqual(["XY 1", "XY 3"]);
+      labelElements(uiLayer)[1].click();
+      expect(mockedStore.setXY).toHaveBeenCalledWith(2);
+    });
+
+    it("includes the dataset's dimension label when that axis is switched on", () => {
+      mockedStore.dataset = {
+        ...(mockedStore.dataset as any),
+        dimensionLabels: { xy: ["19263, -6626", "18743, -8631"] },
+      } as any;
+      mountUnrolled(2);
+
+      expect(labelTexts()).toEqual([
+        "XY 1 (19263, -6626)",
+        "XY 2 (18743, -8631)",
+      ]);
+    });
+
+    it("rebuilds the labels when a viewer label setting is toggled", async () => {
+      // Toggling "Show XY labels" changes only label text, so it never
+      // triggers a redraw — the labels have to react to the setting itself.
+      mockedStore.dataset = {
+        ...(mockedStore.dataset as any),
+        dimensionLabels: { xy: ["19263, -6626", "18743, -8631"] },
+      } as any;
+      mountUnrolled(2);
+      expect(labelTexts()).toEqual([
+        "XY 1 (19263, -6626)",
+        "XY 2 (18743, -8631)",
+      ]);
+
+      mockedStore.showXYLabels = false;
+      await nextTick();
+
+      expect(labelTexts()).toEqual(["XY 1", "XY 2"]);
+    });
+
+    it("drops the dimension label when the viewer setting is off", () => {
+      mockedStore.dataset = {
+        ...(mockedStore.dataset as any),
+        dimensionLabels: { xy: ["19263, -6626", "18743, -8631"] },
+      } as any;
+      mockedStore.showXYLabels = false;
+      mountUnrolled(2);
+
+      expect(labelTexts()).toEqual(["XY 1", "XY 2"]);
+    });
+
+    it("labels each map from its own layer group in unroll layer mode", () => {
+      // Two visible layers, so mapLayerList has two groups and each gets a map.
+      // The second layer covers fewer frames than the first.
+      mockedStore.layerMode = "unroll" as any;
+      mockedStore.unroll = true;
+      mockedStore.unrollXY = true;
+      mockedStore.dataset = {
+        ...(mockedStore.dataset as any),
+        allImages: [0, 1, 2, 3].map((IndexXY) => ({ frame: { IndexXY } })),
+      } as any;
+      mockedStore.layerStackImages = [
+        unrolledXYStack(4, { layer: { id: "layer1" } }),
+        unrolledXYStack(2, { layer: { id: "layer2" } }),
+      ];
+
+      wrapper = mountComponent();
+
+      expect(mockedStore.maps).toHaveLength(2);
+      expect(
+        mockedStore.maps.map((mapentry: any) =>
+          labelElements(mapentry.uiLayer).map((el) => el.textContent),
+        ),
+      ).toEqual([
+        ["XY 1", "XY 2", "XY 3", "XY 4"],
+        ["XY 1", "XY 2"],
+      ]);
     });
 
     it("keeps the labels of an unchanged grid instead of rebuilding them", () => {
@@ -1371,7 +1507,7 @@ describe("ImageViewer", () => {
 
       expect(uiLayer.createWidget).not.toHaveBeenCalled();
       // The cells still exist; only the labels are dropped.
-      expect((wrapper.vm as any).unrollCells).toHaveLength(401);
+      expect((wrapper.vm as any).unrollCellsByMap[0]).toHaveLength(401);
       expect(vi.mocked(logWarning)).toHaveBeenCalledWith(
         expect.stringContaining("401 frames exceeds"),
       );

--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -60,9 +60,18 @@ const mockMap = () => {
   return m;
 };
 
+// GeoJS dom widget: a real element so the label code can set its class, text
+// and click handler.
+const mockDomWidget = () => {
+  const element = document.createElement("div");
+  return { canvas: vi.fn(() => element) };
+};
+
 const mockLayer = () => ({
   node: vi.fn().mockReturnValue({ css: vi.fn() }),
   createFeature: vi.fn().mockReturnValue({}),
+  createWidget: vi.fn(() => mockDomWidget()),
+  deleteWidget: vi.fn(),
   moveToTop: vi.fn(),
   zIndex: vi.fn().mockReturnValue(0),
   visible: vi.fn(),
@@ -106,6 +115,9 @@ vi.mock("@/store", () => {
       scales: { pixelSize: { value: 0.5, unit: "µm" } },
       overview: false,
       unroll: false,
+      unrollXY: false,
+      unrollZ: false,
+      unrollT: false,
       selectedTool: null as any,
       layerStackImages: [] as any[],
       layerMode: "multiple",
@@ -121,6 +133,12 @@ vi.mock("@/store", () => {
       setCameraInfo: vi.fn(),
       setDrawAnnotations: vi.fn(),
       setShowTooltips: vi.fn(),
+      setXY: vi.fn(),
+      setZ: vi.fn(),
+      setTime: vi.fn(),
+      setUnrollXY: vi.fn(),
+      setUnrollZ: vi.fn(),
+      setUnrollT: vi.fn(),
       getLayerHistogram: vi.fn().mockResolvedValue(null),
     }),
   };
@@ -297,6 +315,9 @@ describe("ImageViewer", () => {
     mockedStore.backgroundColor = "black";
     mockedStore.overview = false;
     mockedStore.unroll = false;
+    mockedStore.unrollXY = false;
+    mockedStore.unrollZ = false;
+    mockedStore.unrollT = false;
     mockedStore.selectedTool = null;
     mockedStore.layerStackImages = [];
     mockedStore.layerMode = "multiple" as any;
@@ -1239,6 +1260,105 @@ describe("ImageViewer", () => {
       expect(mockedStore.popMap).toHaveBeenCalledOnce();
       expect(removedMaps[0].map.exit).toBe(map2.exit);
       expect(mockedStore.maps).toHaveLength(1);
+    });
+  });
+
+  // ---- 14b. Unroll frame labels ----
+
+  describe("unroll frame labels", () => {
+    // A 2x2 grid of XY frames: unrollW is ceil(sqrt(4)) = 2 for square images.
+    function unrolledXYStack() {
+      const baseImage = createLayerStackImage().images[0];
+      const images = [0, 1, 2, 3].map((IndexXY) => ({
+        ...baseImage,
+        frameIndex: IndexXY,
+        frame: { IndexXY },
+      }));
+      return createLayerStackImage({
+        images,
+        urls: images.map((_image, i) => `http://localhost/${i}/{z}/{x}/{y}`),
+        fullUrls: images.map(
+          (_image, i) => `http://localhost/${i}/{z}/{x}/{y}?full=true`,
+        ),
+        singleFrame: null,
+      });
+    }
+
+    function mountUnrolled() {
+      mockedStore.unroll = true;
+      mockedStore.unrollXY = true;
+      mockedStore.layerStackImages = [unrolledXYStack()];
+      wrapper = mountComponent();
+      return (mockedStore.maps[0] as any).uiLayer;
+    }
+
+    function labelElements(uiLayer: any): HTMLElement[] {
+      return uiLayer.createWidget.mock.results.map((result: any) =>
+        result.value.canvas(),
+      );
+    }
+
+    it("labels each cell of the grid at its upper-left corner", () => {
+      const uiLayer = mountUnrolled();
+
+      expect(uiLayer.createWidget).toHaveBeenCalledTimes(4);
+      expect(
+        uiLayer.createWidget.mock.calls.map((call: any[]) => call[1].position),
+      ).toEqual([
+        { x: 0, y: 0 },
+        { x: 1024, y: 0 },
+        { x: 0, y: 1024 },
+        { x: 1024, y: 1024 },
+      ]);
+      expect(
+        labelElements(uiLayer).map((element) => element.textContent),
+      ).toEqual(["XY 1", "XY 2", "XY 3", "XY 4"]);
+      expect(labelElements(uiLayer)[0].classList).toContain(
+        "unroll-frame-label",
+      );
+    });
+
+    it("navigates to the clicked frame and rolls the grid up", () => {
+      const uiLayer = mountUnrolled();
+
+      labelElements(uiLayer)[2].click();
+
+      expect(mockedStore.setXY).toHaveBeenCalledWith(2);
+      expect(mockedStore.setUnrollXY).toHaveBeenCalledWith(false);
+      // Only the unrolled dimension moves, and the reload is left to the
+      // unroll flag watcher.
+      expect(mockedStore.setZ).not.toHaveBeenCalled();
+      expect(mockedStore.setTime).not.toHaveBeenCalled();
+      expect(mockedStore.setUnrollZ).not.toHaveBeenCalled();
+      expect(mockedStore.setUnrollT).not.toHaveBeenCalled();
+    });
+
+    it("creates no labels when nothing is unrolled", () => {
+      mockedStore.layerStackImages = [createLayerStackImage()];
+      wrapper = mountComponent();
+
+      expect(
+        (mockedStore.maps[0] as any).uiLayer.createWidget,
+      ).not.toHaveBeenCalled();
+      expect((wrapper.vm as any).unrollCells).toEqual([]);
+    });
+
+    it("keeps the labels of an unchanged grid instead of rebuilding them", () => {
+      const uiLayer = mountUnrolled();
+      uiLayer.createWidget.mockClear();
+
+      (wrapper.vm as any).draw();
+
+      expect(uiLayer.createWidget).not.toHaveBeenCalled();
+      expect(uiLayer.deleteWidget).not.toHaveBeenCalled();
+    });
+
+    it("clears the labels when the grid goes away", () => {
+      const uiLayer = mountUnrolled();
+
+      (wrapper.vm as any).clearUnrollLabels();
+
+      expect(uiLayer.deleteWidget).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -221,9 +221,11 @@ import girderResources from "@/store/girderResources";
 import geojs from "geojs";
 
 import {
+  IGeoJSDomWidget,
   IGeoJSPosition,
   IGeoJSScaleWidget,
   IGeoJSTile,
+  IGeoJSUiLayer,
   IImage,
   ILayerStackImage,
   IMapEntry,
@@ -254,6 +256,7 @@ import { convertLength } from "@/utils/conversion";
 import { IHotkey } from "@/utils/v-mousetrap";
 import { NoOutput } from "@/pipelines/computePipeline";
 import { logWarning } from "@/utils/log";
+import { getUnrollCells, IUnrollCell } from "@/utils/unroll";
 
 function generateFilterURL(
   index: number,
@@ -474,6 +477,43 @@ const mapLayerList = computed<ILayerStackImage[][]>(() => {
     });
   }
   return llist;
+});
+
+// ---- Computed Properties - Unroll Labels ----
+
+// Each label is its own element that GeoJS repositions on every pan, so very
+// large grids would pay for labels too small to read at that density anyway.
+const MAX_UNROLL_LABEL_CELLS = 400;
+
+// Cell count of the last grid that went unlabelled, so the warning is logged
+// once per grid instead of on every recompute.
+let warnedUnrollLabelCells = 0;
+
+const unrollCells = computed<IUnrollCell[]>(() => {
+  if (!unrolling.value) {
+    return [];
+  }
+  // The layer draw() lays the grid out from, so cell order matches the tiles.
+  const someImages = layerStackImages.value.find((lsi) => lsi.images[0]);
+  if (!someImages) {
+    return [];
+  }
+  const cells = getUnrollCells(someImages.images, {
+    unrollXY: store.unrollXY,
+    unrollZ: store.unrollZ,
+    unrollT: store.unrollT,
+  });
+  if (cells.length > MAX_UNROLL_LABEL_CELLS) {
+    if (warnedUnrollLabelCells !== cells.length) {
+      warnedUnrollLabelCells = cells.length;
+      logWarning(
+        `Unrolled grid of ${cells.length} frames exceeds the ` +
+          `${MAX_UNROLL_LABEL_CELLS} frame label limit; labels are hidden`,
+      );
+    }
+    return [];
+  }
+  return cells;
 });
 
 // ---- Mousetrap Bindings ----
@@ -838,6 +878,109 @@ function updateScalePixelWidget() {
   }
 }
 
+// ---- Unroll Frame Labels ----
+//
+// One label per cell of the unrolled grid, anchored to the cell's upper-left
+// corner in map coordinates. GeoJS repositions a widget given an { x, y }
+// position on `geo_event.pan`, which its zoom() also fires, so the labels
+// follow both panning and zooming. A dom widget stops mousedown from reaching
+// the GeoJS interactor, so clicking a label never starts an annotation.
+
+interface IUnrollLabelState {
+  widgets: IGeoJSDomWidget[];
+  // Identifies the labelled grid; a change means the widgets are rebuilt.
+  signature: string;
+}
+
+const unrollLabelStates = new WeakMap<IGeoJSMap, IUnrollLabelState>();
+
+// Roll the grid back up at the clicked frame.
+function navigateToUnrolledCell(cell: IUnrollCell) {
+  const { xy, z, time } = cell.location;
+  if (xy !== undefined) {
+    store.setXY(xy);
+  }
+  if (z !== undefined) {
+    store.setZ(z);
+  }
+  if (time !== undefined) {
+    store.setTime(time);
+  }
+  // Clearing the flags is what rolls the grid up: NavigatorPanel watches all
+  // three and refreshes the dataset, the same path snapshot restore and the AI
+  // panel take. Refreshing here as well would load the dataset twice.
+  if (store.unrollXY) {
+    store.setUnrollXY(false);
+  }
+  if (store.unrollZ) {
+    store.setUnrollZ(false);
+  }
+  if (store.unrollT) {
+    store.setUnrollT(false);
+  }
+}
+
+function createUnrollLabel(
+  uiLayer: IGeoJSUiLayer,
+  cell: IUnrollCell,
+  someImage: IImage,
+) {
+  const widget = uiLayer.createWidget("dom", {
+    position: {
+      x: someImage.sizeX * (cell.index % unrollW.value),
+      y: someImage.sizeY * Math.floor(cell.index / unrollW.value),
+    },
+  });
+  const element = widget.canvas();
+  element.classList.add("unroll-frame-label");
+  element.textContent = cell.label;
+  element.title = `Show ${cell.label} on its own`;
+  element.onclick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    navigateToUnrolledCell(cell);
+  };
+  return widget;
+}
+
+function clearUnrollLabels() {
+  for (const mapentry of maps.value) {
+    const state = unrollLabelStates.get(mapentry.map);
+    if (!state) {
+      continue;
+    }
+    state.widgets.forEach((widget) => mapentry.uiLayer?.deleteWidget(widget));
+    unrollLabelStates.delete(mapentry.map);
+  }
+}
+
+function updateUnrollLabels(someImage: IImage) {
+  // Unlabelled cells (a grid whose unrolled dimensions all have one value)
+  // get no widget.
+  const cells = unrollCells.value.filter((cell) => cell.label);
+  const signature = JSON.stringify([
+    cells.map((cell) => [cell.index, cell.label]),
+    unrollW.value,
+    someImage.sizeX,
+    someImage.sizeY,
+  ]);
+  for (const mapentry of maps.value) {
+    const uiLayer = mapentry.uiLayer;
+    if (!uiLayer) {
+      continue;
+    }
+    const state = unrollLabelStates.get(mapentry.map);
+    if (state?.signature === signature) {
+      continue;
+    }
+    state?.widgets.forEach((widget) => uiLayer.deleteWidget(widget));
+    unrollLabelStates.set(mapentry.map, {
+      widgets: cells.map((cell) => createUnrollLabel(uiLayer, cell, someImage)),
+      signature,
+    });
+  }
+}
+
 function _setupMap(
   mllidx: number,
   someImage: IImage,
@@ -990,13 +1133,16 @@ function _setupMap(
     }
   }
 
+  // Every map gets a ui layer to hold its unroll frame labels — the "unroll"
+  // layer mode draws one grid per layer, and each grid labels its own cells.
+  const uiMapEntry = maps.value[mllidx];
+  if (!uiMapEntry.uiLayer) {
+    uiMapEntry.uiLayer = markRaw(uiMapEntry.map.createLayer("ui"));
+    uiMapEntry.uiLayer.node().css({ "mix-blend-mode": "unset" });
+  }
+
   // only have a scale widget on the first map
   if (mllidx === 0) {
-    const mapentry = maps.value[mllidx];
-    if (!mapentry.uiLayer) {
-      mapentry.uiLayer = markRaw(mapentry.map.createLayer("ui"));
-      mapentry.uiLayer.node().css({ "mix-blend-mode": "unset" });
-    }
     updateScaleWidget();
     updateScalePixelWidget();
 
@@ -1275,6 +1421,9 @@ function draw() {
         layer.node().css("visibility", "hidden");
       });
     });
+    // The labels describe the grid that is being replaced, so drop them with
+    // the tiles rather than leaving them over the loading overlay.
+    clearUnrollLabels();
     return;
   }
   if ((width.value == height.value && width.value == 1) || !dataset.value) {
@@ -1349,6 +1498,8 @@ function draw() {
     baseLayerIndex += mll.length;
     map.draw();
   });
+
+  updateUnrollLabels(someImage);
 
   // Track progress of layers.
   // Two-pass approach: first build the array and assign the ref, THEN register
@@ -1502,6 +1653,7 @@ watch(
           layer.node().css("visibility", "hidden");
         });
       });
+      clearUnrollLabels();
     } else {
       draw();
     }
@@ -1621,6 +1773,7 @@ defineExpose({
   layersReady,
   mouseMap,
   mapLayerList,
+  unrollCells,
   mousetrapAnnotations,
   refsMounted,
   readyLayers,
@@ -1667,6 +1820,9 @@ defineExpose({
   setCorners,
   draw,
   toggleViewLock,
+  navigateToUnrolledCell,
+  updateUnrollLabels,
+  clearUnrollLabels,
   _setupMap,
   _setupTileLayers,
   _setTileUrls,
@@ -1692,6 +1848,31 @@ defineExpose({
 
 .scale-widget:hover {
   cursor: pointer;
+}
+
+/* Frame labels on the unrolled grid. GeoJS positions the element at its cell's
+   upper-left corner; the translate insets it into the cell. Unscoped because
+   the element is created by GeoJS, not rendered by this component. */
+.unroll-frame-label {
+  transform: translate(5px, 5px);
+  padding: 0 6px;
+  border-radius: 3px;
+  background: rgb(0 0 0 / 55%);
+  color: #fff;
+  font:
+    500 12px/1.7 "Helvetica Neue",
+    Arial,
+    Helvetica,
+    sans-serif;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  pointer-events: auto;
+}
+
+.unroll-frame-label:hover {
+  background: rgb(0 0 0 / 85%);
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 65%);
 }
 </style>
 

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -481,19 +481,41 @@ const mapLayerList = computed<ILayerStackImage[][]>(() => {
 
 // ---- Computed Properties - Unroll Labels ----
 
-const unrollCells = computed<IUnrollCell[]>(() => {
+// One entry per map, index-aligned with mapLayerList (and so with maps): each
+// map draws its own layer group in the "unroll" layer mode, and a group can
+// cover different frames than its neighbour, so cells are derived per map from
+// the layer whose tiles that map shows.
+const unrollCellsByMap = computed<IUnrollCell[][]>(() => {
   if (!unrolling.value) {
     return [];
   }
-  // The layer draw() lays the grid out from, so cell order matches the tiles.
-  const someImages = layerStackImages.value.find((lsi) => lsi.images[0]);
-  if (!someImages) {
-    return [];
-  }
-  return getUnrollCells(someImages.images, {
+  const dataset = store.dataset;
+  const flags = {
     unrollXY: store.unrollXY,
     unrollZ: store.unrollZ,
     unrollT: store.unrollT,
+  };
+  const showDimensionLabels = {
+    xy: store.showXYLabels,
+    z: store.showZLabels,
+    time: store.showTimeLabels,
+  };
+  return mapLayerList.value.map((mll) => {
+    const someImages = mll.find((lsi) => lsi.images[0]);
+    if (!someImages) {
+      return [];
+    }
+    return getUnrollCells({
+      cellImages: someImages.images,
+      flags,
+      // Axis indices have to be ranked over every frame of the dataset, since
+      // that is the set store.xy / .z / .time index into.
+      axisImages: dataset?.allImages?.length
+        ? dataset.allImages
+        : someImages.images,
+      dimensionLabels: dataset?.dimensionLabels,
+      showDimensionLabels,
+    });
   });
 });
 
@@ -883,10 +905,12 @@ const unrollLabelStates = new WeakMap<IGeoJSMap, IUnrollLabelState>();
 // once per grid rather than on every draw.
 let warnedUnrollLabelCells = 0;
 
-// The cells that get a label: unlabelled ones (every unrolled dimension has a
-// single value) and grids too dense to label are dropped.
-function labelledUnrollCells(): IUnrollCell[] {
-  const cells = unrollCells.value.filter((cell) => cell.label);
+// The cells of one map's grid that get a label: unlabelled ones (every unrolled
+// dimension has a single value) and grids too dense to label are dropped.
+function labelledUnrollCells(mapIndex: number): IUnrollCell[] {
+  const cells = (unrollCellsByMap.value[mapIndex] ?? []).filter(
+    (cell) => cell.label,
+  );
   if (cells.length > MAX_UNROLL_LABEL_CELLS) {
     if (warnedUnrollLabelCells !== cells.length) {
       warnedUnrollLabelCells = cells.length;
@@ -932,15 +956,20 @@ function createUnrollLabel(
   someImage: IImage,
 ) {
   const widget = uiLayer.createWidget("dom", {
+    // A real button, so the label is reachable by keyboard and reads as a
+    // control; GeoJS creates whatever element `el` names.
+    el: "button",
     position: {
       x: someImage.sizeX * (cell.index % unrollW.value),
       y: someImage.sizeY * Math.floor(cell.index / unrollW.value),
     },
   });
-  const element = widget.canvas();
+  const element = widget.canvas() as HTMLButtonElement;
+  element.type = "button";
   element.classList.add("unroll-frame-label");
   element.textContent = cell.label;
   element.title = `Show ${cell.label} on its own`;
+  element.setAttribute("aria-label", `Show ${cell.label} on its own`);
   element.onclick = (event: MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
@@ -960,29 +989,36 @@ function clearUnrollLabels() {
   }
 }
 
-function updateUnrollLabels(someImage: IImage) {
-  const cells = labelledUnrollCells();
-  const signature = JSON.stringify([
-    cells.map((cell) => [cell.index, cell.label]),
-    unrollW.value,
-    someImage.sizeX,
-    someImage.sizeY,
-  ]);
-  for (const mapentry of maps.value) {
+function updateUnrollLabels() {
+  // The same image draw() sizes the grid from, so a cell's corner is at a
+  // multiple of this image's size.
+  const someImage = layerStackImages.value.find((lsi) => lsi.images[0])
+    ?.images[0];
+  if (!someImage) {
+    return;
+  }
+  maps.value.forEach((mapentry, mapIndex) => {
     const uiLayer = mapentry.uiLayer;
     if (!uiLayer) {
-      continue;
+      return;
     }
+    const cells = labelledUnrollCells(mapIndex);
+    const signature = JSON.stringify([
+      cells.map((cell) => [cell.index, cell.label]),
+      unrollW.value,
+      someImage.sizeX,
+      someImage.sizeY,
+    ]);
     const state = unrollLabelStates.get(mapentry.map);
     if (state?.signature === signature) {
-      continue;
+      return;
     }
     state?.widgets.forEach((widget) => uiLayer.deleteWidget(widget));
     unrollLabelStates.set(mapentry.map, {
       widgets: cells.map((cell) => createUnrollLabel(uiLayer, cell, someImage)),
       signature,
     });
-  }
+  });
 }
 
 function _setupMap(
@@ -1503,7 +1539,7 @@ function draw() {
     map.draw();
   });
 
-  updateUnrollLabels(someImage);
+  updateUnrollLabels();
 
   // Track progress of layers.
   // Two-pass approach: first build the array and assign the ref, THEN register
@@ -1683,6 +1719,13 @@ watch([showScalebar, pixelSize], updateScaleWidget);
 
 watch([showPixelScalebar, pixelSize], updateScalePixelWidget);
 
+// Rebuild the labels whenever what they should say changes. Watching the cells
+// rather than draw() matters for the inputs that never trigger a redraw — the
+// "Show XY / Z / Time labels" viewer settings, which only change label text.
+// Redundant calls are cheap: updateUnrollLabels no-ops on an unchanged
+// signature.
+watch(unrollCellsByMap, () => updateUnrollLabels());
+
 watch(dataset, () => {
   resetMapsOnDraw.value = true;
   datasetReset();
@@ -1777,7 +1820,7 @@ defineExpose({
   layersReady,
   mouseMap,
   mapLayerList,
-  unrollCells,
+  unrollCellsByMap,
   mousetrapAnnotations,
   refsMounted,
   readyLayers,
@@ -1858,7 +1901,9 @@ defineExpose({
    upper-left corner; the translate insets it into the cell. Unscoped because
    the element is created by GeoJS, not rendered by this component. */
 .unroll-frame-label {
+  appearance: none;
   transform: translate(5px, 5px);
+  border: 0;
   padding: 0 6px;
   border-radius: 3px;
   background: rgb(0 0 0 / 55%);
@@ -1877,6 +1922,12 @@ defineExpose({
 .unroll-frame-label:hover {
   background: rgb(0 0 0 / 85%);
   box-shadow: 0 0 0 1px rgb(255 255 255 / 65%);
+}
+
+.unroll-frame-label:focus-visible {
+  background: rgb(0 0 0 / 85%);
+  outline: 2px solid #fff;
+  outline-offset: 1px;
 }
 </style>
 

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -481,14 +481,6 @@ const mapLayerList = computed<ILayerStackImage[][]>(() => {
 
 // ---- Computed Properties - Unroll Labels ----
 
-// Each label is its own element that GeoJS repositions on every pan, so very
-// large grids would pay for labels too small to read at that density anyway.
-const MAX_UNROLL_LABEL_CELLS = 400;
-
-// Cell count of the last grid that went unlabelled, so the warning is logged
-// once per grid instead of on every recompute.
-let warnedUnrollLabelCells = 0;
-
 const unrollCells = computed<IUnrollCell[]>(() => {
   if (!unrolling.value) {
     return [];
@@ -498,22 +490,11 @@ const unrollCells = computed<IUnrollCell[]>(() => {
   if (!someImages) {
     return [];
   }
-  const cells = getUnrollCells(someImages.images, {
+  return getUnrollCells(someImages.images, {
     unrollXY: store.unrollXY,
     unrollZ: store.unrollZ,
     unrollT: store.unrollT,
   });
-  if (cells.length > MAX_UNROLL_LABEL_CELLS) {
-    if (warnedUnrollLabelCells !== cells.length) {
-      warnedUnrollLabelCells = cells.length;
-      logWarning(
-        `Unrolled grid of ${cells.length} frames exceeds the ` +
-          `${MAX_UNROLL_LABEL_CELLS} frame label limit; labels are hidden`,
-      );
-    }
-    return [];
-  }
-  return cells;
 });
 
 // ---- Mousetrap Bindings ----
@@ -886,6 +867,10 @@ function updateScalePixelWidget() {
 // follow both panning and zooming. A dom widget stops mousedown from reaching
 // the GeoJS interactor, so clicking a label never starts an annotation.
 
+// Each label is its own element that GeoJS repositions on every pan, so very
+// large grids would pay for labels too small to read at that density anyway.
+const MAX_UNROLL_LABEL_CELLS = 400;
+
 interface IUnrollLabelState {
   widgets: IGeoJSDomWidget[];
   // Identifies the labelled grid; a change means the widgets are rebuilt.
@@ -893,6 +878,27 @@ interface IUnrollLabelState {
 }
 
 const unrollLabelStates = new WeakMap<IGeoJSMap, IUnrollLabelState>();
+
+// Cell count of the last grid that went unlabelled, so the warning is logged
+// once per grid rather than on every draw.
+let warnedUnrollLabelCells = 0;
+
+// The cells that get a label: unlabelled ones (every unrolled dimension has a
+// single value) and grids too dense to label are dropped.
+function labelledUnrollCells(): IUnrollCell[] {
+  const cells = unrollCells.value.filter((cell) => cell.label);
+  if (cells.length > MAX_UNROLL_LABEL_CELLS) {
+    if (warnedUnrollLabelCells !== cells.length) {
+      warnedUnrollLabelCells = cells.length;
+      logWarning(
+        `Unrolled grid of ${cells.length} frames exceeds the ` +
+          `${MAX_UNROLL_LABEL_CELLS} frame label limit; labels are hidden`,
+      );
+    }
+    return [];
+  }
+  return cells;
+}
 
 // Roll the grid back up at the clicked frame.
 function navigateToUnrolledCell(cell: IUnrollCell) {
@@ -955,9 +961,7 @@ function clearUnrollLabels() {
 }
 
 function updateUnrollLabels(someImage: IImage) {
-  // Unlabelled cells (a grid whose unrolled dimensions all have one value)
-  // get no widget.
-  const cells = unrollCells.value.filter((cell) => cell.label);
+  const cells = labelledUnrollCells();
   const signature = JSON.stringify([
     cells.map((cell) => [cell.index, cell.label]),
     unrollW.value,
@@ -1135,10 +1139,10 @@ function _setupMap(
 
   // Every map gets a ui layer to hold its unroll frame labels — the "unroll"
   // layer mode draws one grid per layer, and each grid labels its own cells.
-  const uiMapEntry = maps.value[mllidx];
-  if (!uiMapEntry.uiLayer) {
-    uiMapEntry.uiLayer = markRaw(uiMapEntry.map.createLayer("ui"));
-    uiMapEntry.uiLayer.node().css({ "mix-blend-mode": "unset" });
+  const mapentry = maps.value[mllidx];
+  if (!mapentry.uiLayer) {
+    mapentry.uiLayer = markRaw(mapentry.map.createLayer("ui"));
+    mapentry.uiLayer.node().css({ "mix-blend-mode": "unset" });
   }
 
   // only have a scale widget on the first map

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1168,12 +1168,24 @@ interface IGeoJSScaleWidgetSpec {
 
 type IGeoJSScaleWidgetOptions = keyof IGeoJSScaleWidgetSpec;
 
+// https://opengeoscience.github.io/geojs/apidocs/geo.gui.domWidget.html
+// Created with a `position` of map coordinates ({ x, y }), the widget's element
+// tracks that point as the map is panned and zoomed.
+export interface IGeoJSDomWidget extends IGeoJSWidget {
+  canvas: (() => HTMLElement) & ((val: HTMLElement) => IGeoJSDomWidget);
+  layer: () => IGeoJSUiLayer;
+}
+
 // https://opengeoscience.github.io/geojs/apidocs/geo.gui.uiLayer.html
 export interface IGeoJSUiLayer extends IGeoJSLayer {
   createWidget: <WidgetName extends string, ParentType extends IGeoJsObject>(
     widgetName: WidgetName,
     arg: { parent?: ParentType; [k: string]: any },
-  ) => WidgetName extends "scale" ? IGeoJSScaleWidget : IGeoJSWidget;
+  ) => WidgetName extends "scale"
+    ? IGeoJSScaleWidget
+    : WidgetName extends "dom"
+      ? IGeoJSDomWidget
+      : IGeoJSWidget;
   deleteWidget: (widget: IGeoJSWidget) => IGeoJSUiLayer;
 }
 

--- a/src/utils/unroll.test.ts
+++ b/src/utils/unroll.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { IImage } from "@/store/model";
+import { getUnrollCells, IUnrollFlags } from "./unroll";
+
+// Only `frame` matters to getUnrollCells.
+function image(frame: Partial<IImage["frame"]>): IImage {
+  return { frame } as IImage;
+}
+
+const noUnroll: IUnrollFlags = {
+  unrollXY: false,
+  unrollZ: false,
+  unrollT: false,
+};
+
+describe("getUnrollCells", () => {
+  it("returns nothing for no images", () => {
+    expect(getUnrollCells([], { ...noUnroll, unrollXY: true })).toEqual([]);
+  });
+
+  it("labels and locates unrolled XY frames", () => {
+    const images = [0, 1, 2].map((IndexXY) => image({ IndexXY }));
+    expect(getUnrollCells(images, { ...noUnroll, unrollXY: true })).toEqual([
+      { index: 0, label: "XY 1", location: { xy: 0 } },
+      { index: 1, label: "XY 2", location: { xy: 1 } },
+      { index: 2, label: "XY 3", location: { xy: 2 } },
+    ]);
+  });
+
+  it("leaves cells unlabelled when nothing is unrolled", () => {
+    const images = [0, 1].map((IndexXY) => image({ IndexXY }));
+    expect(getUnrollCells(images, noUnroll)).toEqual([
+      { index: 0, label: "", location: {} },
+      { index: 1, label: "", location: {} },
+    ]);
+  });
+
+  it("navigates by rank, not by raw frame value", () => {
+    // dataset.xy holds the sorted distinct values, and store.xy indexes into
+    // it, so XY 5 is the third XY of this dataset — index 2, not 5.
+    const images = [0, 2, 5].map((IndexXY) => image({ IndexXY }));
+    expect(getUnrollCells(images, { ...noUnroll, unrollXY: true })).toEqual([
+      { index: 0, label: "XY 1", location: { xy: 0 } },
+      { index: 1, label: "XY 2", location: { xy: 1 } },
+      { index: 2, label: "XY 3", location: { xy: 2 } },
+    ]);
+  });
+
+  it("falls back to PositionZ when IndexZ is absent", () => {
+    const images = [0, 0.5, 1].map((PositionZ) => image({ PositionZ }));
+    expect(getUnrollCells(images, { ...noUnroll, unrollZ: true })).toEqual([
+      { index: 0, label: "Z 1", location: { z: 0 } },
+      { index: 1, label: "Z 2", location: { z: 1 } },
+      { index: 2, label: "Z 3", location: { z: 2 } },
+    ]);
+  });
+
+  it("prefers IndexZ over PositionZ", () => {
+    const images = [
+      image({ IndexZ: 1, PositionZ: 12.5 }),
+      image({ IndexZ: 0, PositionZ: 0.5 }),
+    ];
+    expect(getUnrollCells(images, { ...noUnroll, unrollZ: true })).toEqual([
+      { index: 0, label: "Z 2", location: { z: 1 } },
+      { index: 1, label: "Z 1", location: { z: 0 } },
+    ]);
+  });
+
+  it("ranks by value regardless of grid order", () => {
+    const images = [2, 0, 1].map((IndexT) => image({ IndexT }));
+    expect(getUnrollCells(images, { ...noUnroll, unrollT: true })).toEqual([
+      { index: 0, label: "Time 3", location: { time: 2 } },
+      { index: 1, label: "Time 1", location: { time: 0 } },
+      { index: 2, label: "Time 2", location: { time: 1 } },
+    ]);
+  });
+
+  it("joins every unrolled dimension into one label", () => {
+    const images = [
+      image({ IndexXY: 0, IndexZ: 0 }),
+      image({ IndexXY: 0, IndexZ: 1 }),
+      image({ IndexXY: 1, IndexZ: 0 }),
+      image({ IndexXY: 1, IndexZ: 1 }),
+    ];
+    expect(
+      getUnrollCells(images, { ...noUnroll, unrollXY: true, unrollZ: true }),
+    ).toEqual([
+      { index: 0, label: "XY 1 · Z 1", location: { xy: 0, z: 0 } },
+      { index: 1, label: "XY 1 · Z 2", location: { xy: 0, z: 1 } },
+      { index: 2, label: "XY 2 · Z 1", location: { xy: 1, z: 0 } },
+      { index: 3, label: "XY 2 · Z 2", location: { xy: 1, z: 1 } },
+    ]);
+  });
+
+  it("keeps single-valued dimensions out of the label but in the location", () => {
+    const images = [
+      image({ IndexXY: 0, IndexT: 3 }),
+      image({ IndexXY: 1, IndexT: 3 }),
+    ];
+    expect(
+      getUnrollCells(images, { ...noUnroll, unrollXY: true, unrollT: true }),
+    ).toEqual([
+      { index: 0, label: "XY 1", location: { xy: 0, time: 0 } },
+      { index: 1, label: "XY 2", location: { xy: 1, time: 0 } },
+    ]);
+  });
+
+  it("treats a missing index as 0", () => {
+    expect(
+      getUnrollCells([image({})], { ...noUnroll, unrollXY: true }),
+    ).toEqual([{ index: 0, label: "", location: { xy: 0 } }]);
+  });
+});

--- a/src/utils/unroll.test.ts
+++ b/src/utils/unroll.test.ts
@@ -15,12 +15,19 @@ const noUnroll: IUnrollFlags = {
 
 describe("getUnrollCells", () => {
   it("returns nothing for no images", () => {
-    expect(getUnrollCells([], { ...noUnroll, unrollXY: true })).toEqual([]);
+    expect(
+      getUnrollCells({
+        cellImages: [],
+        flags: { ...noUnroll, unrollXY: true },
+      }),
+    ).toEqual([]);
   });
 
   it("labels and locates unrolled XY frames", () => {
-    const images = [0, 1, 2].map((IndexXY) => image({ IndexXY }));
-    expect(getUnrollCells(images, { ...noUnroll, unrollXY: true })).toEqual([
+    const cellImages = [0, 1, 2].map((IndexXY) => image({ IndexXY }));
+    expect(
+      getUnrollCells({ cellImages, flags: { ...noUnroll, unrollXY: true } }),
+    ).toEqual([
       { index: 0, label: "XY 1", location: { xy: 0 } },
       { index: 1, label: "XY 2", location: { xy: 1 } },
       { index: 2, label: "XY 3", location: { xy: 2 } },
@@ -28,8 +35,8 @@ describe("getUnrollCells", () => {
   });
 
   it("leaves cells unlabelled when nothing is unrolled", () => {
-    const images = [0, 1].map((IndexXY) => image({ IndexXY }));
-    expect(getUnrollCells(images, noUnroll)).toEqual([
+    const cellImages = [0, 1].map((IndexXY) => image({ IndexXY }));
+    expect(getUnrollCells({ cellImages, flags: noUnroll })).toEqual([
       { index: 0, label: "", location: {} },
       { index: 1, label: "", location: {} },
     ]);
@@ -38,17 +45,39 @@ describe("getUnrollCells", () => {
   it("navigates by rank, not by raw frame value", () => {
     // dataset.xy holds the sorted distinct values, and store.xy indexes into
     // it, so XY 5 is the third XY of this dataset — index 2, not 5.
-    const images = [0, 2, 5].map((IndexXY) => image({ IndexXY }));
-    expect(getUnrollCells(images, { ...noUnroll, unrollXY: true })).toEqual([
+    const cellImages = [0, 2, 5].map((IndexXY) => image({ IndexXY }));
+    expect(
+      getUnrollCells({ cellImages, flags: { ...noUnroll, unrollXY: true } }),
+    ).toEqual([
       { index: 0, label: "XY 1", location: { xy: 0 } },
       { index: 1, label: "XY 2", location: { xy: 1 } },
       { index: 2, label: "XY 3", location: { xy: 2 } },
     ]);
   });
 
+  it("ranks over the dataset's frames, not just the grid's", () => {
+    // A channel imaged only at XY 0 and XY 5, in a dataset whose frames cover
+    // XY 0, 2 and 5: rolling up at the second cell has to land on dataset
+    // index 2, not on index 1 (which is XY 2, where this channel has no image).
+    const cellImages = [0, 5].map((IndexXY) => image({ IndexXY }));
+    const axisImages = [0, 2, 5, 0, 2, 5].map((IndexXY) => image({ IndexXY }));
+    expect(
+      getUnrollCells({
+        cellImages,
+        axisImages,
+        flags: { ...noUnroll, unrollXY: true },
+      }),
+    ).toEqual([
+      { index: 0, label: "XY 1", location: { xy: 0 } },
+      { index: 1, label: "XY 3", location: { xy: 2 } },
+    ]);
+  });
+
   it("falls back to PositionZ when IndexZ is absent", () => {
-    const images = [0, 0.5, 1].map((PositionZ) => image({ PositionZ }));
-    expect(getUnrollCells(images, { ...noUnroll, unrollZ: true })).toEqual([
+    const cellImages = [0, 0.5, 1].map((PositionZ) => image({ PositionZ }));
+    expect(
+      getUnrollCells({ cellImages, flags: { ...noUnroll, unrollZ: true } }),
+    ).toEqual([
       { index: 0, label: "Z 1", location: { z: 0 } },
       { index: 1, label: "Z 2", location: { z: 1 } },
       { index: 2, label: "Z 3", location: { z: 2 } },
@@ -56,19 +85,23 @@ describe("getUnrollCells", () => {
   });
 
   it("prefers IndexZ over PositionZ", () => {
-    const images = [
+    const cellImages = [
       image({ IndexZ: 1, PositionZ: 12.5 }),
       image({ IndexZ: 0, PositionZ: 0.5 }),
     ];
-    expect(getUnrollCells(images, { ...noUnroll, unrollZ: true })).toEqual([
+    expect(
+      getUnrollCells({ cellImages, flags: { ...noUnroll, unrollZ: true } }),
+    ).toEqual([
       { index: 0, label: "Z 2", location: { z: 1 } },
       { index: 1, label: "Z 1", location: { z: 0 } },
     ]);
   });
 
   it("ranks by value regardless of grid order", () => {
-    const images = [2, 0, 1].map((IndexT) => image({ IndexT }));
-    expect(getUnrollCells(images, { ...noUnroll, unrollT: true })).toEqual([
+    const cellImages = [2, 0, 1].map((IndexT) => image({ IndexT }));
+    expect(
+      getUnrollCells({ cellImages, flags: { ...noUnroll, unrollT: true } }),
+    ).toEqual([
       { index: 0, label: "Time 3", location: { time: 2 } },
       { index: 1, label: "Time 1", location: { time: 0 } },
       { index: 2, label: "Time 2", location: { time: 1 } },
@@ -76,14 +109,17 @@ describe("getUnrollCells", () => {
   });
 
   it("joins every unrolled dimension into one label", () => {
-    const images = [
+    const cellImages = [
       image({ IndexXY: 0, IndexZ: 0 }),
       image({ IndexXY: 0, IndexZ: 1 }),
       image({ IndexXY: 1, IndexZ: 0 }),
       image({ IndexXY: 1, IndexZ: 1 }),
     ];
     expect(
-      getUnrollCells(images, { ...noUnroll, unrollXY: true, unrollZ: true }),
+      getUnrollCells({
+        cellImages,
+        flags: { ...noUnroll, unrollXY: true, unrollZ: true },
+      }),
     ).toEqual([
       { index: 0, label: "XY 1 · Z 1", location: { xy: 0, z: 0 } },
       { index: 1, label: "XY 1 · Z 2", location: { xy: 0, z: 1 } },
@@ -93,12 +129,15 @@ describe("getUnrollCells", () => {
   });
 
   it("keeps single-valued dimensions out of the label but in the location", () => {
-    const images = [
+    const cellImages = [
       image({ IndexXY: 0, IndexT: 3 }),
       image({ IndexXY: 1, IndexT: 3 }),
     ];
     expect(
-      getUnrollCells(images, { ...noUnroll, unrollXY: true, unrollT: true }),
+      getUnrollCells({
+        cellImages,
+        flags: { ...noUnroll, unrollXY: true, unrollT: true },
+      }),
     ).toEqual([
       { index: 0, label: "XY 1", location: { xy: 0, time: 0 } },
       { index: 1, label: "XY 2", location: { xy: 1, time: 0 } },
@@ -107,7 +146,76 @@ describe("getUnrollCells", () => {
 
   it("treats a missing index as 0", () => {
     expect(
-      getUnrollCells([image({})], { ...noUnroll, unrollXY: true }),
+      getUnrollCells({
+        cellImages: [image({})],
+        flags: { ...noUnroll, unrollXY: true },
+      }),
     ).toEqual([{ index: 0, label: "", location: { xy: 0 } }]);
+  });
+
+  describe("dimension labels", () => {
+    const cellImages = [0, 1].map((IndexXY) => image({ IndexXY }));
+    const dimensionLabels = { xy: ["19263, -6626", "18743, -8631"] };
+
+    it("appends the dataset's label for the axis", () => {
+      expect(
+        getUnrollCells({
+          cellImages,
+          flags: { ...noUnroll, unrollXY: true },
+          dimensionLabels,
+        }).map((cell) => cell.label),
+      ).toEqual(["XY 1 (19263, -6626)", "XY 2 (18743, -8631)"]);
+    });
+
+    it("omits the label when the axis is switched off", () => {
+      expect(
+        getUnrollCells({
+          cellImages,
+          flags: { ...noUnroll, unrollXY: true },
+          dimensionLabels,
+          showDimensionLabels: { xy: false },
+        }).map((cell) => cell.label),
+      ).toEqual(["XY 1", "XY 2"]);
+    });
+
+    it("skips axes and entries the dataset has no label for", () => {
+      expect(
+        getUnrollCells({
+          cellImages: [
+            image({ IndexXY: 0, IndexZ: 0 }),
+            image({ IndexXY: 1, IndexZ: 1 }),
+          ],
+          flags: { ...noUnroll, unrollXY: true, unrollZ: true },
+          // One XY label missing, no z labels at all.
+          dimensionLabels: { xy: ["19263, -6626", ""], z: null },
+        }).map((cell) => cell.label),
+      ).toEqual(["XY 1 (19263, -6626) · Z 1", "XY 2 · Z 2"]);
+    });
+
+    it("labels each unrolled dimension it has an entry for", () => {
+      expect(
+        getUnrollCells({
+          cellImages: [
+            image({ IndexXY: 0, IndexZ: 0 }),
+            image({ IndexXY: 1, IndexZ: 1 }),
+          ],
+          flags: { ...noUnroll, unrollXY: true, unrollZ: true },
+          dimensionLabels: { xy: ["A01", "A02"], z: ["-3 µm", "-2 µm"] },
+        }).map((cell) => cell.label),
+      ).toEqual(["XY 1 (A01) · Z 1 (-3 µm)", "XY 2 (A02) · Z 2 (-2 µm)"]);
+    });
+
+    it("indexes labels by dataset rank, not by grid position", () => {
+      // Same sparse-channel grid as above: cell 1 is XY 5, dataset index 2, so
+      // it must show the third label.
+      expect(
+        getUnrollCells({
+          cellImages: [0, 5].map((IndexXY) => image({ IndexXY })),
+          axisImages: [0, 2, 5].map((IndexXY) => image({ IndexXY })),
+          flags: { ...noUnroll, unrollXY: true },
+          dimensionLabels: { xy: ["A01", "A02", "A03"] },
+        }).map((cell) => cell.label),
+      ).toEqual(["XY 1 (A01)", "XY 3 (A03)"]);
+    });
   });
 });

--- a/src/utils/unroll.ts
+++ b/src/utils/unroll.ts
@@ -1,4 +1,4 @@
-import { IImage } from "@/store/model";
+import { IDimensionLabels, IImage } from "@/store/model";
 
 // Helpers for the unrolled image grid: what each cell is, what it should be
 // labelled, and which frame it navigates back to (issue #151).
@@ -27,85 +27,130 @@ export interface IUnrollCellLocation {
   time?: number;
 }
 
+/** Per-dimension switch for appending the dataset's dimension label. */
+export type TUnrollLabelSwitches = {
+  [Axis in keyof IUnrollCellLocation]?: boolean;
+};
+
 export interface IUnrollCell {
   /** Grid cell index, i.e. the frame's `keyOffset`. */
   index: number;
   /**
    * Corner text, 1-based to match the navigator sliders' `offset` of 1
-   * ("XY 3", or "XY 3 · Z 2" when several dimensions are unrolled at once).
-   * Empty when no unrolled dimension has more than one value.
+   * ("XY 3", "XY 3 (19263, -6626)", or "XY 3 · Z 2" when several dimensions
+   * are unrolled at once). Empty when no unrolled dimension has more than one
+   * value.
    */
   label: string;
   location: IUnrollCellLocation;
 }
 
+export interface IUnrollCellsOptions {
+  /**
+   * The grid's frames in cell order — the `images` of the `layerStackImages`
+   * entry whose tiles the grid is drawn from.
+   */
+  cellImages: IImage[];
+  flags: IUnrollFlags;
+  /**
+   * Every frame of the dataset (`dataset.allImages`). Axis indices are ranked
+   * over these, because that is the set `dataset.xy` / `.z` / `.time` are built
+   * from — ranking over `cellImages` alone is wrong as soon as the drawn layer
+   * covers fewer frames than the dataset does. Defaults to `cellImages`, which
+   * is equivalent whenever the layer covers every frame.
+   */
+  axisImages?: IImage[];
+  /** `dataset.dimensionLabels`, if the dataset has any. */
+  dimensionLabels?: IDimensionLabels | null;
+  /** Defaults to on for every dimension. */
+  showDimensionLabels?: TUnrollLabelSwitches;
+}
+
 // One entry per unrollable dimension. `value` mirrors how `parseTiles` reads
 // the frame, including the `PositionZ` fallback, so the ordered distinct values
 // here are the same ones `dataset.z` etc. are built from. `title` matches the
-// navigator slider labels.
+// navigator slider labels, and `labels` names the `dimensionLabels` key, which
+// is `t` where the location key is `time`.
 const UNROLL_AXES = [
   {
     key: "xy",
     flag: "unrollXY",
     title: "XY",
+    labels: "xy",
     value: (image: IImage) => image.frame.IndexXY ?? 0,
   },
   {
     key: "z",
     flag: "unrollZ",
     title: "Z",
+    labels: "z",
     value: (image: IImage) => image.frame.IndexZ ?? image.frame.PositionZ ?? 0,
   },
   {
     key: "time",
     flag: "unrollT",
     title: "Time",
+    labels: "t",
     value: (image: IImage) => image.frame.IndexT ?? 0,
   },
 ] as const satisfies readonly {
   key: keyof IUnrollCellLocation;
   flag: keyof IUnrollFlags;
   title: string;
+  labels: keyof IDimensionLabels;
   value: (image: IImage) => number;
 }[];
 
-/**
- * Describe every cell of the unrolled grid.
- *
- * @param images The images of one unrolled layer, in grid order — the `images`
- *   of a `layerStackImages` entry, whose order is the frames' `keyOffset`.
- * @param flags Which dimensions are unrolled.
- */
-export function getUnrollCells(
-  images: IImage[],
-  flags: IUnrollFlags,
-): IUnrollCell[] {
+// The distinct values of one dimension in ascending order. `parseTiles` builds
+// `dataset.xy` / `.z` / `.time` the same way, and the store navigates by index
+// into those arrays — so a frame's position here is the index to set. That is
+// not the raw frame value in general: `z` can fall back to a `PositionZ` float,
+// and nothing guarantees dense indices.
+function sortedAxisValues(images: IImage[], value: (i: IImage) => number) {
+  return [...new Set(images.map(value))].sort((a, b) => a - b);
+}
+
+/** Describe every cell of the unrolled grid. */
+export function getUnrollCells({
+  cellImages,
+  flags,
+  axisImages,
+  dimensionLabels,
+  showDimensionLabels,
+}: IUnrollCellsOptions): IUnrollCell[] {
   const unrolledAxes = UNROLL_AXES.filter((axis) => flags[axis.flag]).map(
     (axis) => {
-      const values = images.map(axis.value);
-      // `dataset.xy` / `.z` / `.time` hold the sorted distinct values of the
-      // dimension, and the store navigates by index into those arrays. So a
-      // frame's rank among the sorted distinct values *is* the index to set,
-      // which is not the raw frame value in general (`z` can fall back to a
-      // `PositionZ` float, and nothing guarantees dense indices).
-      const ranks = new Map(
-        [...new Set(values)].sort((a, b) => a - b).map((v, rank) => [v, rank]),
-      );
-      return { ...axis, values, ranks };
+      const values = sortedAxisValues(axisImages ?? cellImages, axis.value);
+      return {
+        ...axis,
+        ranks: new Map(values.map((value, rank) => [value, rank])),
+        // A dimension with a single value carries no information, so it is left
+        // out of the label ("XY 3", not "XY 3 · Time 1" on one timepoint). It
+        // stays in the location so navigating still pins it.
+        labelled: values.length > 1,
+        dimensionLabels:
+          showDimensionLabels?.[axis.key] ?? true
+            ? dimensionLabels?.[axis.labels]
+            : null,
+      };
     },
   );
 
-  return images.map((_image, index) => {
+  return cellImages.map((cellImage, index) => {
     const location: IUnrollCellLocation = {};
     const labelParts: string[] = [];
     for (const axis of unrolledAxes) {
-      const rank = axis.ranks.get(axis.values[index]) ?? 0;
+      const rank = axis.ranks.get(axis.value(cellImage)) ?? 0;
       location[axis.key] = rank;
-      // A dimension with a single value carries no information, so leave it out
-      // of the label ("XY 3", not "XY 3 · Time 1" on one timepoint). It stays
-      // in the location so navigating still pins it.
-      if (axis.ranks.size > 1) {
-        labelParts.push(`${axis.title} ${rank + 1}`);
+      if (axis.labelled) {
+        // The dimension label array is indexed the same way the store is, so
+        // by rank rather than by the cell's position in the grid.
+        const dimensionLabel = axis.dimensionLabels?.[rank];
+        labelParts.push(
+          dimensionLabel
+            ? `${axis.title} ${rank + 1} (${dimensionLabel})`
+            : `${axis.title} ${rank + 1}`,
+        );
       }
     }
     return { index, label: labelParts.join(" · "), location };

--- a/src/utils/unroll.ts
+++ b/src/utils/unroll.ts
@@ -1,0 +1,113 @@
+import { IImage } from "@/store/model";
+
+// Helpers for the unrolled image grid: what each cell is, what it should be
+// labelled, and which frame it navigates back to (issue #151).
+//
+// When a dimension is unrolled, `parseTiles` collapses that dimension's key to
+// -1 so every frame lands in one lookup entry, and each frame's position in
+// that entry (its `keyOffset`) is its cell in the grid. `ImageViewer` lays the
+// grid out row-major with `unrollW` columns, so cell `index` sits at
+// `(index % unrollW, floor(index / unrollW))`.
+
+/** Which frame dimensions are currently unrolled into the grid. */
+export interface IUnrollFlags {
+  unrollXY: boolean;
+  unrollZ: boolean;
+  unrollT: boolean;
+}
+
+/**
+ * A location to navigate to, in the same terms as `store.xy` / `.z` / `.time`:
+ * indices into `dataset.xy` / `.z` / `.time`. Dimensions that are not unrolled
+ * are absent — they already hold the value the user is looking at.
+ */
+export interface IUnrollCellLocation {
+  xy?: number;
+  z?: number;
+  time?: number;
+}
+
+export interface IUnrollCell {
+  /** Grid cell index, i.e. the frame's `keyOffset`. */
+  index: number;
+  /**
+   * Corner text, 1-based to match the navigator sliders' `offset` of 1
+   * ("XY 3", or "XY 3 · Z 2" when several dimensions are unrolled at once).
+   * Empty when no unrolled dimension has more than one value.
+   */
+  label: string;
+  location: IUnrollCellLocation;
+}
+
+// One entry per unrollable dimension. `value` mirrors how `parseTiles` reads
+// the frame, including the `PositionZ` fallback, so the ordered distinct values
+// here are the same ones `dataset.z` etc. are built from. `title` matches the
+// navigator slider labels.
+const UNROLL_AXES = [
+  {
+    key: "xy",
+    flag: "unrollXY",
+    title: "XY",
+    value: (image: IImage) => image.frame.IndexXY ?? 0,
+  },
+  {
+    key: "z",
+    flag: "unrollZ",
+    title: "Z",
+    value: (image: IImage) => image.frame.IndexZ ?? image.frame.PositionZ ?? 0,
+  },
+  {
+    key: "time",
+    flag: "unrollT",
+    title: "Time",
+    value: (image: IImage) => image.frame.IndexT ?? 0,
+  },
+] as const satisfies readonly {
+  key: keyof IUnrollCellLocation;
+  flag: keyof IUnrollFlags;
+  title: string;
+  value: (image: IImage) => number;
+}[];
+
+/**
+ * Describe every cell of the unrolled grid.
+ *
+ * @param images The images of one unrolled layer, in grid order — the `images`
+ *   of a `layerStackImages` entry, whose order is the frames' `keyOffset`.
+ * @param flags Which dimensions are unrolled.
+ */
+export function getUnrollCells(
+  images: IImage[],
+  flags: IUnrollFlags,
+): IUnrollCell[] {
+  const unrolledAxes = UNROLL_AXES.filter((axis) => flags[axis.flag]).map(
+    (axis) => {
+      const values = images.map(axis.value);
+      // `dataset.xy` / `.z` / `.time` hold the sorted distinct values of the
+      // dimension, and the store navigates by index into those arrays. So a
+      // frame's rank among the sorted distinct values *is* the index to set,
+      // which is not the raw frame value in general (`z` can fall back to a
+      // `PositionZ` float, and nothing guarantees dense indices).
+      const ranks = new Map(
+        [...new Set(values)].sort((a, b) => a - b).map((v, rank) => [v, rank]),
+      );
+      return { ...axis, values, ranks };
+    },
+  );
+
+  return images.map((_image, index) => {
+    const location: IUnrollCellLocation = {};
+    const labelParts: string[] = [];
+    for (const axis of unrolledAxes) {
+      const rank = axis.ranks.get(axis.values[index]) ?? 0;
+      location[axis.key] = rank;
+      // A dimension with a single value carries no information, so leave it out
+      // of the label ("XY 3", not "XY 3 · Time 1" on one timepoint). It stays
+      // in the location so navigating still pins it.
+      if (axis.ranks.size > 1) {
+        labelParts.push(`${axis.title} ${rank + 1}`);
+      }
+    }
+    return { index, label: labelParts.join(" · "), location };
+  });
+}


### PR DESCRIPTION
Closes #151.

## What

When a dimension is unrolled, each cell of the grid now carries a label in its upper-left corner, and the label is a control: clicking it rolls the grid back up at that frame.

- **Label text** mirrors the navigator sliders' 1-based display, and includes the dataset's dimension label when it has one: `XY 3 (19263, -6626)`, or plain `XY 3` / `Z 2` / `Time 7` without one. With several dimensions unrolled at once it joins them — `XY 3 · Z 2`. A dimension with a single value is left out of the label (no `XY 3 · Time 1` on a one-timepoint dataset) but is still pinned on navigation. The parenthetical is gated per axis on the existing **Show XY / Z / Time labels** viewer settings — the same switches the navigator sliders use — so one toggle controls both places.
- **Clicking a label** sets `xy`/`z`/`time` to that cell's frame for the unrolled dimensions, leaves the others alone, then clears the unroll flags. Clearing the flags is what triggers the dataset reload — `NavigatorPanel` watches all three, the same path snapshot restore (`Snapshots.vue`) and the AI panel (`agent/executors.ts`) already rely on. Calling `refreshDataset()` here as well would load the dataset twice.
- Labels are `<button>` elements, so they work from the keyboard as well as the mouse. Only the label is clickable; the rest of each cell behaves exactly as before, so annotation tools still work in unroll mode.
- Labels exist only while unrolled — no new setting, no new persisted state.

## How

`src/utils/unroll.ts` (new, pure, unit-tested) turns the grid's frames into `{ index, label, location }` per cell. Two subtleties it encapsulates:

- `store.xy`/`.z`/`.time` are **indices into `dataset.xy`/`.z`/`.time`**, which `parseTiles` builds as the sorted distinct axis values. So the index to navigate to is a frame's *rank* among those values, not its raw `IndexXY`/`IndexZ` (`z` can fall back to a `PositionZ` float, and nothing guarantees dense indices). Ranking also keeps the label (`rank + 1`) consistent with where the slider lands.
- Those ranks have to come from **every frame of the dataset** (`dataset.allImages`), not from the drawn layer's frames. A channel imaged only at XY 0 and 5, in a dataset whose frames cover XY 0, 2 and 5, would otherwise label its second cell `XY 2` and navigate to XY 2 — where that channel has no image.

`ImageViewer.vue` renders each label as a GeoJS `dom` widget on the map's ui layer, positioned with map coordinates so GeoJS tracks it through pan, zoom and container resize (its `zoom()` ends in a `pan()` and `size()` ends in a `center()`, both firing the `geo_event.pan` that widgets bind). A `domWidget` stops `mousedown` from reaching the GeoJS interactor, which is why a label click cannot start an annotation. Cells are derived **per map** from that map's own `mapLayerList` group, so the multi-map `layerMode: "unroll"` view labels each grid from its own layer. Widgets are rebuilt only when a signature (labels + grid width + cell size) changes, and a watcher on the cells covers the inputs that change label text without causing a redraw (the viewer settings). Grids past 400 cells go unlabelled — one repositioned element per cell stops being reasonable and the text is unreadable at that density — and that decision is logged rather than silent.

## Review rounds

Two Codex rounds plus a `/branch-review`, tracked in `codebaseDocumentation/UNROLL-FRAME-LABELS-REVIEW.md`:

| Finding | Fix |
|---|---|
| Ranks from one layer's frames, and one layer's cells reused for every map (Medium) | `axisImages` (`dataset.allImages`) separate from `cellImages`; cells derived per map |
| Clickable `<div>` had no keyboard access or button semantics (Low) | `<button type="button">` with `aria-label` and a focus ring, via GeoJS's `el` option |
| Label settings didn't update existing widgets until the next redraw (Low) | `watch(unrollCellsByMap, …)` rebuilds them |
| `/branch-review`: impure computed (logged and mutated state in its getter), test identified widgets by call order, one naming slip | Cap and warning moved to the draw path; test picks labels out by class; name restored |

Two pre-existing bugs in `ImageViewer.test.ts` surfaced while testing the watcher and are fixed here: the file never unmounted its wrappers, so every earlier test's component stayed alive and reacted to the shared `reactive()` store mock (one store change ran ~90 components' watchers); and the label assertions read the widget *creation log* rather than the widgets a layer still has, which `draw()`'s map-recreation in the harness made misleading.

## Verification

`pnpm tsc`, `pnpm lint:ci`, and the full suite (178 files / 2973 tests) are green. New tests: 16 unit tests for the ranking and label rules (sparse coverage, dataset-wide ranks, `PositionZ` fallback, grid order, multi-axis, single-valued dimensions, dimension labels on/off/missing), and 11 `ImageViewer` tests for widget creation and positions, the click → navigate path, button semantics, per-map cells, the settings watcher, no-unroll, signature reuse, teardown, and the 400-cell cap.

Driven in the browser on the `normmedia_8well_col2_livecellgfp` dataset (6 XY × 7 Z × 4 T), with real clicks and keystrokes:

| Case | Result |
|---|---|
| Unroll XY | 6 labels `XY 1 (19263, -6626)` … at the cell corners of the 3×2 grid |
| Click `XY 5` | `unrollXY=false`, `xy=4`, `z`/`time` untouched, labels gone, slider reads the 5th XY's dimension label |
| Unroll Z + Time | 28 labels `Z 1 · Time 1` … `Z 7 · Time 4`, 6 per row, matching the tile layout |
| Click `Z 1 · Time 2` | both flags cleared, `z=0`, `time=1`, `xy` preserved |
| Focus `XY 4` + Enter | same navigation as a click — keyboard path works |
| `layerMode: "unroll"` + XY unroll | 12 labels across 2 maps, each from its own layer; clicking the second map's `XY 6` navigates |
| Toggle **Show XY labels** off/on while unrolled | labels rewrite to `XY 1` and back to `XY 1 (19263, -6626)` with no redraw |
| Click a label with the "YFP blob" tool armed | navigated; no annotation created, no pending annotation |

No console errors (only pre-existing Vuetify `dense` deprecation warnings). Note for anyone reproducing with screenshots: the tiles are WebGL canvases that come out black in captured screenshots even though the page renders them — `map.screenshot()` compositing confirms the pixels are there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzqX5knspQjXKBJGUPVMpo
