### PR TITLE
Override js-yaml 3.x to 3.15.0 for the merge-key advisories (supersedes #1284)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@protobufjs/utf8': ^1.1.1
   '@girder/components>markdown-it': ^14.0.0
   uc.micro: 2.0.0
+  js-yaml@3: 3.15.0
 
 patchedDependencies:
   '@girder/components@4.0.0': 8aaba3e355e9252cd18d88b6f2300a8f2738fa449f7fc042708e1119b16d514b
@@ -3292,12 +3293,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.14.0:
-    resolution: {integrity: sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==}
-    hasBin: true
-
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.3.0:
@@ -8249,13 +8246,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.14.0:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-    optional: true
-
-  js-yaml@3.14.1:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -9767,7 +9758,7 @@ snapshots:
       '@oozcitak/infra': 1.0.8
       '@oozcitak/util': 8.3.8
       '@types/node': 20.19.33
-      js-yaml: 3.14.0
+      js-yaml: 3.15.0
     optional: true
 
   xmlbuilder2@4.0.3:
@@ -9793,7 +9784,7 @@ snapshots:
   yaml-front-matter@4.1.1:
     dependencies:
       commander: 6.2.1
-      js-yaml: 3.14.1
+      js-yaml: 3.15.0
 
   yaml-loader@0.8.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,20 @@ overrides:
   "@protobufjs/utf8": "^1.1.1"
   "@girder/components>markdown-it": "^14.0.0"
   "uc.micro": "2.0.0"
+  # GHSA-52cp-r559-cp3m (high), GHSA-h67p-54hq-rp68, GHSA-mh29-5h37-fv8m:
+  # merge-key DoS and prototype pollution, all patched in the 3.x line at
+  # 3.15.0. Two consumers are stuck on js-yaml 3: yaml-front-matter (^3.14.1)
+  # and xmlbuilder2@3.0.2, which pins 3.14.0 exactly and so cannot float on
+  # its own. Scoped to the 3.x range so the direct js-yaml 4 dep is untouched.
+  #
+  # This clears `pnpm audit`, but note what it does NOT reach: the copy that
+  # actually ships to the browser is inlined inside vtk.js@29.4.2's prebuilt
+  # vtk.js (pulled in by geojs > geo.lean.js), so no js-yaml version override
+  # can touch it. Confirmed via a --sourcemap build: the bundled YAML reader
+  # maps to vtk.js@29.4.2/vtk.js, and the output is byte-identical with and
+  # without this override. That code is only exploitable by parsing untrusted
+  # YAML through xmlbuilder2's reader, which this app never does.
+  "js-yaml@3": "3.15.0"
 patchedDependencies:
   "@girder/components@4.0.0": patches/@girder__components.patch
   "d3@3.5.17": patches/d3@3.5.17.patch


### PR DESCRIPTION
Supersedes #1284.

## What the advisory actually is

Three advisories affect the **js-yaml 3.x** line, all patched at **3.15.0**:

| Advisory | Severity | Issue |
|---|---|---|
| [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | high | YAML merge-key chains force quadratic CPU consumption |
| [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) | moderate | Quadratic-complexity DoS in merge key handling via repeated aliases |
| [GHSA-mh29-5h37-fv8m](https://github.com/advisories/GHSA-mh29-5h37-fv8m) | moderate | Prototype pollution in merge (`<<`) |

Dependabot's #1284 is titled "3.14.0 → 5.2.2", which is the advisory's *latest safe version* rather than the fix for this line. Both affected consumers need the **v3** API, so the correct target is 3.15.0.

## Why an override is needed

Two packages are stuck on js-yaml 3:

- `yaml-front-matter@4.1.1` declares `^3.14.1` — would float to 3.15.0 on its own.
- `xmlbuilder2@3.0.2` pins js-yaml to **exactly `3.14.0`** (no caret), so nothing but an override can move it.

The override is scoped to `js-yaml@3`, so the direct `js-yaml` 4.3.0 dependency and `xmlbuilder2@4` (used by `@kitware/vtk.js`) are untouched.

Result: `pnpm audit` reports **no remaining js-yaml advisories**.

```
js-yaml 4.3.0  <- @eslint/eslintrc, @rollup/plugin-yaml, eslint, xmlbuilder2@4.0.3
js-yaml 3.15.0 <- xmlbuilder2@3.0.2, yaml-front-matter@4.1.1     (was 3.14.0 / 3.14.1)
```

## ⚠️ What this does *not* fix

**The copy that actually ships to the browser is not affected by this override.** It is inlined inside `vtk.js@29.4.2`'s prebuilt `vtk.js`, which `geojs`'s `geo.lean.js` requires — so no js-yaml version override can reach it.

Evidence:
- A `--sourcemap` production build maps the bundled YAML reader (`"Unable to parse YAML document."`, `DEFAULT_FULL_SCHEMA`, `safeLoad`) to `vtk.js@29.4.2/vtk.js`.
- The production bundle is **byte-identical** with and without this override (`index-BIxp5Ay6.js`, md5 `a73d4a1b…`).

That code is only exploitable by parsing **untrusted YAML** through xmlbuilder2's reader. This app never does — geojs uses vtk.js for rendering, not YAML parsing. So it is effectively dead code in the bundle, but worth knowing that a green `pnpm audit` overstates the fix here.

**Possible follow-up (not in this PR):** `vtk.js@29`'s prebuilt file is ~2.55 MB of source, ~16% of the main chunk, pulled in only because `geo.lean.js` requires it. If geojs's vtk renderer is unused, stubbing/externalizing that import would both drop the vulnerable code and meaningfully shrink the bundle. That is a behavioural change and needs its own testing.

## Verification

- `pnpm tsc` ✅
- `pnpm lint:ci` ✅
- `pnpm build` ✅
- `pnpm test` — 3125 tests / 186 files ✅
- `pnpm audit` — js-yaml advisories cleared ✅
- Dev server boots clean; `geojs` (and with it the `vtk.js@29` module chain) loads without error.

Not yet exercised: a logged-in dataset/image-viewer pass — worth a click-through before merge.
