### PR TITLE
Replace deprecated Vuetify 4 `dense` prop (#1281)

### DIFF
--- a/.agents/skills/in-browser-testing/SKILL.md
+++ b/.agents/skills/in-browser-testing/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when verifying NimbusImage changes in a live browser tab (loca
 
 Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reasoning — and only broke in the live app (pointer-events layering, deep-watch over-firing, HMR-corrupted store, background-tab false-passes). For any user-facing change, in-browser verification is a required gate, and it must be done in a way that can actually fail. The traps below each produced a false "it works" at least once.
 
-## The five false-pass traps
+## The six false-pass traps
 
 1. **Synthetic clicks lie.** `element.dispatchEvent(new MouseEvent('click'))` bypasses hit-testing, `pointer-events`, z-index, and overlays. A synthetic-click walkthrough once reported a tour "working" while real user clicks did nothing. Verify clickability with `document.elementFromPoint(cx, cy)` (is the intended element the topmost hit target?), then click with the real `computer` tool. Reserve synthetic dispatch for *driving* flows fast only after clickability is independently confirmed.
 2. **Background tabs lie.** A hidden tab pauses `requestAnimationFrame`, throttles `setTimeout` to ~1 Hz, and never composites — perf probes report 0 long tasks and event loops stall/time out. The tab must be foreground/visible for any timing or rendering claim. If a paced loop must survive a background tab, use busy-wait gaps (`while (performance.now() < end) {}`), not setTimeout.
@@ -21,6 +21,20 @@ Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reaso
    // draw to an offscreen canvas, then getImageData → report max/mean channel value
    ```
    A non-zero max means the tiles are there. Note that a fluorescence dataset is *legitimately* near-black at fit-to-view zoom (sparse bright cells, `hist.max` pinned to 65535 by a few saturated pixels), so a low mean is not evidence of a bug either. Verify tile health from `statusCode`s in `read_network_requests` (`/tiles/zxy/` → 200) plus the layers' `idle`/`_imageUrls`, and verify overlays from live DOM state — not from the picture.
+6. **An empty console reads as "clean" when it means "not capturing."** `read_console_messages` only records from the moment it is **first called**, so a warning emitted during app boot is invisible unless you call it *then* reload *then* read. Worse, a `console.warn` wrapper installed via `javascript_tool` can never see boot-time output at all — the app has already mounted by the time you can install it. Chasing a missing `[Vuetify UPGRADE]` warning this way produced two false passes in a row (issue #1281) before the order was fixed.
+
+   Compounding it: **`eager` dialogs mount at app boot, and a mount-time warning fires exactly once.** `PipelineDialog.vue` sets `eager` so its content stays mounted while closed — so closing and reopening the dialog does *not* re-run any child's `setup()`, and any one-shot warning there (Vuetify deprecations, prop validators) never fires again for the life of the page. Toggling the dialog to "re-trigger" it silently measures nothing.
+
+   Working order for any boot-time console assertion:
+   ```
+   1. read_console_messages{clear:true}    // start tracking / empty the buffer
+   2. location.reload()                    // via javascript_tool; a #hash nav is NOT a reload
+   3. wait for boot (poll store state)
+   4. read_console_messages{pattern:…}     // the real read
+   5. read again with a broad pattern (e.g. "vite") to prove capture is live —
+      seeing "[vite] connected" is what makes an empty filtered result meaningful
+   ```
+   Then invert it: put the pre-fix code back (`git stash`) and confirm the same sequence *does* report the warning. Verify which code is actually being served rather than assuming the stash took effect — `fetch('/src/path/To.vue?t=' + Date.now())` returns Vite's current transform, and counting tokens in it (`dense` vs `comfortable`) settles it. Rendered DOM often can't: `dense` and `density="comfortable"` produce the *same* `v-row--density-comfortable` class, so the DOM looked identical in both states.
 
 ## Console handles (javascript_tool)
 

--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -332,10 +332,17 @@ On `<v-row>`, the boolean `dense` prop is deprecated. Use `density="comfortable"
 The substitution is **visually identical** — VRow maps
 `density === 'comfortable' || dense` to the same `v-row--density-comfortable`
 class, so `dense` still works and the only symptom is
-`[Vuetify UPGRADE] 'dense' is deprecated` logged on every render. Don't trust
+`[Vuetify UPGRADE] 'dense' is deprecated` in the console. Don't trust
 Vuetify's own JSDoc here: `makeVRowProps` says `@deprecated use
 density="compact"` while the runtime warning and the class mapping both say
 `comfortable`. `comfortable` is the behaviour-preserving one.
+
+**The warning is one-shot per mounted row, not per render.** `deprecate()` is
+called from `VRow.setup()`, so re-rendering or updating an existing row never
+repeats it — which is exactly why you cannot "re-trigger" it by toggling the UI
+that contains it, and why it is usually already gone by the time you attach a
+console listener. See the `in-browser-testing` skill for the capture order this
+forces.
 
 **`VRow` is the only component that warns.** `deprecate('dense', …)` is called
 in exactly one place in Vuetify 4 (`VRow.setup()`). So a `dense` on anything

--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -322,12 +322,41 @@ watch(promptMode, (v) => segState.value?.nodes.input.promptMode.setValue(v));
 
 Reactive **state** fields (from `reactive(...)` in the tool-state factory) are fine to read in computeds — only raw `markRaw`'d node `.output` reads are the trap.
 
-### VRow Density
+### VRow Density — and `dense` everywhere else
 
-`dense` prop is deprecated. Use `density="comfortable"`:
+On `<v-row>`, the boolean `dense` prop is deprecated. Use `density="comfortable"`:
 ```vue
 <v-row density="comfortable" align="center">
 ```
+
+The substitution is **visually identical** — VRow maps
+`density === 'comfortable' || dense` to the same `v-row--density-comfortable`
+class, so `dense` still works and the only symptom is
+`[Vuetify UPGRADE] 'dense' is deprecated` logged on every render. Don't trust
+Vuetify's own JSDoc here: `makeVRowProps` says `@deprecated use
+density="compact"` while the runtime warning and the class mapping both say
+`comfortable`. `comfortable` is the behaviour-preserving one.
+
+**`VRow` is the only component that warns.** `deprecate('dense', …)` is called
+in exactly one place in Vuetify 4 (`VRow.setup()`). So a `dense` on anything
+else is *silent* — and dead: `VCard`, `VListSubheader`, and our own
+`tag-picker` / `docker-image-select` / `property-worker-menu` declare no `dense`
+prop, so Vue passes it through to the root element as a stray DOM attribute that
+styles nothing.
+
+**Delete those; don't convert them.** `VListSubheader` has no `density` prop
+either, so a swap is just a different dead attribute. `VCard` *does* have one,
+so a swap there newly tightens title/subtitle/text padding — an unrequested
+visual change. This is the trap in a scripted sweep: a regex that rewrites
+`dense` → `density="comfortable"` on every tag it matches is wrong on most of
+them, and a regex restricted to `<v-[a-z-]+` misses the custom-component
+instances entirely (they need the opposite treatment, so they can't just be
+ignored).
+
+`src/vuetifyDeprecations.test.ts` scans every `.vue` template for a boolean
+`dense` on any tag and fails the build, so this can't silently come back.
+Extend that test rather than hand-grepping when auditing a new Vuetify
+deprecation.
 
 ### v-menu / v-dialog Initial State
 

--- a/.claude/skills/in-browser-testing/SKILL.md
+++ b/.claude/skills/in-browser-testing/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when verifying NimbusImage changes in a live browser tab (loca
 
 Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reasoning — and only broke in the live app (pointer-events layering, deep-watch over-firing, HMR-corrupted store, background-tab false-passes). For any user-facing change, in-browser verification is a required gate, and it must be done in a way that can actually fail. The traps below each produced a false "it works" at least once.
 
-## The five false-pass traps
+## The six false-pass traps
 
 1. **Synthetic clicks lie.** `element.dispatchEvent(new MouseEvent('click'))` bypasses hit-testing, `pointer-events`, z-index, and overlays. A synthetic-click walkthrough once reported a tour "working" while real user clicks did nothing. Verify clickability with `document.elementFromPoint(cx, cy)` (is the intended element the topmost hit target?), then click with the real `computer` tool. Reserve synthetic dispatch for *driving* flows fast only after clickability is independently confirmed.
 2. **Background tabs lie.** A hidden tab pauses `requestAnimationFrame`, throttles `setTimeout` to ~1 Hz, and never composites — perf probes report 0 long tasks and event loops stall/time out. The tab must be foreground/visible for any timing or rendering claim. If a paced loop must survive a background tab, use busy-wait gaps (`while (performance.now() < end) {}`), not setTimeout.
@@ -21,6 +21,20 @@ Multiple real bugs in this repo passed tsc, lint, all unit tests, and code reaso
    // draw to an offscreen canvas, then getImageData → report max/mean channel value
    ```
    A non-zero max means the tiles are there. Note that a fluorescence dataset is *legitimately* near-black at fit-to-view zoom (sparse bright cells, `hist.max` pinned to 65535 by a few saturated pixels), so a low mean is not evidence of a bug either. Verify tile health from `statusCode`s in `read_network_requests` (`/tiles/zxy/` → 200) plus the layers' `idle`/`_imageUrls`, and verify overlays from live DOM state — not from the picture.
+6. **An empty console reads as "clean" when it means "not capturing."** `read_console_messages` only records from the moment it is **first called**, so a warning emitted during app boot is invisible unless you call it *then* reload *then* read. Worse, a `console.warn` wrapper installed via `javascript_tool` can never see boot-time output at all — the app has already mounted by the time you can install it. Chasing a missing `[Vuetify UPGRADE]` warning this way produced two false passes in a row (issue #1281) before the order was fixed.
+
+   Compounding it: **`eager` dialogs mount at app boot, and a mount-time warning fires exactly once.** `PipelineDialog.vue` sets `eager` so its content stays mounted while closed — so closing and reopening the dialog does *not* re-run any child's `setup()`, and any one-shot warning there (Vuetify deprecations, prop validators) never fires again for the life of the page. Toggling the dialog to "re-trigger" it silently measures nothing.
+
+   Working order for any boot-time console assertion:
+   ```
+   1. read_console_messages{clear:true}    // start tracking / empty the buffer
+   2. location.reload()                    // via javascript_tool; a #hash nav is NOT a reload
+   3. wait for boot (poll store state)
+   4. read_console_messages{pattern:…}     // the real read
+   5. read again with a broad pattern (e.g. "vite") to prove capture is live —
+      seeing "[vite] connected" is what makes an empty filtered result meaningful
+   ```
+   Then invert it: put the pre-fix code back (`git stash`) and confirm the same sequence *does* report the warning. Verify which code is actually being served rather than assuming the stash took effect — `fetch('/src/path/To.vue?t=' + Date.now())` returns Vite's current transform, and counting tokens in it (`dense` vs `comfortable`) settles it. Rendered DOM often can't: `dense` and `density="comfortable"` produce the *same* `v-row--density-comfortable` class, so the DOM looked identical in both states.
 
 ## Console handles (javascript_tool)
 

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -332,10 +332,17 @@ On `<v-row>`, the boolean `dense` prop is deprecated. Use `density="comfortable"
 The substitution is **visually identical** — VRow maps
 `density === 'comfortable' || dense` to the same `v-row--density-comfortable`
 class, so `dense` still works and the only symptom is
-`[Vuetify UPGRADE] 'dense' is deprecated` logged on every render. Don't trust
+`[Vuetify UPGRADE] 'dense' is deprecated` in the console. Don't trust
 Vuetify's own JSDoc here: `makeVRowProps` says `@deprecated use
 density="compact"` while the runtime warning and the class mapping both say
 `comfortable`. `comfortable` is the behaviour-preserving one.
+
+**The warning is one-shot per mounted row, not per render.** `deprecate()` is
+called from `VRow.setup()`, so re-rendering or updating an existing row never
+repeats it — which is exactly why you cannot "re-trigger" it by toggling the UI
+that contains it, and why it is usually already gone by the time you attach a
+console listener. See the `in-browser-testing` skill for the capture order this
+forces.
 
 **`VRow` is the only component that warns.** `deprecate('dense', …)` is called
 in exactly one place in Vuetify 4 (`VRow.setup()`). So a `dense` on anything

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -322,12 +322,41 @@ watch(promptMode, (v) => segState.value?.nodes.input.promptMode.setValue(v));
 
 Reactive **state** fields (from `reactive(...)` in the tool-state factory) are fine to read in computeds — only raw `markRaw`'d node `.output` reads are the trap.
 
-### VRow Density
+### VRow Density — and `dense` everywhere else
 
-`dense` prop is deprecated. Use `density="comfortable"`:
+On `<v-row>`, the boolean `dense` prop is deprecated. Use `density="comfortable"`:
 ```vue
 <v-row density="comfortable" align="center">
 ```
+
+The substitution is **visually identical** — VRow maps
+`density === 'comfortable' || dense` to the same `v-row--density-comfortable`
+class, so `dense` still works and the only symptom is
+`[Vuetify UPGRADE] 'dense' is deprecated` logged on every render. Don't trust
+Vuetify's own JSDoc here: `makeVRowProps` says `@deprecated use
+density="compact"` while the runtime warning and the class mapping both say
+`comfortable`. `comfortable` is the behaviour-preserving one.
+
+**`VRow` is the only component that warns.** `deprecate('dense', …)` is called
+in exactly one place in Vuetify 4 (`VRow.setup()`). So a `dense` on anything
+else is *silent* — and dead: `VCard`, `VListSubheader`, and our own
+`tag-picker` / `docker-image-select` / `property-worker-menu` declare no `dense`
+prop, so Vue passes it through to the root element as a stray DOM attribute that
+styles nothing.
+
+**Delete those; don't convert them.** `VListSubheader` has no `density` prop
+either, so a swap is just a different dead attribute. `VCard` *does* have one,
+so a swap there newly tightens title/subtitle/text padding — an unrequested
+visual change. This is the trap in a scripted sweep: a regex that rewrites
+`dense` → `density="comfortable"` on every tag it matches is wrong on most of
+them, and a regex restricted to `<v-[a-z-]+` misses the custom-component
+instances entirely (they need the opposite treatment, so they can't just be
+ignored).
+
+`src/vuetifyDeprecations.test.ts` scans every `.vue` template for a boolean
+`dense` on any tag and fails the build, so this can't silently come back.
+Extend that test rather than hand-grepping when auditing a new Vuetify
+deprecation.
 
 ### v-menu / v-dialog Initial State
 

--- a/codebaseDocumentation/VUETIFY4_MIGRATION.md
+++ b/codebaseDocumentation/VUETIFY4_MIGRATION.md
@@ -39,7 +39,33 @@ Files changed:
 **Note:** The `#item` slot name itself did NOT change (contrary to some online sources claiming it was renamed to `#internalItem`).
 
 ### VRow `dense` Prop Deprecated
-Vuetify 4 deprecates the boolean `dense` prop on `v-row`. Replaced with `density="comfortable"` across 10 occurrences in 6 files.
+Vuetify 4 deprecates the boolean `dense` prop on `v-row`. Replaced with `density="comfortable"` across 10 occurrences in 6 files. A follow-up sweep (issue #1281) caught the remaining 19; `src/vuetifyDeprecations.test.ts` now fails the build if any come back.
+
+`VRow` is the **only** component that warns: `VRow.setup()` calls
+`deprecate('dense', 'density="comfortable"')`, and nothing else in Vuetify 4
+does. The prop is *not* ignored — VRow maps `density === 'comfortable' || dense`
+to the same `v-row--density-comfortable` class, so the substitution is
+visually identical and purely silences the console.
+
+Two things to know before touching a `dense` outside `v-row`:
+
+- **Vuetify's own JSDoc contradicts its runtime.** `makeVRowProps` is annotated
+  `@deprecated use density="compact"` while the warning and the class mapping
+  both say `comfortable`. `comfortable` is the behaviour-preserving choice —
+  `compact` would tighten gutters that `dense` never tightened.
+- **On anything other than `v-row`, `dense` was always dead** — `VCard`,
+  `VListSubheader`, and our own `tag-picker` / `docker-image-select` /
+  `property-worker-menu` declare no `dense` prop, so it fell through to the DOM
+  as a stray attribute and never styled anything. These get **deleted**, not
+  converted: `VListSubheader` has no `density` prop either (a swap would just be
+  a different dead attribute), and `VCard` *does* have one, so a swap there
+  would newly tighten title/subtitle/text padding — a visual change nobody
+  asked for. `TagPicker` and `DockerImageSelect` already set
+  `density="compact"` on their inner field internally.
+
+  (An earlier revision of this document listed these under "What Was NOT
+  Changed" as "app-level props." That was wrong — none of the three components
+  ever declared the prop.)
 
 ### `!important` Cleanup
 With CSS Cascade Layers, custom styles (outside layers) automatically win over Vuetify's layered styles. Removed 61 `!important` declarations that were only needed to beat Vuetify specificity.
@@ -83,5 +109,4 @@ Vuetify 4 reduced elevation levels from 0-24 to 0-5. All usages in the codebase 
 ## What Was NOT Changed
 - `v-data-table` `#item` slot — this is a VDataTable slot, not VSelect, and was not affected
 - `v-breadcrumbs` `#item` slot — not affected
-- `dense` prop on custom components (`tag-picker`, `docker-image-select`, etc.) — these are app-level props, not Vuetify deprecations
 - `@girder/components` version — staying at 4.0.0 until a Vuetify 4-compatible release

--- a/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
+++ b/src/components/AnnotationBrowser/AnnotationProperties/PropertyCreation.vue
@@ -10,12 +10,11 @@
       <v-container class="pa-2">
         <v-row align="center" class="mb-1" density="comfortable">
           <v-col cols="4">
-            <v-list-subheader dense>Measure by tag:</v-list-subheader>
+            <v-list-subheader>Measure by tag:</v-list-subheader>
           </v-col>
           <v-col cols="5">
             <tag-picker
               v-model="filteringTags"
-              dense
               :data-tour="TOUR_ANCHORS.propertyTagPicker"
               v-tour-trigger="TOUR_TRIGGERS.propertyTagPicker"
             />
@@ -31,9 +30,7 @@
         </v-row>
         <v-row align="center" density="comfortable">
           <v-col cols="4">
-            <v-list-subheader dense>{{
-              shapeSelectionString
-            }}</v-list-subheader>
+            <v-list-subheader>{{ shapeSelectionString }}</v-list-subheader>
           </v-col>
           <v-col cols="8">
             <v-select
@@ -55,7 +52,6 @@
         <v-row density="comfortable">
           <v-col>
             <docker-image-select
-              dense
               v-model="dockerImage"
               :imageFilter="propertyImageFilter"
               :data-tour="TOUR_ANCHORS.propertyAlgorithmSelect"
@@ -69,7 +65,6 @@
               <property-worker-menu
                 v-model="interfaceValues"
                 :image="dockerImage"
-                dense
               />
             </v-col>
           </v-row>

--- a/src/components/SharingStatusIcon.vue
+++ b/src/components/SharingStatusIcon.vue
@@ -16,7 +16,7 @@
         {{ iconName }}
       </v-icon>
     </template>
-    <v-card dense class="pa-2" max-width="300">
+    <v-card class="pa-2" max-width="300">
       <!-- Loading -->
       <div v-if="loading" class="text-center pa-1">
         <v-progress-circular indeterminate size="16" width="2" />

--- a/src/components/pipelines/PipelineEditor.vue
+++ b/src/components/pipelines/PipelineEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="pa-0">
-    <v-row class="my-0" dense>
+    <v-row class="my-0" density="comfortable">
       <v-col cols="12" class="py-1">
         <v-text-field
           v-model="localPipeline.name"
@@ -11,7 +11,7 @@
         />
       </v-col>
     </v-row>
-    <v-row class="my-0" dense>
+    <v-row class="my-0" density="comfortable">
       <v-col class="py-1">
         <v-textarea
           v-model="localPipeline.description"
@@ -39,7 +39,11 @@
       {{ warning }}
     </v-alert>
 
-    <v-row v-if="localPipeline.steps.length === 0" class="my-2" dense>
+    <v-row
+      v-if="localPipeline.steps.length === 0"
+      class="my-2"
+      density="comfortable"
+    >
       <v-col class="text-caption text-medium-emphasis">
         No steps yet. Add a step to get started.
       </v-col>
@@ -130,7 +134,7 @@
             :auto-wired-caption="stepCaptions[index]"
             @update:model-value="handleStepUpdate(index, $event)"
           />
-          <v-row class="my-0" dense>
+          <v-row class="my-0" density="comfortable">
             <v-col class="d-flex ga-2 py-1 align-center">
               <v-btn
                 variant="text"
@@ -169,7 +173,7 @@
       </v-expansion-panel>
     </v-expansion-panels>
 
-    <v-row class="my-2" dense>
+    <v-row class="my-2" density="comfortable">
       <v-col class="py-1">
         <v-btn
           variant="outlined"
@@ -185,7 +189,7 @@
     </v-row>
 
     <!-- Run options -->
-    <v-row class="my-0" dense>
+    <v-row class="my-0" density="comfortable">
       <v-col class="py-1">
         <v-checkbox
           v-model="controller.continueOnError.value"
@@ -202,7 +206,7 @@
         controller.batchDisabledReason.value
       "
       class="my-0"
-      dense
+      density="comfortable"
     >
       <v-col class="py-1">
         <v-tooltip
@@ -240,7 +244,7 @@
       {{ controller.runNotice.value }}
     </v-alert>
 
-    <v-row class="my-2" dense>
+    <v-row class="my-2" density="comfortable">
       <v-col class="d-flex ga-2 py-1 justify-end align-center">
         <!-- Saved / unsaved chrome, pushed to the left of the action buttons. -->
         <v-chip

--- a/src/components/pipelines/PipelineList.vue
+++ b/src/components/pipelines/PipelineList.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="pa-0">
-    <v-row class="my-0" dense>
+    <v-row class="my-0" density="comfortable">
       <v-col class="d-flex ga-2 py-1 justify-end">
         <v-btn
           variant="flat"
@@ -106,7 +106,7 @@
         </template>
       </v-list-item>
     </v-list>
-    <v-row v-else class="my-2" dense>
+    <v-row v-else class="my-2" density="comfortable">
       <v-col class="text-caption text-medium-emphasis">
         No pipelines yet. Create one to get started.
       </v-col>

--- a/src/components/pipelines/PipelineStepEditor.vue
+++ b/src/components/pipelines/PipelineStepEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="pa-0">
-    <v-row class="my-0" dense>
+    <v-row class="my-0" density="comfortable">
       <v-col cols="8" class="py-1">
         <v-text-field
           v-model="name"
@@ -19,7 +19,7 @@
       </v-col>
     </v-row>
 
-    <v-row class="my-0" dense>
+    <v-row class="my-0" density="comfortable">
       <v-col class="py-1">
         <docker-image-select v-model="image" :imageFilter="imageFilter" />
       </v-col>
@@ -43,7 +43,7 @@
       </v-row>
     </template>
     <template v-else>
-      <v-row class="my-0" dense>
+      <v-row class="my-0" density="comfortable">
         <v-col cols="6" class="py-1">
           <v-select
             label="Shape"

--- a/src/vuetifyDeprecations.test.ts
+++ b/src/vuetifyDeprecations.test.ts
@@ -40,9 +40,10 @@ function templateBlock(source: string): string {
 const OPEN_TAG = /<([A-Za-z][a-zA-Z0-9.-]*)((?:[^>"']|"[^"]*"|'[^']*')*?)\/?>/g;
 
 // A `dense` attribute in any binding form: bare, `dense="true"`, `:dense="x"`,
-// or `v-bind:dense="x"`. `density="…"` never matches, because the character
-// after `dense` must be whitespace, "=", or the blob's end.
-const DENSE_ATTR = /(^|\s)(?::|v-bind:)?dense(?=[\s=]|$)/;
+// `v-bind:dense="x"`, and with modifiers (`:dense.camel="x"`). `density="…"`
+// never matches, because after the optional modifier chain the next character
+// must be whitespace, "=", or the blob's end.
+const DENSE_ATTR = /(^|\s)(?::|v-bind:)?dense(?:\.[a-zA-Z]+)*(?=[\s=]|$)/;
 
 // Attribute *values* are not attribute names: `class="a dense b"` must not
 // register, so blank the quoted spans before looking for the token.
@@ -50,12 +51,33 @@ function attrNames(blob: string): string {
   return blob.replace(/"[^"]*"/g, '""').replace(/'[^']*'/g, "''");
 }
 
+// `v-bind="{ dense: true }"` spreads onto props, so a `dense` key there really
+// does set the prop — unlike a `dense` key inside a *named* prop's object value
+// (`:x="{ dense: true }"`), which binds to `x` and must be ignored. Only the
+// unnamed spread's own value is searched.
+const VBIND_SPREAD = /v-bind\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+// An object key named `dense`, including the `{ dense }` shorthand.
+const DENSE_KEY = /(^|[{,\s])dense\s*(?=[:,}\s]|$)/;
+
+// KNOWN LIMIT: `v-bind="someObject"` (116 occurrences in src, all
+// `activatorProps`/`$attrs` style) cannot be resolved statically, so a `dense`
+// arriving through one is invisible to this guard. Documented rather than
+// silently assumed away; `does not fire on look-alikes` pins the behaviour so
+// the gap stays visible instead of being mistaken for coverage.
+function denseInTag(blob: string): boolean {
+  if (DENSE_ATTR.test(attrNames(blob))) return true;
+  for (const spread of blob.matchAll(VBIND_SPREAD)) {
+    if (DENSE_KEY.test(spread[1] ?? spread[2] ?? "")) return true;
+  }
+  return false;
+}
+
 function densePlaces(source: string): string[] {
   // Drop HTML comments so prose mentioning "dense" is not scanned as markup.
   const stripped = templateBlock(source).replace(/<!--[\s\S]*?-->/g, "");
   const found: string[] = [];
   for (const match of stripped.matchAll(OPEN_TAG)) {
-    if (DENSE_ATTR.test(attrNames(match[2]))) {
+    if (denseInTag(match[2])) {
       found.push(match[1]);
     }
   }
@@ -64,9 +86,11 @@ function densePlaces(source: string): string[] {
 
 describe("Vuetify 4 deprecations", () => {
   // Vuetify 4 deprecated the boolean `dense` prop. VRow still honours it but
-  // logs `[Vuetify UPGRADE] 'dense' is deprecated` on every render; every
-  // other component in this app never had a `dense` prop at all, so there the
-  // attribute silently falls through to the DOM as dead markup.
+  // logs `[Vuetify UPGRADE] 'dense' is deprecated` once per mounted instance —
+  // `deprecate()` is called from `setup()`, so re-rendering an existing row
+  // never repeats it. Every other component in this app never had a `dense`
+  // prop at all, so there the attribute silently falls through to the DOM as
+  // dead markup.
   //
   // Fix: on `<v-row>` use `density="comfortable"` (identical rendered class —
   // VRow maps both to `v-row--density-comfortable`). Anywhere else, delete the
@@ -119,6 +143,13 @@ describe("Vuetify 4 deprecations", () => {
     expect(t(`<v-row dense="true">`)).toEqual(["v-row"]);
     expect(t(`<v-row :dense="isDense">`)).toEqual(["v-row"]);
     expect(t(`<v-row v-bind:dense="isDense">`)).toEqual(["v-row"]);
+    // binding modifiers
+    expect(t(`<v-row :dense.camel="isDense">`)).toEqual(["v-row"]);
+    expect(t(`<v-row v-bind:dense.prop="isDense">`)).toEqual(["v-row"]);
+    // object-literal v-bind spread really does set the prop
+    expect(t(`<VRow v-bind="{ dense: true }" />`)).toEqual(["VRow"]);
+    expect(t(`<VRow v-bind="{ ...rest, dense: true }" />`)).toEqual(["VRow"]);
+    expect(t(`<VRow v-bind="{ dense }" />`)).toEqual(["VRow"]);
     // custom components, which the issue's `<v-[a-z-]+` regex missed entirely
     expect(t(`<tag-picker v-model="t" dense />`)).toEqual(["tag-picker"]);
   });
@@ -128,14 +159,23 @@ describe("Vuetify 4 deprecations", () => {
 
     expect(t(`<v-row density="comfortable">`)).toEqual([]);
     expect(t(`<v-checkbox density="compact" />`)).toEqual([]);
+    expect(t(`<v-row v-bind="{ density: 'comfortable' }" />`)).toEqual([]);
     expect(t(`<!-- the slider is dense -->`)).toEqual([]);
     // "dense" appearing inside an attribute *value*, not as a prop name
     expect(t(`<v-col class="a dense b">`)).toEqual([]);
     expect(t(`<v-col :label="a > b ? 'dense' : ''">`)).toEqual([]);
+    // a `dense` key on a NAMED prop binds to that prop, not to `dense`
     expect(t(`<v-col :x="{ dense: true }">`)).toEqual([]);
+    // similarly-spelled identifiers are not the prop
+    expect(t(`<v-row :is-dense="x" />`)).toEqual([]);
+    expect(t(`<v-row v-bind="{ isDense: true }" />`)).toEqual([]);
     // script-block generics are outside the template and must be ignored
     expect(
       densePlaces(`<script setup>const r = ref<Dense>();</script>`),
     ).toEqual([]);
+
+    // Documented limit, asserted so it stays visible rather than being
+    // mistaken for coverage: an opaque spread cannot be resolved statically.
+    expect(t(`<VRow v-bind="activatorProps" />`)).toEqual([]);
   });
 });

--- a/src/vuetifyDeprecations.test.ts
+++ b/src/vuetifyDeprecations.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "fs";
+import { join, dirname, relative } from "path";
+import { fileURLToPath } from "url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = here;
+
+function allVueFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith(".vue")) {
+        out.push(full);
+      }
+    }
+  };
+  walk(srcRoot);
+  return out.sort();
+}
+
+// Matches an opening tag and captures its attribute blob. Quoted values are
+// consumed wholesale so a ">" inside an attribute (e.g. `:x="a > b"`) does not
+// end the match early, and the blob may span newlines so multi-line tags are
+// covered. HTML comments never match because "!" is not in [a-z].
+const OPEN_TAG = /<([a-z][a-zA-Z0-9-]*)((?:[^>"']|"[^"]*"|'[^']*')*?)\/?>/g;
+
+// A standalone boolean `dense` attribute. `density="…"` does not match, because
+// the character after `dense` must be whitespace, "=", or the blob's end.
+const BOOLEAN_DENSE = /(^|\s)dense(\s|=|$)/;
+
+function densePlaces(source: string): string[] {
+  // Drop HTML comments so prose mentioning "dense" is not scanned as markup.
+  const stripped = source.replace(/<!--[\s\S]*?-->/g, "");
+  const found: string[] = [];
+  for (const match of stripped.matchAll(OPEN_TAG)) {
+    if (BOOLEAN_DENSE.test(match[2])) {
+      found.push(match[1]);
+    }
+  }
+  return found;
+}
+
+describe("Vuetify 4 deprecations", () => {
+  // Vuetify 4 deprecated the boolean `dense` prop. VRow still honours it but
+  // logs `[Vuetify UPGRADE] 'dense' is deprecated` on every render; every
+  // other component in this app never had a `dense` prop at all, so there the
+  // attribute silently falls through to the DOM as dead markup.
+  //
+  // Fix: on `<v-row>` use `density="comfortable"` (identical rendered class —
+  // VRow maps both to `v-row--density-comfortable`). Anywhere else, delete the
+  // attribute; do not swap in `density`, which is either equally dead or a new
+  // unintended visual change.
+  it("no component uses the deprecated boolean `dense` prop", () => {
+    const offenders: string[] = [];
+    for (const file of allVueFiles()) {
+      for (const tag of densePlaces(readFileSync(file, "utf8"))) {
+        offenders.push(`${relative(srcRoot, file)}: <${tag} dense>`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("the scanner detects `dense` but not `density`", () => {
+    expect(densePlaces(`<v-row class="my-0" dense>`)).toEqual(["v-row"]);
+    expect(densePlaces(`<v-row\n  class="my-0"\n  dense\n>`)).toEqual([
+      "v-row",
+    ]);
+    expect(densePlaces(`<v-row density="comfortable">`)).toEqual([]);
+    expect(densePlaces(`<!-- the slider is dense -->`)).toEqual([]);
+    expect(densePlaces(`<v-col :label="a > b ? 'dense' : ''">`)).toEqual([]);
+  });
+});

--- a/src/vuetifyDeprecations.test.ts
+++ b/src/vuetifyDeprecations.test.ts
@@ -22,22 +22,40 @@ function allVueFiles(): string[] {
   return out.sort();
 }
 
+// Only the SFC's template block is markup. Scoping to it lets the tag pattern
+// accept PascalCase without TypeScript generics in <script> (`ref<VForm>()`,
+// `Ref<PaletteRefEl | undefined>`) being mistaken for component tags.
+function templateBlock(source: string): string {
+  const start = source.indexOf("<template>");
+  const end = source.lastIndexOf("</template>");
+  return start === -1 || end <= start ? "" : source.slice(start, end);
+}
+
 // Matches an opening tag and captures its attribute blob. Quoted values are
 // consumed wholesale so a ">" inside an attribute (e.g. `:x="a > b"`) does not
 // end the match early, and the blob may span newlines so multi-line tags are
-// covered. HTML comments never match because "!" is not in [a-z].
-const OPEN_TAG = /<([a-z][a-zA-Z0-9-]*)((?:[^>"']|"[^"]*"|'[^']*')*?)\/?>/g;
+// covered. HTML comments never match because "!" is not in [A-Za-z].
+// The tag name accepts both `<v-row>` and `<VRow>` — both are valid Vue, and a
+// guard that sees only one spelling would pass while the deprecation returns.
+const OPEN_TAG = /<([A-Za-z][a-zA-Z0-9.-]*)((?:[^>"']|"[^"]*"|'[^']*')*?)\/?>/g;
 
-// A standalone boolean `dense` attribute. `density="…"` does not match, because
-// the character after `dense` must be whitespace, "=", or the blob's end.
-const BOOLEAN_DENSE = /(^|\s)dense(\s|=|$)/;
+// A `dense` attribute in any binding form: bare, `dense="true"`, `:dense="x"`,
+// or `v-bind:dense="x"`. `density="…"` never matches, because the character
+// after `dense` must be whitespace, "=", or the blob's end.
+const DENSE_ATTR = /(^|\s)(?::|v-bind:)?dense(?=[\s=]|$)/;
+
+// Attribute *values* are not attribute names: `class="a dense b"` must not
+// register, so blank the quoted spans before looking for the token.
+function attrNames(blob: string): string {
+  return blob.replace(/"[^"]*"/g, '""').replace(/'[^']*'/g, "''");
+}
 
 function densePlaces(source: string): string[] {
   // Drop HTML comments so prose mentioning "dense" is not scanned as markup.
-  const stripped = source.replace(/<!--[\s\S]*?-->/g, "");
+  const stripped = templateBlock(source).replace(/<!--[\s\S]*?-->/g, "");
   const found: string[] = [];
   for (const match of stripped.matchAll(OPEN_TAG)) {
-    if (BOOLEAN_DENSE.test(match[2])) {
+    if (DENSE_ATTR.test(attrNames(match[2]))) {
       found.push(match[1]);
     }
   }
@@ -54,7 +72,7 @@ describe("Vuetify 4 deprecations", () => {
   // VRow maps both to `v-row--density-comfortable`). Anywhere else, delete the
   // attribute; do not swap in `density`, which is either equally dead or a new
   // unintended visual change.
-  it("no component uses the deprecated boolean `dense` prop", () => {
+  it("no component uses the deprecated `dense` prop", () => {
     const offenders: string[] = [];
     for (const file of allVueFiles()) {
       for (const tag of densePlaces(readFileSync(file, "utf8"))) {
@@ -64,13 +82,60 @@ describe("Vuetify 4 deprecations", () => {
     expect(offenders).toEqual([]);
   });
 
-  it("the scanner detects `dense` but not `density`", () => {
-    expect(densePlaces(`<v-row class="my-0" dense>`)).toEqual(["v-row"]);
-    expect(densePlaces(`<v-row\n  class="my-0"\n  dense\n>`)).toEqual([
-      "v-row",
+  // A guard that silently inspects nothing passes forever. If the template
+  // extraction or the tag pattern ever breaks, this fails instead of the
+  // check above quietly going vacuous.
+  it("actually scans the component tree", () => {
+    const files = allVueFiles();
+    expect(files.length).toBeGreaterThan(100);
+
+    const withoutTemplate = files.filter(
+      (f) => !templateBlock(readFileSync(f, "utf8")),
+    );
+    expect(withoutTemplate.map((f) => relative(srcRoot, f))).toEqual([]);
+
+    const tags = files.reduce(
+      (n, f) =>
+        n +
+        [...templateBlock(readFileSync(f, "utf8")).matchAll(OPEN_TAG)].length,
+      0,
+    );
+    expect(tags).toBeGreaterThan(1000);
+  });
+
+  it("detects `dense` in every binding form, on either tag spelling", () => {
+    const t = (markup: string) => densePlaces(`<template>${markup}</template>`);
+
+    // bare boolean, kebab-case and PascalCase tags
+    expect(t(`<v-row class="my-0" dense>`)).toEqual(["v-row"]);
+    expect(t(`<VRow class="my-0" dense>`)).toEqual(["VRow"]);
+    expect(t(`<v-list-subheader dense>x</v-list-subheader>`)).toEqual([
+      "v-list-subheader",
     ]);
-    expect(densePlaces(`<v-row density="comfortable">`)).toEqual([]);
-    expect(densePlaces(`<!-- the slider is dense -->`)).toEqual([]);
-    expect(densePlaces(`<v-col :label="a > b ? 'dense' : ''">`)).toEqual([]);
+    // multi-line tag, attribute on its own line
+    expect(t(`<v-row\n  class="my-0"\n  dense\n>`)).toEqual(["v-row"]);
+    expect(t(`<VRow\n  dense\n/>`)).toEqual(["VRow"]);
+    // explicit and bound forms
+    expect(t(`<v-row dense="true">`)).toEqual(["v-row"]);
+    expect(t(`<v-row :dense="isDense">`)).toEqual(["v-row"]);
+    expect(t(`<v-row v-bind:dense="isDense">`)).toEqual(["v-row"]);
+    // custom components, which the issue's `<v-[a-z-]+` regex missed entirely
+    expect(t(`<tag-picker v-model="t" dense />`)).toEqual(["tag-picker"]);
+  });
+
+  it("does not fire on look-alikes", () => {
+    const t = (markup: string) => densePlaces(`<template>${markup}</template>`);
+
+    expect(t(`<v-row density="comfortable">`)).toEqual([]);
+    expect(t(`<v-checkbox density="compact" />`)).toEqual([]);
+    expect(t(`<!-- the slider is dense -->`)).toEqual([]);
+    // "dense" appearing inside an attribute *value*, not as a prop name
+    expect(t(`<v-col class="a dense b">`)).toEqual([]);
+    expect(t(`<v-col :label="a > b ? 'dense' : ''">`)).toEqual([]);
+    expect(t(`<v-col :x="{ dense: true }">`)).toEqual([]);
+    // script-block generics are outside the template and must be ignored
+    expect(
+      densePlaces(`<script setup>const r = ref<Dense>();</script>`),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #1281.

## Verified, with two corrections to the issue

**`dense` was not being ignored.** The issue says the components "render at default density rather than the compact spacing originally intended." `VRow` maps `density === 'comfortable' || props.dense` to the same `v-row--density-comfortable` class, so `dense` still worked — only the console warning was new. Confirmed live: pre-fix the rows rendered `v-row--density-comfortable`, and post-fix all 6 rows in the dialog do too, with zero `v-row--density-default`. **This PR is a pure warning cleanup with no visual change.**

**There are 19 occurrences, not 16.** `PropertyCreation.vue` has 5, not 2. The issue's regex was scoped to `<v-[a-z-]+`, so it missed `dense` on three *custom* components — which happen to be the ones needing the opposite treatment.

## Why the 6 non-`VRow` cases are deleted, not converted

`VRow` is the **only** component in Vuetify 4 that calls `deprecate('dense', …)` (`VRow.js:167`). Everything else was silent *and* dead: `VCard`, `VListSubheader`, `tag-picker`, `docker-image-select` and `property-worker-menu` declare no `dense` prop, so Vue passed it through to the DOM as a stray attribute. Measured in the live DOM: **3 stray `[dense]` attributes pre-fix, 0 after.**

The issue's scripted sweep would have been wrong on all of these:

| Target | `dense` prop? | `density` prop? | Correct fix |
|---|---|---|---|
| `v-row` × 13 | yes (deprecated) | yes | `density="comfortable"` |
| `v-card` × 1 | no | **yes** | delete — a swap would newly tighten title/subtitle/text padding |
| `v-list-subheader` × 2 | no | no | delete — a swap is just a different dead attribute |
| 3 custom components | no | no | delete — and `TagPicker`/`DockerImageSelect` already set `density="compact"` internally |

Note Vuetify contradicts itself here: `makeVRowProps` is annotated `@deprecated use density="compact"` while the runtime warning and the class mapping both say `comfortable`. `comfortable` is the behaviour-preserving one.

## Verification

`pnpm tsc` clean, `pnpm lint:ci` clean, 3123 tests across 186 files pass. (Two vitest stderr `Could not parse CSS stylesheet` errors are pre-existing jsdom-vs-`@layer` noise in files this PR doesn't touch — confirmed on stashed-clean `master`.)

In-browser A/B, since the whole issue is a console warning:

- **Pre-fix** (`git stash`): 2 `[Vuetify UPGRADE]` warnings at page load, trace matching the issue exactly — `<VRow class="my-0" dense="">` at `<PipelineList>`, with `modelValue=false`.
- **Post-fix**: zero, with `[vite] connected` still captured to prove the reader was live.

This took three attempts because the first two probes *couldn't fail*: `PipelineDialog` sets `eager`, so its content mounts at app boot and the one-shot warning fires before any console hook can be installed — and toggling the dialog re-runs no `setup()`. That trap is now written into the `in-browser-testing` skill.

**Not verified live:** `SharingStatusIcon` renders only `v-if="getConfigSharingInfo(...)"` and no dataset on hand was shared, so its popover never mounted. Its change rests on `VCard`'s prop table plus the 3→0 stray-attribute count — the same mechanism verified on `v-list-subheader`.

## Durable artifacts

Per `CLAUDE.md` ("turn review findings into durable artifacts"):

- **`src/vuetifyDeprecations.test.ts`** (new) — scans every `.vue` template for boolean `dense` on any tag, with self-tests for the scanner itself. Failed with exactly 19 offenders before the fix.
- **`nimbus-frontend` skill** — why `VRow` is the only warner, the JSDoc/runtime contradiction, and why a blanket regex sweep is wrong in both directions.
- **`in-browser-testing` skill** — sixth false-pass trap: an empty console reads as "clean" when it means "not capturing".
- **`VUETIFY4_MIGRATION.md`** — corrected; it had listed the custom components under "What Was NOT Changed" as "app-level props", which was factually wrong (none ever declared the prop).

## Out of scope

The `<Transition>` non-element-root warning at `<LargeImageDropdown>`/`<NavigatorPanel>` is untouched, as the issue specifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPECZgLuVqaRom51j1su9y