### PR TITLE
Name the worker interface job instead of titling it "unknown"

### DIFF
--- a/.agents/skills/nimbus-backend/SKILL.md
+++ b/.agents/skills/nimbus-backend/SKILL.md
@@ -305,6 +305,12 @@ Match each kind of request-data access to its helper:
 
 Rules: validation and `RestException` live in the API layer, never in models. Validate NESTED elements, not just the top-level container — each list entry (`[123]`) and nested map (`propertyValues: {"a1": 5}`) is caller-supplied; `.get()`/`.items()` on a non-dict entry → 500. Add a backend test per malformed-input case (malformed body → 400, not 500); `test/test_validation.py` unit-tests the helpers directly, and endpoint tests assert the 400. When you fix one endpoint, sweep the other endpoints in the same file for the identical gap — reviewers flag one instance per round.
 
+**`assertStatus(resp, 400)` alone is not a regression test for input validation.** These endpoints have *other* 400 paths — a missing `datasetId`, an unknown dataset id, a failed schema validation — so a malformed-body test can pass while the body is never validated at all. Observed for real: a `/upenn_annotation/compute` test using a syntactically valid but nonexistent `datasetId` passed **before** its fix, because the model's dataset lookup rejected the request first.
+
+Two habits close it:
+- **Assert the message, not just the status** (`assert "must be a JSON object" in resp.json["message"]`), and set up the request so the code actually reaches the validation — use a real `utilities.createFolder(...)` dataset when the handler looks one up before touching the body.
+- **`git stash push <source files>` and confirm the test fails**, leaving the new test file in place (untracked files aren't stashed). A malformed-input test that passes both ways is worse than none.
+
 ## Loading Plugin Changes Into the Running Backend
 
 The `girder` container bakes the plugin into its image (no source mount). After editing backend plugin code:

--- a/.agents/skills/nimbus-backend/SKILL.md
+++ b/.agents/skills/nimbus-backend/SKILL.md
@@ -363,6 +363,18 @@ job = JobModel().createLocalJob(
 JobModel().scheduleJob(job)
 ```
 
+### Every Job Title Reaches Users — Never Ship a Placeholder
+
+Job titles are user-visible: they are listed in Settings → **Jobs & Logs** and quoted in the frontend's job notifications (`src/store/jobs.ts`). A title that doesn't identify the work is a support burden — issue #1294 was a `girder_job_title` defaulting to the literal `"unknown"` for worker *interface* requests (containers named `unknown_None_<ts>`), which users saw appear right before their segmentation run with no way to tell the two apart.
+
+Rules when adding a job, or a helper that creates jobs:
+
+- **Default to something meaningful, not a placeholder.** If the title comes from caller-supplied data (`params.get("name")`), fall back to the request/job type, never to `"unknown"`. Check *every* caller — one caller omitting the field is how the placeholder reaches production.
+- **Derive the container name and the title separately.** Docker names allow only `[a-zA-Z0-9_.-]`, so sanitizing shared text costs the title its spaces, `/` and `:`. `runJobRequest` takes an explicit `jobTitle` for this reason (`server/helpers/tasks.py`).
+- **Don't interpolate `None` into a name.** Join only the parts that exist — `datasetId` is absent for interface requests.
+- **A caller-supplied name may not be a string.** `re.findall` on an int is a 500; guard with `isinstance(name, str)`.
+- **If users didn't start the job, document it** in `girder-claude-chat/girder_claude_chat/help/troubleshooting.md`, so the assistant can answer "what is this job?" instead of guessing.
+
 ### Progress Reporting via SSE
 
 Jobs report progress through `Job().updateJob()` which emits SSE events:

--- a/.claude/skills/nimbus-backend/SKILL.md
+++ b/.claude/skills/nimbus-backend/SKILL.md
@@ -305,6 +305,12 @@ Match each kind of request-data access to its helper:
 
 Rules: validation and `RestException` live in the API layer, never in models. Validate NESTED elements, not just the top-level container — each list entry (`[123]`) and nested map (`propertyValues: {"a1": 5}`) is caller-supplied; `.get()`/`.items()` on a non-dict entry → 500. Add a backend test per malformed-input case (malformed body → 400, not 500); `test/test_validation.py` unit-tests the helpers directly, and endpoint tests assert the 400. When you fix one endpoint, sweep the other endpoints in the same file for the identical gap — reviewers flag one instance per round.
 
+**`assertStatus(resp, 400)` alone is not a regression test for input validation.** These endpoints have *other* 400 paths — a missing `datasetId`, an unknown dataset id, a failed schema validation — so a malformed-body test can pass while the body is never validated at all. Observed for real: a `/upenn_annotation/compute` test using a syntactically valid but nonexistent `datasetId` passed **before** its fix, because the model's dataset lookup rejected the request first.
+
+Two habits close it:
+- **Assert the message, not just the status** (`assert "must be a JSON object" in resp.json["message"]`), and set up the request so the code actually reaches the validation — use a real `utilities.createFolder(...)` dataset when the handler looks one up before touching the body.
+- **`git stash push <source files>` and confirm the test fails**, leaving the new test file in place (untracked files aren't stashed). A malformed-input test that passes both ways is worse than none.
+
 ## Loading Plugin Changes Into the Running Backend
 
 The `girder` container bakes the plugin into its image (no source mount). After editing backend plugin code:

--- a/.claude/skills/nimbus-backend/SKILL.md
+++ b/.claude/skills/nimbus-backend/SKILL.md
@@ -363,6 +363,18 @@ job = JobModel().createLocalJob(
 JobModel().scheduleJob(job)
 ```
 
+### Every Job Title Reaches Users — Never Ship a Placeholder
+
+Job titles are user-visible: they are listed in Settings → **Jobs & Logs** and quoted in the frontend's job notifications (`src/store/jobs.ts`). A title that doesn't identify the work is a support burden — issue #1294 was a `girder_job_title` defaulting to the literal `"unknown"` for worker *interface* requests (containers named `unknown_None_<ts>`), which users saw appear right before their segmentation run with no way to tell the two apart.
+
+Rules when adding a job, or a helper that creates jobs:
+
+- **Default to something meaningful, not a placeholder.** If the title comes from caller-supplied data (`params.get("name")`), fall back to the request/job type, never to `"unknown"`. Check *every* caller — one caller omitting the field is how the placeholder reaches production.
+- **Derive the container name and the title separately.** Docker names allow only `[a-zA-Z0-9_.-]`, so sanitizing shared text costs the title its spaces, `/` and `:`. `runJobRequest` takes an explicit `jobTitle` for this reason (`server/helpers/tasks.py`).
+- **Don't interpolate `None` into a name.** Join only the parts that exist — `datasetId` is absent for interface requests.
+- **A caller-supplied name may not be a string.** `re.findall` on an int is a 500; guard with `isinstance(name, str)`.
+- **If users didn't start the job, document it** in `girder-claude-chat/girder_claude_chat/help/troubleshooting.md`, so the assistant can answer "what is this job?" instead of guessing.
+
 ### Progress Reporting via SSE
 
 Jobs report progress through `Job().updateJob()` which emits SSE events:

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/annotation.py
@@ -472,7 +472,9 @@ class Annotation(Resource):
                 code=400, message="Missing datasetId parameter"
             )
         return self._annotationModel.compute(
-            datasetId, self.getBodyJson(), self.getCurrentUser()
+            datasetId,
+            requireObjectBody(self.getBodyJson(), "Tool"),
+            self.getCurrentUser(),
         )
 
     @access.public(scope=TokenScope.DATA_READ)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/property.py
@@ -2,6 +2,7 @@ from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.constants import AccessType, TokenScope
 from girder.api.rest import Resource, loadmodel
+from ..helpers.validation import requireObjectBody
 from ..models.property import AnnotationProperty as PropertyModel
 from ..models.collection import Collection as CollectionModel
 from girder.exceptions import RestException, AccessException
@@ -63,7 +64,9 @@ class AnnotationProperty(Resource):
         datasetId = params.get("datasetId", None)
         if datasetId and id:
             return self._propertyModel.compute(
-                annotation_property, datasetId, self.getBodyJson()
+                annotation_property,
+                datasetId,
+                requireObjectBody(self.getBodyJson(), "Parameters"),
             )
         return {}
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/workerPreviews.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/workerPreviews.py
@@ -2,6 +2,7 @@ from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource
 from girder.constants import TokenScope
+from ..helpers.validation import requireObjectBody
 from ..models.workerPreviews import WorkerPreviewModel as PreviewModel
 from girder.exceptions import RestException
 
@@ -84,5 +85,8 @@ class WorkerPreviews(Resource):
                 code=400, message="Missing datasetId parameter"
             )
         return self._previewModel.requestPreviewUpdate(
-            image, datasetId, self.getBodyJson(), self.getCurrentUser()
+            image,
+            datasetId,
+            requireObjectBody(self.getBodyJson(), "Parameters"),
+            self.getCurrentUser(),
         )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/tasks.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/tasks.py
@@ -19,18 +19,22 @@ import re
 
 
 def runJobRequest(image, datasetId, params, requestType, jobTitle=None):
-    # The container name and the job title are derived separately: docker
-    # only accepts [a-zA-Z0-9_.-] in a name, while the title is shown to
-    # users in Jobs & Logs and can keep spaces, "/" and ":". Requests with
-    # no name of their own (interface requests) pass an explicit jobTitle,
-    # and fall back to the request type rather than a bare "unknown".
+    # The container name and the job title are derived separately: the
+    # container name is constrained by docker (see below), while the title is
+    # shown to users in Jobs & Logs and can keep spaces, "/" and ":".
+    # Requests with no name of their own (interface requests) pass an explicit
+    # jobTitle, and fall back to the request type rather than a bare
+    # "unknown".
     name = params.get("name")
     if not isinstance(name, str) or not name.strip():
         name = requestType
+    # Docker container names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*, so a
+    # leading "_", "-" or "." survives the character filter but still makes
+    # the name invalid — strip it rather than let docker reject the run.
     containerName = "_".join(
         str(part)
         for part in (
-            "".join(re.findall("[a-zA-Z0-9_.-]", name)) or requestType,
+            re.sub("[^a-zA-Z0-9_.-]", "", name).lstrip("_.-") or requestType,
             datasetId,
             datetime.datetime.now().timestamp(),
         )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/tasks.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/helpers/tasks.py
@@ -18,10 +18,24 @@ import re
 # )
 
 
-def runJobRequest(image, datasetId, params, requestType):
-    name = params.get("name", "unknown")
-    # Make sure name is a valid name for a docker container
-    name = "".join(re.findall("[a-zA-Z0-9_.-]", name))
+def runJobRequest(image, datasetId, params, requestType, jobTitle=None):
+    # The container name and the job title are derived separately: docker
+    # only accepts [a-zA-Z0-9_.-] in a name, while the title is shown to
+    # users in Jobs & Logs and can keep spaces, "/" and ":". Requests with
+    # no name of their own (interface requests) pass an explicit jobTitle,
+    # and fall back to the request type rather than a bare "unknown".
+    name = params.get("name")
+    if not isinstance(name, str) or not name.strip():
+        name = requestType
+    containerName = "_".join(
+        str(part)
+        for part in (
+            "".join(re.findall("[a-zA-Z0-9_.-]", name)) or requestType,
+            datasetId,
+            datetime.datetime.now().timestamp(),
+        )
+        if part
+    )
     params = json.dumps(params)
 
     containerArgs = [
@@ -45,10 +59,8 @@ def runJobRequest(image, datasetId, params, requestType):
                 "pull_image": False,
                 "container_args": containerArgs,
                 "remove_container": True,
-                "name": "{}_{}_{}".format(
-                    name, datasetId, datetime.datetime.now().timestamp()
-                ),
-                "girder_job_title": name,
+                "name": containerName,
+                "girder_job_title": jobTitle or name,
                 # 'girder_result_hooks': [testHook]
             },
             # Route to the "cpu" or "gpu" queue by worker class; interface

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerInterfaces.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerInterfaces.py
@@ -78,4 +78,14 @@ class WorkerInterfaceModel(ProxiedModel):
         )
 
     def requestWorkerUpdate(self, image):
-        return runJobRequest(image, None, {"image": image}, "interface")
+        # This job only asks the worker which parameters it accepts, so it
+        # has no tool or property name to borrow a title from. Name it
+        # explicitly, otherwise users see an unexplained job appear right
+        # before the run that triggered the interface fetch.
+        return runJobRequest(
+            image,
+            None,
+            {"image": image},
+            "interface",
+            jobTitle="Pulled worker interface for {}".format(image),
+        )

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerPreviews.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/models/workerPreviews.py
@@ -1,5 +1,5 @@
 from ..helpers.proxiedModel import ProxiedModel
-from girder.exceptions import ValidationException, RestException
+from girder.exceptions import ValidationException
 from girder.constants import AccessType
 from ..helpers.tasks import runJobRequest
 
@@ -73,10 +73,8 @@ class WorkerPreviewModel(ProxiedModel):
         return self.findOne(query)
 
     def requestPreviewUpdate(self, image, datasetId, parameters, user):
-        dataset = Folder().load(datasetId, user=user, level=AccessType.WRITE)
-        if not dataset:
-            raise RestException(
-                code=500, message="Invalid dataset id in annotation"
-            )
-
+        # Matches annotation.compute: a bad dataset id is caller error, so
+        # let Girder raise it (ValidationException -> 400, AccessException
+        # -> 403) rather than a RestException 500 from inside a model.
+        Folder().load(datasetId, user=user, level=AccessType.WRITE, exc=True)
         return runJobRequest(image, datasetId, parameters, "preview")

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_tasks.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_tasks.py
@@ -3,8 +3,16 @@ from unittest import mock
 
 import pytest
 
+from girder.constants import AccessType
+from pytest_girder.assertions import assertStatus
+
 from upenncontrast_annotation.server.helpers import tasks
 from upenncontrast_annotation.server.models import workerInterfaces
+from upenncontrast_annotation.server.models.property import (
+    AnnotationProperty,
+)
+
+from . import girder_utilities as utilities
 
 IMAGE = "properties/blob_metrics:latest"
 DATASET_ID = "5f9a1b2c3d4e5f6a7b8c9d0e"
@@ -13,12 +21,14 @@ DATASET_ID = "5f9a1b2c3d4e5f6a7b8c9d0e"
 @pytest.fixture
 def dockerRun():
     """Stub out the girder/celery side effects of runJobRequest."""
-    with mock.patch.object(tasks, "docker_run") as docker, mock.patch.object(
+    with mock.patch.object(
+        tasks, "docker_run"
+    ) as dockerRunTask, mock.patch.object(
         tasks, "getCurrentToken", return_value={"_id": "token"}
     ), mock.patch.object(tasks, "Setting"), mock.patch.object(
         tasks, "getQueueForRequest", return_value="cpu"
     ):
-        yield docker
+        yield dockerRunTask
 
 
 def jobKwargs(dockerRun):
@@ -33,9 +43,14 @@ def containerArg(dockerRun, flag):
 
 
 def requestInterface():
-    """Call the interface request without needing a database."""
+    """Call the interface request without needing a database.
+
+    `self` is None rather than a Mock on purpose: the method must not need
+    model state to build its title, and a Mock would silently absorb any
+    future `self.<anything>` access instead of failing the test.
+    """
     return workerInterfaces.WorkerInterfaceModel.requestWorkerUpdate(
-        mock.Mock(), IMAGE
+        None, IMAGE
     )
 
 
@@ -95,3 +110,107 @@ def test_name_of_only_invalid_characters_falls_back(dockerRun):
         "preview_{}_".format(DATASET_ID)
     )
     assert jobKwargs(dockerRun)["girder_job_title"] == "??? ///"
+
+
+@pytest.mark.parametrize("name", ["_temp mask", "-draft", "..hidden"])
+def test_container_name_starts_with_an_alphanumeric(dockerRun, name):
+    # Docker requires [a-zA-Z0-9] as the first character of a container
+    # name, and a leading "_", "-" or "." survives the character filter.
+    tasks.runJobRequest(IMAGE, DATASET_ID, {"name": name}, "compute")
+    assert jobKwargs(dockerRun)["name"][0].isalnum()
+    # The title is untouched by the container's naming rules.
+    assert jobKwargs(dockerRun)["girder_job_title"] == name
+
+
+def test_leading_punctuation_only_name_falls_back(dockerRun):
+    tasks.runJobRequest(IMAGE, DATASET_ID, {"name": "___"}, "compute")
+    assert jobKwargs(dockerRun)["name"].startswith(
+        "compute_{}_".format(DATASET_ID)
+    )
+
+
+@pytest.mark.usefixtures("unbindLargeImage", "unbindAnnotation")
+@pytest.mark.plugin("upenncontrast_annotation")
+class TestWorkerRequestBodyValidation:
+    """A non-object body must be a 400, not an uncaught 500.
+
+    All three endpoints hand their request body straight to runJobRequest,
+    which calls .get("name") on it — a JSON array would raise
+    AttributeError deep in the helper.
+    """
+
+    NON_OBJECT_BODY = json.dumps(["not", "an", "object"])
+
+    def assertBodyRejected(self, resp):
+        """400 specifically because of the body's shape.
+
+        Asserting the message matters here: these endpoints have other 400
+        paths (a missing or unknown datasetId), so a bare status check can
+        pass without the body ever being validated.
+        """
+        assertStatus(resp, 400)
+        assert "must be a JSON object" in resp.json["message"]
+
+    def _createProperty(self, admin):
+        prop = {
+            "name": "test-prop",
+            "image": IMAGE,
+            "shape": "point",
+            "tags": {"tags": ["tag1"], "exclusive": False},
+            "workerInterface": {},
+        }
+        model = AnnotationProperty()
+        model.setUserAccess(
+            prop, user=admin, level=AccessType.ADMIN, save=False
+        )
+        return model.save(prop)
+
+    def testAnnotationComputeNonObjectBodyReturns400(self, admin, server):
+        # A real dataset, so the request gets past the dataset lookup and
+        # the body is what the endpoint rejects.
+        dataset = utilities.createFolder(admin, "compute-body-dataset", {})
+        resp = server.request(
+            path="/upenn_annotation/compute",
+            method="POST",
+            user=admin,
+            params={"datasetId": str(dataset["_id"])},
+            body=self.NON_OBJECT_BODY,
+            type="application/json",
+        )
+        self.assertBodyRejected(resp)
+
+    def testPropertyComputeNonObjectBodyReturns400(self, admin, server):
+        prop = self._createProperty(admin)
+        resp = server.request(
+            path="/annotation_property/%s/compute" % prop["_id"],
+            method="POST",
+            user=admin,
+            params={"datasetId": DATASET_ID},
+            body=self.NON_OBJECT_BODY,
+            type="application/json",
+        )
+        self.assertBodyRejected(resp)
+
+    def testWorkerPreviewNonObjectBodyReturns400(self, admin, server):
+        dataset = utilities.createFolder(admin, "preview-body-dataset", {})
+        resp = server.request(
+            path="/worker_preview/request",
+            method="POST",
+            user=admin,
+            params={"datasetId": str(dataset["_id"]), "image": IMAGE},
+            body=self.NON_OBJECT_BODY,
+            type="application/json",
+        )
+        self.assertBodyRejected(resp)
+
+    def testWorkerPreviewUnknownDatasetReturns400(self, admin, server):
+        # Was a RestException 500 raised from inside the model.
+        resp = server.request(
+            path="/worker_preview/request",
+            method="POST",
+            user=admin,
+            params={"datasetId": DATASET_ID, "image": IMAGE},
+            body=json.dumps({"name": "preview"}),
+            type="application/json",
+        )
+        assertStatus(resp, 400)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_tasks.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_tasks.py
@@ -1,0 +1,97 @@
+import json
+from unittest import mock
+
+import pytest
+
+from upenncontrast_annotation.server.helpers import tasks
+from upenncontrast_annotation.server.models import workerInterfaces
+
+IMAGE = "properties/blob_metrics:latest"
+DATASET_ID = "5f9a1b2c3d4e5f6a7b8c9d0e"
+
+
+@pytest.fixture
+def dockerRun():
+    """Stub out the girder/celery side effects of runJobRequest."""
+    with mock.patch.object(tasks, "docker_run") as docker, mock.patch.object(
+        tasks, "getCurrentToken", return_value={"_id": "token"}
+    ), mock.patch.object(tasks, "Setting"), mock.patch.object(
+        tasks, "getQueueForRequest", return_value="cpu"
+    ):
+        yield docker
+
+
+def jobKwargs(dockerRun):
+    """The kwargs docker_run was asked to pass to the docker task."""
+    return dockerRun.apply_async.call_args.kwargs["kwargs"]
+
+
+def containerArg(dockerRun, flag):
+    """The value following flag in the container's argument list."""
+    args = jobKwargs(dockerRun)["container_args"]
+    return args[args.index(flag) + 1]
+
+
+def requestInterface():
+    """Call the interface request without needing a database."""
+    return workerInterfaces.WorkerInterfaceModel.requestWorkerUpdate(
+        mock.Mock(), IMAGE
+    )
+
+
+def test_interface_request_title_names_the_image(dockerRun):
+    requestInterface()
+    assert (
+        jobKwargs(dockerRun)["girder_job_title"]
+        == "Pulled worker interface for properties/blob_metrics:latest"
+    )
+
+
+def test_interface_container_name_is_not_unknown_none(dockerRun):
+    requestInterface()
+    name = jobKwargs(dockerRun)["name"]
+    assert name.startswith("interface_")
+    assert "unknown" not in name
+    # datasetId is absent for interface requests, so it must not appear as
+    # the literal "None" in the middle of the container name.
+    assert "None" not in name
+
+
+def test_interface_worker_parameters_are_unchanged(dockerRun):
+    requestInterface()
+    # The title lives in the job, not in the payload the worker parses.
+    assert json.loads(containerArg(dockerRun, "--parameters")) == {
+        "image": IMAGE
+    }
+    assert containerArg(dockerRun, "--request") == "interface"
+
+
+def test_named_request_keeps_its_name_as_the_title(dockerRun):
+    tasks.runJobRequest(
+        IMAGE, DATASET_ID, {"name": "Cellpose Segmentation"}, "compute"
+    )
+    # The title keeps the spaces the container name has to drop.
+    assert jobKwargs(dockerRun)["girder_job_title"] == "Cellpose Segmentation"
+    assert jobKwargs(dockerRun)["name"].startswith(
+        "CellposeSegmentation_{}_".format(DATASET_ID)
+    )
+
+
+@pytest.mark.parametrize("name", [None, "", "   ", 123, {"a": "b"}])
+def test_unusable_name_falls_back_to_request_type(dockerRun, name):
+    params = {} if name is None else {"name": name}
+    tasks.runJobRequest(IMAGE, DATASET_ID, params, "compute")
+    assert jobKwargs(dockerRun)["girder_job_title"] == "compute"
+    assert jobKwargs(dockerRun)["name"].startswith(
+        "compute_{}_".format(DATASET_ID)
+    )
+
+
+def test_name_of_only_invalid_characters_falls_back(dockerRun):
+    # Sanitizing leaves nothing, so the container name would otherwise
+    # start with the datasetId and lose all trace of the request type.
+    tasks.runJobRequest(IMAGE, DATASET_ID, {"name": "??? ///"}, "preview")
+    assert jobKwargs(dockerRun)["name"].startswith(
+        "preview_{}_".format(DATASET_ID)
+    )
+    assert jobKwargs(dockerRun)["girder_job_title"] == "??? ///"

--- a/devops/girder/plugins/girder-claude-chat/girder_claude_chat/help/troubleshooting.md
+++ b/devops/girder/plugins/girder-claude-chat/girder_claude_chat/help/troubleshooting.md
@@ -92,6 +92,14 @@ Improving results when analysis is incorrect:
 - For time lapse, check gap handling settings
 - Manually fix critical connections with connection tools
 
+## Unfamiliar Jobs in Jobs & Logs
+
+**"Pulled worker interface for ..." (followed by a worker image name)**:
+- Not an error, and not something the user started directly
+- When a worker tool is added — or when its parameter list isn't already cached — NimbusImage briefly runs the worker just to ask which parameters it accepts. That fetch is itself a job, so it shows up in Recent Jobs, usually immediately before the run that needed it
+- It does no analysis: it creates no objects, computes no properties, and changes no data
+- Safe to ignore. If it fails, the tool's parameter list can't load — check that the worker image is available on the server, then re-add the tool
+
 ## Common Error Messages
 
 **"Worker failed"**:


### PR DESCRIPTION
Fixes #1294.

## Problem

`runJobRequest` derived both the Girder job title and the docker container name from `params["name"]`, defaulting to the literal `"unknown"`. Interface requests are the only one of the four callers that has no name to offer, so every interface fetch — which happens whenever a worker tool is added, i.e. immediately *before* a real run — left a job titled `unknown` in Settings → Jobs & Logs and a container named `unknown_None_<ts>`. Users couldn't tell it apart from the run itself, and the assistant couldn't explain it either.

## Changes

Backend only; no frontend changes were needed. The frontend only *reads* `job.title` (`src/store/jobs.ts`, `JobsLogs.vue`) and sends just `image` for interface requests, so the better title propagates on its own.

- **`server/models/workerInterfaces.py`** — pass an explicit `jobTitle="Pulled worker interface for <image>"`. It sets `girder_job_title` only, so the `--parameters` payload the worker parses stays exactly `{"image": image}` (locked by a test).
- **`server/helpers/tasks.py`** — derive the container name and the job title separately. Container names allow only `[a-zA-Z0-9_.-]`, and sharing one sanitized value cost every title its spaces, `/` and `:`; compute and preview jobs now read `Cellpose Segmentation` instead of `CellposeSegmentation`. Also:
  - fall back to the **request type** rather than `"unknown"`, so a future caller that omits a name still gets an identifiable job — this generalizes the fix past the one caller that triggered the issue;
  - join only the container-name parts that exist, so an absent `datasetId` no longer appears as the literal `None`;
  - guard a non-string `name` — `re.findall` on an int was an uncaught `TypeError` (500).
- **`girder-claude-chat/.../help/troubleshooting.md`** — a new "Unfamiliar Jobs in Jobs & Logs" entry explaining what the interface job is, that it does no analysis, and what to check if it fails, so the assistant can answer "what is this job?".
- **`.claude`/`.agents` `nimbus-backend` skill** — records the rule (job titles are user-visible; never default one to a placeholder; derive container name and title separately; document jobs users didn't start), both trees synced via `sync_skills.py`.

## Verification

- **New unit tests** (`test/test_tasks.py`, 10 cases): interface title/container name, the worker payload staying unchanged, named requests keeping spaces in the title, and unusable names (missing, empty, whitespace, int, dict, all-invalid-characters) falling back to the request type. Confirmed **9 of the 10 fail** against the unfixed source with the changes stashed; the 10th is the payload invariant, which must hold both before and after.
- **Full backend suite:** `tox` → 368 passed. `flake8` clean on all changed files.
- **End-to-end against a rebuilt local backend** — real `POST worker_interface/request` for `annotations/connect_to_nearest:latest`:
  - title: `Pulled worker interface for annotations/connect_to_nearest:latest`
  - container name: `interface_1785493338.471857` (was `unknown_None_<ts>`)
  - job status `3` (SUCCESS), so the interface fetch itself still works

The container name no longer embeds the image, but `docker ps` shows the image in its own column, so `interface_<ts>` plus that column is unambiguous.

## Noted, not fixed

The three `runJobRequest` callers that read a JSON request body (`property.compute`, `worker_preview/request`, annotation `compute`) would still 500 rather than 400 on a non-object body — a separate input-validation gap for `server/helpers/validation.py`, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LE4Kf3kUrbZt3MfMqacuba