### PR TITLE
Add wait_for_job tool to block on background job completion

### DIFF
--- a/codebaseDocumentation/AI_PANEL_SPEC.md
+++ b/codebaseDocumentation/AI_PANEL_SPEC.md
@@ -699,6 +699,15 @@ Failure and edge paths:
   not in a tight loop"; an unresolvable id errors instead of hanging —
   "rejects a job id it cannot resolve".
 
+Conversation scoping (module state must not outlive its conversation):
+
+- Clearing the conversation drops tracked jobs, so the previous user's job
+  labels and worker error text can't be read back by job id after a
+  login/logout — `aiPanel.test.ts` "forgets tracked background jobs when the
+  authenticated user changes" and `executors.test.ts` "forgets a tracked job
+  when the conversation is cleared". This is the pair to `clearPlots()`: any
+  new module-level cache in `src/agent/` needs the same treatment.
+
 Cost and responsiveness:
 
 - Stop and a forced clear unwind a blocking tool immediately, via the turn's

--- a/codebaseDocumentation/AI_PANEL_SPEC.md
+++ b/codebaseDocumentation/AI_PANEL_SPEC.md
@@ -167,6 +167,7 @@ method — the executor registry (§6) is a thin table, not new logic.
 | `list_workers` | Available worker images with labels/descriptions | `properties.workerImageList` |
 | `get_worker_interface` | Parameter schema for a worker image | `properties.fetchWorkerInterface` |
 | `get_property_summary` | Property definitions + basic stats/histogram for a property path | `properties`, `filters.getHistogram` |
+| `wait_for_job` | Blocks until a `run_worker`/`compute_property` job finishes, then `{finished, success, errors?}` (or `{stillRunning}` when the wait budget runs out, `{aborted}` when the user stops) | the completion callback the executor already wires for the transcript note; `jobs.fetchJobStatus` as fallback |
 
 `get_interface_state` is the workhorse: it is cheap, textual (no image
 tokens), and precise where screenshots are fuzzy. The system prompt
@@ -514,7 +515,7 @@ Loop sketch (in `aiPanel.ts`):
 async runTurn(userText: string) {
   this.snapshotViewState();                 // for per-turn revert
   push(userMessage(userText, interfaceStateSnapshot()));
-  for (let i = 0; i < MAX_ITERATIONS; i++) { // e.g. 20
+  for (let i = 0; i < MAX_ITERATIONS; i++) { // 30
     const res = await agentAPI.postAgentMessage(this.wireMessages);
     push(assistantMessage(res.content));
     if (res.stop_reason !== "tool_use") break;
@@ -536,9 +537,36 @@ returns them as `is_error` tool results so the model can recover.
 `run_worker` inside a turn: the executor submits the job and returns
 `{jobId, started: true}` immediately; job progress streams into the
 transcript via the existing `jobs.addJob` callback. The agent may end its
-turn with the job running; when the job's promise resolves, the panel
-offers ("Worker finished — 1,912 annotations. Ask the agent to review?")
-rather than auto-resuming the loop (keeps turns bounded and user-paced).
+turn with the job running, or continue the workflow by calling
+**`wait_for_job`** with that id.
+
+`wait_for_job` exists because the model cannot see the transcript notes:
+without it, the only way to learn a job had finished was to re-read state
+each turn, and a single Cellpose run consumed the whole
+`MAX_TOOL_ITERATIONS` budget on polling. The tool blocks on the same
+completion callback that writes the transcript note (so it returns *when the
+job finishes*, not on a timer, and after the store has refreshed annotations
+/ property values), and hands the outcome — including the worker's own error
+messages — back as a tool result.
+
+Details that matter:
+
+- **One wait per job, not a poll loop.** The wait budget defaults to 10
+  minutes and is clamped to `[30s, 30min]`. The 30-second floor is the
+  anti-spin guarantee: a result that says `stillRunning` has by construction
+  blocked for at least that long, so re-waiting can never burn turns quickly.
+- **Stop works.** The turn's `AbortController` (`aiPanel.ts`) is passed to
+  executors as `context.abortSignal`; `requestStop` and a forced
+  `clearConversation` abort it, so a blocking wait unwinds immediately
+  instead of holding the panel busy for minutes.
+- **Fallbacks.** Jobs this session never registered (e.g. started before a
+  page reload) have no completion event, so the wait races the jobs store's
+  promise against `jobs.fetchJobStatus` checks every 10s — REST calls inside
+  one tool call, invisible to the model and free of turn cost. A tracked job
+  that times out also gets one confirming status check, so a dropped
+  notification WebSocket is not reported as "still running".
+- `MAX_TOOL_ITERATIONS` is 30, kept below the backend's per-minute rate
+  limit so one long turn cannot 429 itself.
 
 ### 6.3 Errors
 
@@ -638,3 +666,56 @@ session service, browser bridge, sandboxed `run_python` with
 6. **When does code execution earn Option B?** Proposed trigger: recurring
    user requests that reduce to per-annotation math the tool surface can't
    express, or demand for unattended multi-step pipelines.
+
+## 11. Regression checklist — background jobs
+
+Invariants that have broken (or would silently break) here, each with the test
+that holds it. Re-check these when touching `run_worker`, `compute_property`,
+`wait_for_job`, the loop in `aiPanel.ts`, or the jobs store.
+
+Waiting instead of polling:
+
+- `wait_for_job` returns on the completion event, with **zero** status
+  requests — `executors.test.ts` "returns as soon as the completion event
+  arrives, without polling".
+- A wait that reports `stillRunning` has blocked for at least the 30s floor,
+  whatever `timeoutSeconds` the model asked for — "waits at least the 30s floor
+  before reporting a job still running".
+- A job that finished before the wait started returns immediately —
+  "returns immediately for a job that already finished".
+- Both job-starting tools are covered, not just the worker one: property
+  computations get the same tracking, transcript note and wait —
+  "waits for a property computation and notes its completion".
+
+Failure and edge paths:
+
+- The worker's own error messages reach the model, not just the transcript —
+  "reports the worker's own errors when the job fails".
+- A missed completion event (dropped notification WebSocket) is confirmed
+  against the server rather than reported as still running — "reports a
+  completion the notification stream missed".
+- An untracked job (started before a page reload) is polled at the slow
+  interval, not in a tight loop — "polls an untracked job on a slow interval,
+  not in a tight loop"; an unresolvable id errors instead of hanging —
+  "rejects a job id it cannot resolve".
+
+Cost and responsiveness:
+
+- Stop and a forced clear unwind a blocking tool immediately, via the turn's
+  abort signal — `aiPanel.test.ts` "aborts a blocking tool when the user
+  presses Stop" / "aborts a blocking tool on a forced clear".
+- The frontend tool surface and the backend's `agent_tools.json` define the
+  same set of tools — `executors.test.ts` "defines exactly the tools the
+  backend advertises".
+- `MAX_TOOL_ITERATIONS` (30) stays below the plugin's
+  `RATE_LIMIT_MAX_REQUESTS` (45) so one turn cannot 429 itself. No test; both
+  constants carry a comment pointing at the other.
+
+Process notes:
+
+- Verifying by hand means a *real* worker run: submit Cellpose-SAM on a dataset
+  with nuclei and watch the transcript show one "Wait for Worker …" card for the
+  whole run, not a series of state re-reads.
+- The completion callback must fire *after* the store refreshed its data
+  (`annotation.ts` awaits `fetchAnnotations` before `callback`), otherwise the
+  model reads stale counts the moment it is told the job finished.

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/__init__.py
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/__init__.py
@@ -158,7 +158,11 @@ class ClaudeAgentResource(Resource):
     # API_RATE_LIMITING_AUDIT.md); limiter semantics and the
     # single-process caveat are documented in rate_limit.py.
     RATE_LIMIT_WINDOW_SECONDS = 60
-    RATE_LIMIT_MAX_REQUESTS = 30
+    # Must stay above the frontend's per-message loop cap
+    # (MAX_TOOL_ITERATIONS in src/store/aiPanel.ts, currently 30): a single
+    # legitimate multi-step turn spends one request per iteration, and it must
+    # not be able to 429 itself partway through.
+    RATE_LIMIT_MAX_REQUESTS = 45
     # Reject conversations whose JSON-serialized messages exceed this size
     # (base64 screenshots dominate; the frontend prunes old ones).
     MAX_BODY_BYTES = 25 * 1024 * 1024

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_system_prompt.txt
@@ -59,12 +59,22 @@ How to work:
   - "notes": informational only — never set a value for it.
   A worker with input slots (e.g. Cellpose "Channel for Slot 1/2/3") needs at
   least the required first slot set to the right channel.
+- Background jobs (run_worker, compute_property) take minutes. They return a
+  jobId immediately; to wait for one, call wait_for_job with that jobId. It
+  returns the moment the job finishes, so a single call covers the whole run.
+  Never poll: do not call get_interface_state, get_annotation_summary,
+  get_property_values or anything else in a loop to see whether a job is done —
+  you have a limited number of turns per message and polling wastes them all
+  before the job finishes. If wait_for_job comes back stillRunning, either wait
+  again on the same jobId or tell the user it is still running; don't start a
+  second run of the same thing, and don't report results you haven't read yet.
 - You can compute measurements (properties) on annotations. list_properties
   shows what is defined; create_property defines one from a property worker
   (a list_workers image whose isPropertyWorker is true) for a given shape/tags;
   compute_property runs it; get_property_values reads the results as summary
   statistics. For "measure X on my Ys", check list_properties first, then
-  create_property (if needed) and compute_property, then get_property_values.
+  create_property (if needed) and compute_property, then wait_for_job on the
+  returned jobId, then get_property_values.
 - Starting workers, creating tools, or anything that creates/edits/deletes many
   annotations is gated: the interface will ask the user to approve. If a tool
   result says the user declined, adjust your plan or ask what they'd like

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json
@@ -792,6 +792,25 @@
     }
   },
   {
+    "name": "wait_for_job",
+    "description": "Block until a background job started by run_worker or compute_property finishes, then report its outcome. This is how you wait for a worker: it returns as soon as the job completes (it listens for the completion event, it does not poll), so one call covers a run of any length. Never check on a job by re-reading state (get_interface_state / get_annotation_summary / get_property_values) in a loop — that burns your turns and you will run out before the job is done. If the wait budget runs out before the job finishes, the result says stillRunning and you may call this again with the same jobId, or tell the user it is still going. Read-only.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "The jobId returned by run_worker or compute_property."
+        },
+        "timeoutSeconds": {
+          "type": "number",
+          "description": "How long to wait before giving up on this call, 30-1800 seconds (default 600). Values outside that range are clamped. Segmentation of a large dataset can take many minutes, so prefer the default over a short wait."
+        }
+      },
+      "required": ["jobId"],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "read_help_topic",
     "description": "Read NimbusImage documentation on a topic — how a feature works, or how the user can do something themselves in the UI. Call this before explaining a workflow you are unsure about. The available topic slugs are listed in the system prompt.",
     "input_schema": {

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -204,10 +204,10 @@ import filterStore from "@/store/filters";
 import {
   AGENT_TOOL_NAMES,
   annotationsBoundingBox,
+  clearTrackedAgentJobs,
   describeAgentToolCall,
   executeAgentTool,
   isGatedTool,
-  resetTrackedAgentJobsForTests,
   restoreViewState,
   snapshotViewState,
   ToolExecutionError,
@@ -273,7 +273,7 @@ beforeEach(() => {
   mockJobs.getPromiseForJobId = vi.fn(() => undefined);
   mockJobs.fetchJobStatus = vi.fn(async () => null);
   mockJobs.addJob = vi.fn(() => new Promise<boolean>(() => {}));
-  resetTrackedAgentJobsForTests();
+  clearTrackedAgentJobs();
   clearPlots();
 });
 
@@ -1016,6 +1016,28 @@ describe("wait_for_job", () => {
     expect(result).toMatchObject({ finished: false, aborted: true });
     // The job itself is untouched — it keeps running in the background.
     job.complete(true);
+  });
+
+  it("forgets a tracked job when the conversation is cleared", async () => {
+    // A cleared conversation (which is also what an authenticated-user change
+    // triggers) must not leave the previous user's job label and worker errors
+    // readable by job id; without a record the wait goes through the
+    // access-checked server request instead.
+    const job = await startWorkerJob();
+    job.errors().errors.push({ error: "path /user/alice/private" });
+    job.complete(false);
+    clearTrackedAgentJobs();
+
+    mockJobs.fetchJobStatus = vi.fn(async () => jobStates.error);
+    const { result } = await executeAgentTool(
+      "wait_for_job",
+      { jobId: "job7" },
+      context,
+    );
+    expect(mockJobs.fetchJobStatus).toHaveBeenCalledTimes(1);
+    expect(result.errors).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain("alice");
+    expect(JSON.stringify(result)).not.toContain("Cellpose");
   });
 
   it("reads the server status for a job this session did not start", async () => {

--- a/src/agent/executors.test.ts
+++ b/src/agent/executors.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 vi.mock("@/store", () => ({
   default: {
@@ -180,6 +182,10 @@ vi.mock("@/store/jobs", () => ({
   default: {
     jobIdForToolId: {} as { [toolId: string]: string },
     jobIdForPropertyId: {} as { [propertyId: string]: string },
+    // Never settles by default: tests that care resolve their own promise.
+    addJob: vi.fn(() => new Promise<boolean>(() => {})),
+    getPromiseForJobId: vi.fn(() => undefined as Promise<boolean> | undefined),
+    fetchJobStatus: vi.fn(async () => null as number | null),
   },
 }));
 
@@ -196,16 +202,19 @@ import propertyStore from "@/store/properties";
 import volumeViewStore from "@/store/volumeView";
 import filterStore from "@/store/filters";
 import {
+  AGENT_TOOL_NAMES,
   annotationsBoundingBox,
   describeAgentToolCall,
   executeAgentTool,
   isGatedTool,
+  resetTrackedAgentJobsForTests,
   restoreViewState,
   snapshotViewState,
   ToolExecutionError,
   viewIdentityChangedSince,
 } from "./executors";
 import { MAX_BOX_POINTS, MAX_PLOT_POINTS, MAX_SAMPLE_ROWS } from "./analysis";
+import { jobStates } from "@/store/jobConstants";
 import { clearPlots, getPlot } from "./plotRegistry";
 
 const mockMain = main as any;
@@ -261,6 +270,10 @@ beforeEach(() => {
   mockProperties.getFullNameFromPath = () => null;
   mockVolumeView.viewMode = "2d";
   mockFilters.propertyFilters = [];
+  mockJobs.getPromiseForJobId = vi.fn(() => undefined);
+  mockJobs.fetchJobStatus = vi.fn(async () => null);
+  mockJobs.addJob = vi.fn(() => new Promise<boolean>(() => {}));
+  resetTrackedAgentJobsForTests();
   clearPlots();
 });
 
@@ -857,6 +870,246 @@ describe("executeAgentTool", () => {
     expect(result.started).toBe(true);
     expect(result.jobId).toBe("job7");
     expect(mockAnnotations.computeAnnotationsWithWorker).toHaveBeenCalled();
+  });
+});
+
+// wait_for_job exists so the agent never has to poll for a background job:
+// polling a Cellpose run burned every turn of the budget before the job
+// finished. These tests hold the two properties that make that true — it
+// returns on the completion event (not on a timer), and a wait that comes back
+// "still running" has actually blocked for at least the 30s floor.
+describe("wait_for_job", () => {
+  // Submit a worker job through run_worker and hand back the store-side
+  // completion callback plus the progress/error objects it writes into.
+  async function startWorkerJob(jobId = "job7") {
+    mockMain.tools = [
+      { id: "t1", name: "Cellpose", values: { image: { image: "img:1" } } },
+    ];
+    mockJobs.jobIdForToolId = {};
+    let submitted: any;
+    mockAnnotations.computeAnnotationsWithWorker = vi.fn(async (args: any) => {
+      submitted = args;
+      return { jobId };
+    });
+    const { result } = await executeAgentTool(
+      "run_worker",
+      { toolId: "t1" },
+      context,
+    );
+    expect(result.jobId).toBe(jobId);
+    return {
+      complete: (success: boolean) => submitted.callback(success),
+      errors: () => submitted.error as { errors: any[] },
+      progress: () => submitted.progress as { progress?: number },
+    };
+  }
+
+  it("is read-only, so it is not gated", () => {
+    expect(isGatedTool("wait_for_job")).toBe(false);
+  });
+
+  it("returns as soon as the completion event arrives, without polling", async () => {
+    const job = await startWorkerJob();
+    const pending = executeAgentTool(
+      "wait_for_job",
+      { jobId: "job7" },
+      context,
+    );
+    job.complete(true);
+    const { result } = await pending;
+    expect(result).toMatchObject({
+      jobId: "job7",
+      finished: true,
+      success: true,
+    });
+    // The whole point: no status requests were needed to learn the outcome.
+    expect(mockJobs.fetchJobStatus).not.toHaveBeenCalled();
+  });
+
+  it("reports the worker's own errors when the job fails", async () => {
+    const job = await startWorkerJob();
+    const pending = executeAgentTool(
+      "wait_for_job",
+      { jobId: "job7" },
+      context,
+    );
+    job.errors().errors.push({ error: "CUDA out of memory" });
+    job.complete(false);
+    const { result } = await pending;
+    expect(result).toMatchObject({ finished: true, success: false });
+    expect(result.errors).toContain("CUDA out of memory");
+    expect(context.notify).toHaveBeenCalledWith(
+      expect.stringContaining("CUDA out of memory"),
+    );
+  });
+
+  it("returns immediately for a job that already finished", async () => {
+    const job = await startWorkerJob();
+    job.complete(true);
+    const { result } = await executeAgentTool(
+      "wait_for_job",
+      { jobId: "job7" },
+      context,
+    );
+    expect(result).toMatchObject({ finished: true, success: true });
+    expect(result.waitedSeconds).toBe(0);
+  });
+
+  it("waits at least the 30s floor before reporting a job still running", async () => {
+    vi.useFakeTimers();
+    try {
+      const job = await startWorkerJob();
+      job.progress().progress = 0.4;
+      // A 1s budget must be clamped up: a model that re-waits in a loop with a
+      // tiny timeout would otherwise spin through its turns.
+      const pending = executeAgentTool(
+        "wait_for_job",
+        { jobId: "job7", timeoutSeconds: 1 },
+        context,
+      );
+      let settled = false;
+      pending.then(() => (settled = true));
+      await vi.advanceTimersByTimeAsync(29_000);
+      expect(settled).toBe(false);
+      // Budget spent: one status check confirms the job really is still going.
+      mockJobs.fetchJobStatus = vi.fn(async () => jobStates.running);
+      await vi.advanceTimersByTimeAsync(2_000);
+      const { result } = await pending;
+      expect(result).toMatchObject({ finished: false, stillRunning: true });
+      expect(result.waitedSeconds).toBeGreaterThanOrEqual(30);
+      expect(result.progress).toBe(0.4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports a completion the notification stream missed", async () => {
+    vi.useFakeTimers();
+    try {
+      await startWorkerJob();
+      // No completion callback ever fires (e.g. a dropped WebSocket), but the
+      // server says the job succeeded — report that, not "still running".
+      mockJobs.fetchJobStatus = vi.fn(async () => jobStates.success);
+      const pending = executeAgentTool(
+        "wait_for_job",
+        { jobId: "job7", timeoutSeconds: 30 },
+        context,
+      );
+      await vi.advanceTimersByTimeAsync(31_000);
+      const { result } = await pending;
+      expect(result).toMatchObject({ finished: true, success: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("unwinds at once when the user stops the run", async () => {
+    const job = await startWorkerJob();
+    const controller = new AbortController();
+    const pending = executeAgentTool(
+      "wait_for_job",
+      { jobId: "job7" },
+      { ...context, abortSignal: controller.signal },
+    );
+    controller.abort();
+    const { result } = await pending;
+    expect(result).toMatchObject({ finished: false, aborted: true });
+    // The job itself is untouched — it keeps running in the background.
+    job.complete(true);
+  });
+
+  it("reads the server status for a job this session did not start", async () => {
+    mockJobs.fetchJobStatus = vi.fn(async () => jobStates.error);
+    const { result } = await executeAgentTool(
+      "wait_for_job",
+      { jobId: "job-from-a-previous-page-load" },
+      context,
+    );
+    expect(result).toMatchObject({ finished: true, success: false });
+    expect(mockJobs.fetchJobStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls an untracked job on a slow interval, not in a tight loop", async () => {
+    vi.useFakeTimers();
+    try {
+      let checks = 0;
+      mockJobs.fetchJobStatus = vi.fn(async () =>
+        ++checks >= 2 ? jobStates.success : jobStates.running,
+      );
+      const pending = executeAgentTool(
+        "wait_for_job",
+        { jobId: "untracked" },
+        context,
+      );
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(mockJobs.fetchJobStatus).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(2_000);
+      const { result } = await pending;
+      expect(result).toMatchObject({ finished: true, success: true });
+      expect(mockJobs.fetchJobStatus).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a job id it cannot resolve", async () => {
+    mockJobs.fetchJobStatus = vi.fn(async () => null);
+    await expect(
+      executeAgentTool("wait_for_job", { jobId: "bogus" }, context),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+  });
+
+  it("requires a job id", async () => {
+    await expect(
+      executeAgentTool("wait_for_job", {}, context),
+    ).rejects.toBeInstanceOf(ToolExecutionError);
+    expect(mockJobs.fetchJobStatus).not.toHaveBeenCalled();
+  });
+
+  it("waits for a property computation and notes its completion", async () => {
+    mockProperties.properties = [{ id: "prop1", name: "Area" }];
+    mockProperties.computeProperty = vi.fn(async () => ({ jobId: "job-prop" }));
+    let finishJob!: (success: boolean) => void;
+    mockJobs.addJob = vi.fn(
+      () => new Promise<boolean>((resolve) => (finishJob = resolve)),
+    );
+    const { result: started } = await executeAgentTool(
+      "compute_property",
+      { propertyId: "prop1" },
+      context,
+    );
+    expect(started.jobId).toBe("job-prop");
+    const pending = executeAgentTool(
+      "wait_for_job",
+      { jobId: "job-prop" },
+      context,
+    );
+    finishJob(true);
+    const { result } = await pending;
+    expect(result).toMatchObject({ finished: true, success: true });
+    // Property jobs get the same transcript note worker jobs do.
+    expect(context.notify).toHaveBeenCalledWith(
+      expect.stringContaining('Property "Area" finished'),
+    );
+  });
+});
+
+// The executor registry lives here; the schemas the model sees are served by
+// the girder-claude-chat plugin. Nothing else keeps the two in step, and a
+// mismatch fails silently in one direction (a tool the model is never told
+// about) and loudly in the other ("Unknown tool" mid-turn).
+describe("tool schema parity with the backend", () => {
+  // Vitest runs from the repository root.
+  const schemaPath = resolve(
+    process.cwd(),
+    "devops/girder/plugins/girder-claude-chat/girder_claude_chat/agent_tools.json",
+  );
+
+  it("defines exactly the tools the backend advertises", () => {
+    const schemaNames = JSON.parse(readFileSync(schemaPath, "utf8")).map(
+      (tool: { name: string }) => tool.name,
+    );
+    expect([...AGENT_TOOL_NAMES].sort()).toEqual([...schemaNames].sort());
   });
 });
 

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -698,8 +698,13 @@ function trackAgentJob(params: {
   };
 }
 
-// Test seam only: the tracking map is module state that survives between tests.
-export function resetTrackedAgentJobsForTests() {
+// Drop every tracked job. Called from aiPanel.clearConversation — like the plot
+// registry, this is module state that would otherwise outlive the conversation
+// it belongs to. That matters on an authenticated-user change (login/logout is
+// client-side, no page reload): a record holds the previous user's job label and
+// worker error text, and the tracked path returns it without the access-checked
+// job/{id} request, so the next user must not be able to read it by job id.
+export function clearTrackedAgentJobs() {
   agentJobs.clear();
 }
 

--- a/src/agent/executors.ts
+++ b/src/agent/executors.ts
@@ -3,6 +3,7 @@ import annotationStore from "@/store/annotation";
 import filterStore from "@/store/filters";
 import propertyStore from "@/store/properties";
 import jobsStore from "@/store/jobs";
+import { jobStates } from "@/store/jobConstants";
 import volumeViewStore from "@/store/volumeView";
 import {
   AnnotationShape,
@@ -70,6 +71,10 @@ export interface IAgentToolContext {
   // worker interface, then submits a job) calls this immediately before the
   // mutation so it never acts on a dataset the request didn't target.
   hasViewIdentityChanged?: () => boolean;
+  // Aborted when the user presses Stop (or the conversation is cleared) so a
+  // tool that blocks for minutes (wait_for_job) unwinds immediately instead of
+  // keeping the panel busy until its own budget expires.
+  abortSignal?: AbortSignal;
 }
 
 export interface IToolExecutionResult {
@@ -572,6 +577,294 @@ function clamp(value: number, max: number) {
   return Math.max(0, Math.min(value, Math.max(0, max - 1)));
 }
 
+// --- Background jobs -------------------------------------------------------
+//
+// run_worker and compute_property start jobs that take minutes. The model
+// cannot see the transcript notes their completion callbacks write, so without
+// a way to *wait* it can only re-read state on each turn to guess whether the
+// job is done — which burns the turn budget on polling (issue: an agent spent
+// every turn polling a Cellpose run). wait_for_job blocks on the same
+// completion signal the transcript note uses, so one tool call covers the whole
+// run: no polling, and the job's outcome (including its errors) reaches the
+// model as a tool result.
+
+// Jobs started by the agent in this session, keyed by job id. Holds the live
+// progress/error objects the jobs store writes into, so a wait can report
+// progress on timeout and the failure reason on completion.
+interface IAgentJobRecord {
+  label: string;
+  progress: IProgressInfo;
+  errors: IErrorInfoList;
+  // Resolves when the job's completion callback fires (i.e. after the store
+  // has refreshed annotations / property values), never rejects.
+  completion: Promise<boolean>;
+  finished: boolean;
+  success: boolean | null;
+}
+
+const agentJobs = new Map<string, IAgentJobRecord>();
+
+// Records are tiny but must not grow without bound across a long session.
+const MAX_TRACKED_AGENT_JOBS = 20;
+
+// Wait budget for a single wait_for_job call. The floor matters: a wait that
+// comes back "still running" has by construction blocked for at least
+// MIN_WAIT_SECONDS, so a model that re-waits in a loop cannot spin through its
+// turns the way bare polling did.
+const DEFAULT_WAIT_SECONDS = 600;
+const MIN_WAIT_SECONDS = 30;
+const MAX_WAIT_SECONDS = 1800;
+
+// How often the fallback path asks the server for a job's status. Used only for
+// jobs this session never registered (e.g. started before a page reload), where
+// no completion event will arrive. These are plain REST calls inside a single
+// tool call — they cost no agent turns and never reach the model.
+const JOB_STATUS_POLL_SECONDS = 10;
+
+const TERMINAL_JOB_STATES = new Set([
+  jobStates.success,
+  jobStates.error,
+  jobStates.cancelled,
+]);
+
+function pruneAgentJobs() {
+  if (agentJobs.size <= MAX_TRACKED_AGENT_JOBS) {
+    return;
+  }
+  // Map iterates in insertion order: drop the oldest finished records first,
+  // then (only if many jobs are running at once) the oldest records regardless.
+  // A waiter already holds its record, so dropping one only forgets the
+  // outcome — it never breaks an in-flight wait.
+  for (const [jobId, record] of agentJobs) {
+    if (agentJobs.size <= MAX_TRACKED_AGENT_JOBS) {
+      return;
+    }
+    if (record.finished) {
+      agentJobs.delete(jobId);
+    }
+  }
+  for (const jobId of [...agentJobs.keys()]) {
+    if (agentJobs.size <= MAX_TRACKED_AGENT_JOBS) {
+      return;
+    }
+    agentJobs.delete(jobId);
+  }
+}
+
+function jobErrorMessages(errors: IErrorInfoList): string[] {
+  return (
+    errors.errors
+      .map((e) => e.error || e.warning || e.info)
+      .filter((message): message is string => Boolean(message))
+      // Worker logs can emit many messages; the model only needs the gist.
+      .slice(0, 5)
+  );
+}
+
+// Start tracking a job the agent submitted and return the completion handler to
+// wire to the store's callback. The handler both records the outcome (for
+// wait_for_job) and writes the transcript note the user sees.
+function trackAgentJob(params: {
+  jobId: string;
+  label: string;
+  progress: IProgressInfo;
+  errors: IErrorInfoList;
+  notify: (text: string) => void;
+}): (success: boolean) => void {
+  let resolve!: (success: boolean) => void;
+  const record: IAgentJobRecord = {
+    label: params.label,
+    progress: params.progress,
+    errors: params.errors,
+    completion: new Promise<boolean>((r) => (resolve = r)),
+    finished: false,
+    success: null,
+  };
+  agentJobs.set(params.jobId, record);
+  pruneAgentJobs();
+  return (success: boolean) => {
+    if (record.finished) {
+      return;
+    }
+    record.finished = true;
+    record.success = success;
+    const errors = jobErrorMessages(record.errors);
+    params.notify(
+      success
+        ? `${params.label} finished successfully.`
+        : `${params.label} failed${errors.length ? `: ${errors.join("; ")}` : "."}`,
+    );
+    resolve(success);
+  };
+}
+
+// Test seam only: the tracking map is module state that survives between tests.
+export function resetTrackedAgentJobsForTests() {
+  agentJobs.clear();
+}
+
+type TWaitOutcome = "timeout" | "aborted";
+
+// Wait for `completion` to settle, for `timeoutMs` to elapse, or for the user
+// to press Stop — whichever comes first. With no `completion` it is an
+// abortable sleep (used between status checks on the fallback path).
+function raceWait(
+  timeoutMs: number,
+  signal?: AbortSignal,
+  completion?: Promise<boolean>,
+): Promise<boolean | TWaitOutcome> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: boolean | TWaitOutcome) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      resolve(value);
+    };
+    const onAbort = () => finish("aborted");
+    // `finish` closes over `timer`, but is only ever called after this line.
+    const timer = setTimeout(() => finish("timeout"), timeoutMs);
+    if (signal?.aborted) {
+      finish("aborted");
+      return;
+    }
+    signal?.addEventListener("abort", onAbort);
+    completion?.then((success) => finish(success));
+  });
+}
+
+async function waitForJobTool(
+  input: { jobId?: unknown; timeoutSeconds?: unknown },
+  context: IAgentToolContext,
+): Promise<IToolExecutionResult> {
+  const jobId = typeof input?.jobId === "string" ? input.jobId.trim() : "";
+  if (!jobId) {
+    throw new ToolExecutionError(
+      "wait_for_job needs the jobId returned by run_worker or compute_property",
+    );
+  }
+  const timeoutSeconds =
+    typeof input?.timeoutSeconds === "number" &&
+    Number.isFinite(input.timeoutSeconds)
+      ? Math.min(
+          Math.max(input.timeoutSeconds, MIN_WAIT_SECONDS),
+          MAX_WAIT_SECONDS,
+        )
+      : DEFAULT_WAIT_SECONDS;
+  const startedAt = Date.now();
+  const waitedSeconds = () => Math.round((Date.now() - startedAt) / 1000);
+
+  const record = agentJobs.get(jobId);
+  const label = record?.label ?? "The job";
+  const finishedResult = (success: boolean) => {
+    const errors = record ? jobErrorMessages(record.errors) : [];
+    return {
+      result: {
+        jobId,
+        finished: true,
+        success,
+        waitedSeconds: waitedSeconds(),
+        ...(errors.length ? { errors } : {}),
+        note: success
+          ? `${label} finished successfully. Read the results ` +
+            "(get_annotation_summary, get_property_values) before reporting " +
+            "to the user."
+          : `${label} did not succeed. Tell the user what failed; its log is ` +
+            "in Settings > Jobs & Logs.",
+      },
+    };
+  };
+  const abortedResult = () => ({
+    result: {
+      jobId,
+      finished: false,
+      aborted: true,
+      waitedSeconds: waitedSeconds(),
+      note:
+        "The user stopped this turn while waiting; the job keeps running in " +
+        "the background. Do not start another run.",
+    },
+  });
+  const stillRunningResult = () => ({
+    result: {
+      jobId,
+      finished: false,
+      stillRunning: true,
+      waitedSeconds: waitedSeconds(),
+      ...(record?.progress?.progress != null
+        ? { progress: record.progress.progress, step: record.progress.title }
+        : {}),
+      note:
+        `Still running after ${waitedSeconds()}s. Call wait_for_job again ` +
+        "with the same jobId to keep waiting (this costs one turn per wait, " +
+        "polling other tools costs many). If it has been a very long time, " +
+        "tell the user it is still running instead of waiting again.",
+    },
+  });
+
+  if (record) {
+    if (record.finished) {
+      return finishedResult(record.success === true);
+    }
+    const outcome = await raceWait(
+      timeoutSeconds * 1000,
+      context.abortSignal,
+      record.completion,
+    );
+    if (outcome === "aborted") {
+      return abortedResult();
+    }
+    if (typeof outcome === "boolean") {
+      return finishedResult(outcome);
+    }
+    // Budget spent without a completion event. Almost always means the job is
+    // genuinely still running, but a dropped notification WebSocket looks the
+    // same, so confirm against the server before reporting.
+    const status = await jobsStore.fetchJobStatus(jobId);
+    if (status != null && TERMINAL_JOB_STATES.has(status)) {
+      return finishedResult(status === jobStates.success);
+    }
+    return stillRunningResult();
+  }
+
+  // Not started by the agent in this session (or already forgotten): there may
+  // still be a live completion promise in the jobs store; otherwise fall back
+  // to server status checks.
+  const completion = jobsStore.getPromiseForJobId(jobId);
+  const initialStatus = await jobsStore.fetchJobStatus(jobId);
+  if (initialStatus == null && !completion) {
+    throw new ToolExecutionError(
+      `Could not read the status of job "${jobId}" — check the id returned by ` +
+        "run_worker or compute_property.",
+    );
+  }
+  if (initialStatus != null && TERMINAL_JOB_STATES.has(initialStatus)) {
+    return finishedResult(initialStatus === jobStates.success);
+  }
+  const deadline = startedAt + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    const outcome = await raceWait(
+      Math.min(JOB_STATUS_POLL_SECONDS * 1000, deadline - Date.now()),
+      context.abortSignal,
+      completion,
+    );
+    if (outcome === "aborted") {
+      return abortedResult();
+    }
+    if (typeof outcome === "boolean") {
+      return finishedResult(outcome);
+    }
+    const status = await jobsStore.fetchJobStatus(jobId);
+    if (status != null && TERMINAL_JOB_STATES.has(status)) {
+      return finishedResult(status === jobStates.success);
+    }
+  }
+  return stillRunningResult();
+}
+
 async function runWorkerTool(
   input: { toolId: string; workerInterfaceValues?: IWorkerInterfaceValues },
   context: IAgentToolContext,
@@ -589,8 +882,8 @@ async function runWorkerTool(
         alreadyRunning: true,
         jobId: runningJobId,
         note:
-          `A job for tool "${tool.name}" is already running. Wait for its ` +
-          "completion note in the transcript before starting another run.",
+          `A job for tool "${tool.name}" is already running. Call wait_for_job ` +
+          "with this jobId instead of starting another run.",
       },
     };
   }
@@ -631,28 +924,40 @@ async function runWorkerTool(
 
   const progressInfo: IProgressInfo = {};
   const errorInfo: IErrorInfoList = { errors: [] };
+  // The completion handler needs the job id, which only exists after the
+  // submission below, so route the store's callback through this indirection and
+  // replay an outcome that arrived first (a job that fails immediately).
+  const completion: {
+    handler?: (success: boolean) => void;
+    early?: boolean;
+  } = {};
   const computeJob = await annotationStore.computeAnnotationsWithWorker({
     tool,
     workerInterface: values,
     progress: progressInfo,
     error: errorInfo,
     callback: (success: boolean) => {
-      const errors = errorInfo.errors
-        .map((e) => e.error || e.warning || e.info)
-        .filter(Boolean);
-      context.notify(
-        success
-          ? `Worker "${tool.name}" finished successfully.`
-          : `Worker "${tool.name}" failed${
-              errors.length ? `: ${errors.join("; ")}` : "."
-            }`,
-      );
+      if (completion.handler) {
+        completion.handler(success);
+      } else {
+        completion.early = success;
+      }
     },
   });
   if (!computeJob) {
     throw new ToolExecutionError(
       "Failed to start the worker job (are you logged in and is a dataset open?)",
     );
+  }
+  completion.handler = trackAgentJob({
+    jobId: computeJob.jobId,
+    label: `Worker "${tool.name}"`,
+    progress: progressInfo,
+    errors: errorInfo,
+    notify: context.notify,
+  });
+  if (completion.early !== undefined) {
+    completion.handler(completion.early);
   }
   return {
     result: {
@@ -661,8 +966,9 @@ async function runWorkerTool(
       tool: { id: tool.id, name: tool.name, image },
       parameters: values,
       note:
-        "The job runs in the background; its progress is shown to the user. " +
-        "You will get a transcript note when it completes.",
+        "The job runs in the background and can take minutes. Call " +
+        "wait_for_job with this jobId to wait for it — one tool call covers " +
+        "the whole run. Never re-read state in a loop to check on it.",
     },
   };
 }
@@ -1644,7 +1950,10 @@ const registry: { [name: string]: IAgentToolEntry } = {
   compute_property: {
     // Starts a compute job, so it is gated like run_worker.
     gated: true,
-    execute: async (input: { propertyId?: string }) => {
+    execute: async (
+      input: { propertyId?: string },
+      context: IAgentToolContext,
+    ) => {
       requireLogin();
       requireDataset();
       const property = propertyStore.properties.find(
@@ -1666,7 +1975,8 @@ const registry: { [name: string]: IAgentToolEntry } = {
             propertyId: property.id,
             note:
               `Property "${property.name}" is already computing (job ` +
-              `${runningJobId}). Wait for it before starting another run.`,
+              `${runningJobId}). Call wait_for_job with this jobId instead of ` +
+              "starting another run.",
           },
         };
       }
@@ -1687,6 +1997,25 @@ const registry: { [name: string]: IAgentToolEntry } = {
           }`,
         );
       }
+      // Same completion tracking as run_worker (the transcript note and
+      // wait_for_job): addJob is idempotent for an already-tracked job — it
+      // adds a listener and hands back the promise that settles when the job
+      // does — so this works whether or not computeProperty's own registration
+      // has landed yet.
+      const onCompletion = trackAgentJob({
+        jobId: computeJob.jobId,
+        label: `Property "${property.name}"`,
+        progress:
+          propertyStore.propertyStatuses[property.id]?.progressInfo ?? {},
+        errors: errorInfo,
+        notify: context.notify,
+      });
+      jobsStore
+        .addJob({
+          jobId: computeJob.jobId,
+          datasetId: main.dataset?.id ?? null,
+        })
+        .then(onCompletion);
       return {
         result: {
           propertyId: property.id,
@@ -1694,8 +2023,9 @@ const registry: { [name: string]: IAgentToolEntry } = {
           started: true,
           jobId: computeJob.jobId,
           note:
-            "Computation started; values populate as the job runs. Use " +
-            "get_property_values to read the results.",
+            "Computation runs in the background. Call wait_for_job with this " +
+            "jobId to wait for it, then get_property_values to read the " +
+            "results. Never re-read state in a loop to check on it.",
         },
       };
     },
@@ -2099,7 +2429,19 @@ const registry: { [name: string]: IAgentToolEntry } = {
     gated: true,
     execute: runWorkerTool,
   },
+
+  // Read-only: it starts nothing, it only blocks until a job it is told about
+  // finishes, so it is not gated.
+  wait_for_job: {
+    execute: waitForJobTool,
+  },
 };
+
+// Every tool the frontend can execute. Exported for the parity check against
+// the backend's agent_tools.json (see executors.test.ts): a name in only one of
+// the two is either dead code (the model is never told the tool exists) or a
+// guaranteed "Unknown tool" error at runtime.
+export const AGENT_TOOL_NAMES = Object.keys(registry);
 
 export function isGatedTool(name: string): boolean {
   return registry[name]?.gated === true;
@@ -2299,6 +2641,12 @@ export function describeAgentToolCall(name: string, input: any): string {
     case "run_worker": {
       const tool = main.tools.find((t) => t.id === input?.toolId);
       return `Run worker "${tool?.name ?? input?.toolId}" — starts a compute job that may create many annotations`;
+    }
+    case "wait_for_job": {
+      const label = agentJobs.get(
+        typeof input?.jobId === "string" ? input.jobId : "",
+      )?.label;
+      return `Wait for ${label ?? "the background job"} to finish`;
     }
     default:
       return name;

--- a/src/store/aiPanel.test.ts
+++ b/src/store/aiPanel.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/agent/wireConversation", () => ({
 
 vi.mock("@/agent/executors", () => ({
   buildInterfaceState: vi.fn(() => ({ dataset: null })),
+  clearTrackedAgentJobs: vi.fn(),
   snapshotViewState: vi.fn(() => ({ datasetId: "ds1" })),
   describeAgentToolCall: vi.fn(() => "action"),
   executeAgentTool: vi.fn(),
@@ -44,6 +45,7 @@ vi.mock("./index", () => ({
 import aiPanel from "./aiPanel";
 import main from "./index";
 import {
+  clearTrackedAgentJobs,
   executeAgentTool,
   isGatedTool,
   restoreViewState,
@@ -57,6 +59,7 @@ import {
 
 const postAgentMessage = (main as any).agentAPI.postAgentMessage;
 const mockExecuteAgentTool = executeAgentTool as any;
+const mockClearTrackedAgentJobs = clearTrackedAgentJobs as any;
 const mockIsGatedTool = isGatedTool as any;
 const mockRestoreViewState = restoreViewState as any;
 const mockViewIdentityChangedSince = viewIdentityChangedSince as any;
@@ -118,6 +121,17 @@ describe("AI panel conversation isolation across users", () => {
     const sent = lastSentPayload();
     expect(sent).toContain("hello from B");
     expect(sent).not.toContain("secret from A");
+  });
+
+  it("forgets tracked background jobs when the authenticated user changes", async () => {
+    // The job tracker in executors.ts is module state holding job labels and
+    // worker error text. Like the plot registry it must be dropped with the
+    // conversation, so the next user can't read the previous user's job
+    // details back through wait_for_job.
+    await aiPanel.handleAuthenticatedUserChange("userA");
+    mockClearTrackedAgentJobs.mockClear();
+    await aiPanel.handleAuthenticatedUserChange("userB");
+    expect(mockClearTrackedAgentJobs).toHaveBeenCalled();
   });
 
   it("keeps the conversation when the same user is re-observed", async () => {

--- a/src/store/aiPanel.test.ts
+++ b/src/store/aiPanel.test.ts
@@ -259,6 +259,51 @@ describe("AI panel forced clear (finding P2-D)", () => {
   });
 });
 
+// wait_for_job deliberately blocks for minutes, so Stop (and a forced clear)
+// must reach the running tool through the turn's abort signal — otherwise the
+// panel stays busy until the wait's own budget expires.
+describe("AI panel stop reaches a blocking tool", () => {
+  // Resolve only when the turn's abort signal fires, the way wait_for_job does.
+  function blockUntilAborted() {
+    mockExecuteAgentTool.mockImplementationOnce(
+      (_name: string, _input: any, context: any) =>
+        new Promise((resolve) => {
+          context.abortSignal.addEventListener("abort", () =>
+            resolve({ result: { aborted: true } }),
+          );
+        }),
+    );
+  }
+
+  it("aborts a blocking tool when the user presses Stop", async () => {
+    await aiPanel.handleAuthenticatedUserChange("userA");
+    postAgentMessage.mockResolvedValueOnce(toolUseResponse("wait_for_job"));
+    blockUntilAborted();
+
+    const turn = aiPanel.sendUserMessage("wait for the worker");
+    await waitFor(() => mockExecuteAgentTool.mock.calls.length > 0);
+    expect(aiPanel.running).toBe(true);
+
+    aiPanel.requestStop();
+    await turn;
+    expect(aiPanel.running).toBe(false);
+    expect(aiPanel.items.some((i) => i.text === "Stopped.")).toBe(true);
+  });
+
+  it("aborts a blocking tool on a forced clear", async () => {
+    await aiPanel.handleAuthenticatedUserChange("userA");
+    postAgentMessage.mockResolvedValueOnce(toolUseResponse("wait_for_job"));
+    blockUntilAborted();
+
+    const turn = aiPanel.sendUserMessage("wait for the worker");
+    await waitFor(() => mockExecuteAgentTool.mock.calls.length > 0);
+
+    aiPanel.clearConversation(true);
+    await turn;
+    expect(aiPanel.running).toBe(false);
+  });
+});
+
 describe("AI panel persistence", () => {
   // handleAuthenticatedUserChange no-ops when userId === lastKnownUserId, and
   // lastKnownUserId is module-level state that outlives the outer

--- a/src/store/aiPanel.ts
+++ b/src/store/aiPanel.ts
@@ -68,8 +68,12 @@ export interface IAgentPanelItem {
 }
 
 // Upper bound on model round-trips per user message; the backend has a
-// looser backstop on total conversation length.
-const MAX_TOOL_ITERATIONS = 20;
+// looser backstop on total conversation length. Multi-step workflows
+// (create a tool, run a worker, wait for it, define a property, compute it,
+// plot the results) legitimately need a couple of dozen. Raising this past the
+// backend's per-minute rate limit (RATE_LIMIT_MAX_REQUESTS in the
+// girder-claude-chat plugin) would let one turn 429 itself partway through.
+const MAX_TOOL_ITERATIONS = 30;
 
 // Tools whose effects are captured by the per-turn view snapshot and can be
 // reverted with "revert view changes". Annotation edits (color/tag/undo)
@@ -92,6 +96,10 @@ const VIEW_STATE_TOOLS = new Set([
 // serializable state.
 let wireMessages: IAgentWireMessage[] = [];
 let approvalResolver: ((approved: boolean) => void) | null = null;
+// Aborted when the user stops the run (or the conversation is cleared), so a
+// tool that deliberately blocks for minutes (wait_for_job) unwinds at once
+// instead of holding the panel busy until its own wait budget expires.
+let turnAbortController: AbortController | null = null;
 let turnSnapshot: IViewStateSnapshot | null = null;
 let panelElement: HTMLElement | null = null;
 // Bumped on clearConversation so late async notifications (e.g. a worker
@@ -235,6 +243,8 @@ export class AiPanel extends VuexModule {
     if (approvalResolver) {
       approvalResolver(false);
     }
+    // Likewise for a tool that is deliberately blocking (waiting on a job).
+    turnAbortController?.abort();
   }
 
   @Action
@@ -293,10 +303,12 @@ export class AiPanel extends VuexModule {
       this.setStopRequested(true);
       // A gated tool may be blocking the loop on the approval promise; resolve
       // it as declined (same as requestStop) so the loop unwinds immediately
-      // instead of hanging until the user happens to press Stop.
+      // instead of hanging until the user happens to press Stop. Same for a
+      // tool blocked waiting on a job.
       if (approvalResolver) {
         approvalResolver(false);
       }
+      turnAbortController?.abort();
     }
   }
 
@@ -378,6 +390,7 @@ export class AiPanel extends VuexModule {
     }
     this.setRunning(true);
     this.setStopRequested(false);
+    turnAbortController = new AbortController();
     turnSnapshot = snapshotViewState();
     this.setCanRevert(false);
     // If the conversation is cleared mid-run (e.g. the user logs out/in),
@@ -522,6 +535,7 @@ export class AiPanel extends VuexModule {
     } finally {
       this.setRunning(false);
       this.setStopRequested(false);
+      turnAbortController = null;
       // Persist only if this turn's conversation is still the active one
       // (not cleared or switched to another user mid-run).
       if (conversationGeneration === generationAtStart && lastKnownUserId) {
@@ -643,6 +657,7 @@ export class AiPanel extends VuexModule {
           // identity immediately before it acts.
           hasViewIdentityChanged: () =>
             turnSnapshot != null && viewIdentityChangedSince(turnSnapshot),
+          abortSignal: turnAbortController?.signal,
         },
       );
       if (generation !== conversationGeneration) {

--- a/src/store/aiPanel.ts
+++ b/src/store/aiPanel.ts
@@ -16,6 +16,7 @@ import {
 } from "./AgentAPI";
 import {
   buildInterfaceState,
+  clearTrackedAgentJobs,
   describeAgentToolCall,
   executeAgentTool,
   isGatedTool,
@@ -293,6 +294,13 @@ export class AiPanel extends VuexModule {
     wireMessages = [];
     turnSnapshot = null;
     clearPlots();
+    // Same reason as clearPlots: module-level agent state must not outlive the
+    // conversation it belongs to. Tracked jobs additionally carry the previous
+    // user's job labels and worker error text, which the next user (this also
+    // runs on an authenticated-user change) must not be able to read back via
+    // wait_for_job; without a record it falls back to the access-checked
+    // job/{id} request.
+    clearTrackedAgentJobs();
     conversationGeneration++;
     this.clearItemsImpl();
     this.setCanRevert(false);

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -1930,7 +1930,11 @@ export class Annotations extends VuexModule {
     };
 
     jobs.addJob(computeJob).then(async (success: boolean) => {
-      this.fetchAnnotations();
+      // Awaited: `callback` consumers (the AI panel's wait_for_job among them)
+      // read annotation state as soon as they are told the worker finished, so
+      // the refresh must complete before the callback fires. fetchAnnotations
+      // handles its own errors and never rejects.
+      await this.fetchAnnotations();
       // If this was a worker that makes a new large_image, this line will load it
       // I'm pretty sure this function won't reload the large image if it's already loaded
       const newLargeImage = await main.loadLargeImages(true); // true means switch to the new large image

--- a/src/store/jobs.ts
+++ b/src/store/jobs.ts
@@ -122,8 +122,13 @@ export class Jobs extends VuexModule {
 
   connectionErrors: number = 0;
 
+  // The completion promise for a tracked job, or undefined if the job is not
+  // tracked — either it was never registered with addJob, or it already
+  // settled (handleJobEventImp drops the entry once it resolves). Callers must
+  // handle undefined rather than assume a live job.
   get getPromiseForJobId() {
-    return (jobId: string) => this.jobInfoMap[jobId].successPromise;
+    return (jobId: string): Promise<boolean> | undefined =>
+      this.jobInfoMap[jobId]?.successPromise;
   }
 
   get jobIdForToolId() {
@@ -158,14 +163,17 @@ export class Jobs extends VuexModule {
     return (jobId: string) => this.jobInfoMap[jobId]?.log || "";
   }
 
+  // The job's status straight from the server, or null when it could not be
+  // read (network failure, deleted job, bad id) — a transient failure must not
+  // be mistaken for a failed job.
   @Action
-  async getJobStatus(jobId: string): Promise<number> {
+  async fetchJobStatus(jobId: string): Promise<number | null> {
     try {
       const response = await main.girderRest.get(`job/${jobId}`);
       return response.data.status;
     } catch (error) {
       logError(`Failed to get status for job ${jobId}`);
-      return jobStates.error;
+      return null;
     }
   }
 

--- a/src/store/progress.ts
+++ b/src/store/progress.ts
@@ -267,12 +267,13 @@ class Progress extends VuexModule {
       },
     });
 
-    // Sometimes the job completes before the callback even fires (for small images)
-    // So we check the status here to make sure we don't leave a progress item hanging
-    const status = await jobs.getJobStatus(jobId);
-    if (status === undefined) {
-      this.complete(progressId);
-    } else if (
+    // Sometimes the job completes before the callback even fires (for small
+    // images), so check the status here to make sure we don't leave a progress
+    // item hanging. An unreadable status (null) is treated the same way: better
+    // to drop the bar than to leave it spinning forever.
+    const status = await jobs.fetchJobStatus(jobId);
+    if (
+      status === null ||
       [jobStates.success, jobStates.error, jobStates.inactive].includes(status)
     ) {
       this.complete(progressId);

--- a/src/tools/toolsets/ToolItem.vue
+++ b/src/tools/toolsets/ToolItem.vue
@@ -96,9 +96,11 @@ function onJobChanged() {
   if (!jobId.value) {
     return;
   }
+  // Undefined if the job already settled (the jobs store drops finished
+  // entries), in which case there is no outcome left to show an icon for.
   jobs
     .getPromiseForJobId(jobId.value)
-    .then(
+    ?.then(
       (success: boolean) =>
         (statusIcon.value = success ? "mdi-check" : "mdi-close"),
     );


### PR DESCRIPTION
## Summary

Adds a new `wait_for_job` agent tool that allows the AI model to wait for background jobs (started by `run_worker` or `compute_property`) to complete, rather than polling state repeatedly. This prevents the model from burning through its turn budget on polling loops and enables efficient multi-step workflows.

## Key Changes

- **New `wait_for_job` tool** (`src/agent/executors.ts`):
  - Blocks until a job completes, returns immediately on completion event (no polling)
  - Supports configurable timeout (30s–30min, default 10min) with 30s floor to prevent spin loops
  - Respects `AbortSignal` from the turn context so `Stop` and forced clears unwind immediately
  - Falls back to server status checks (every 10s) for jobs not tracked in this session
  - Returns job outcome including worker error messages, or `stillRunning`/`aborted` states

- **Job tracking infrastructure**:
  - `trackAgentJob()` registers jobs started by the agent and wires completion callbacks
  - `agentJobs` map holds live progress/error objects and completion promises
  - Automatic pruning keeps the map bounded (max 20 records)
  - Completion handler writes transcript notes (same as before) and resolves the wait promise

- **Updated `run_worker` and `compute_property`**:
  - Both now track jobs via `trackAgentJob()` for `wait_for_job` support
  - Updated guidance text to recommend `wait_for_job` instead of polling
  - `compute_property` now calls `jobs.addJob()` to register the job with the store

- **Turn abort signal support** (`src/store/aiPanel.ts`):
  - Added `abortSignal` to `IAgentToolContext` (passed from turn's `AbortController`)
  - Increased `MAX_TOOL_ITERATIONS` from 20 to 30 to support multi-step workflows
  - Stop and forced clear now abort blocking tools immediately

- **Backend schema and documentation**:
  - Added `wait_for_job` to `agent_tools.json` with full schema
  - Updated system prompt to discourage polling and explain job waiting
  - Increased rate limit from 30 to 40 requests/min to accommodate longer turns
  - Added regression checklist to `AI_PANEL_SPEC.md`

- **Tests** (`src/agent/executors.test.ts`):
  - Comprehensive test suite for `wait_for_job` covering: immediate completion, error reporting, timeout behavior, abort handling, untracked jobs, polling intervals
  - Tool schema parity check against backend's `agent_tools.json`
  - AI panel tests for abort signal propagation on Stop and forced clear

## Implementation Details

- **Completion event-driven**: Uses the same completion callback infrastructure that writes transcript notes, so the model gets job outcomes as tool results
- **Fallback polling**: For jobs not tracked in this session (e.g., after page reload), polls server status every 10s within the wait budget—these are free REST calls, not agent turns
- **Timeout confirmation**: When a tracked job's wait budget expires, confirms with server before reporting "still running" to catch dropped WebSocket notifications
- **Error aggregation**: Extracts up to 5 error messages from worker logs and includes them in the tool result
- **Module-level state**: `agentJobs` map survives between tool calls within a turn, enabling sequential waits on the same job

## Motivation

Previously, the model had no way to wait for background jobs and could only learn of completion by re-reading state each turn. This led to polling loops that consumed entire turn budgets (e.g., a Cellpose run burned all 20 iterations). The new tool enables efficient workflows: start a job, wait for it in one call, then proceed—no polling, no turn waste.

https://claude.ai/code/session_014qfdqdYMV3HMNjz7jWq7kG