### PR TITLE
fix(dev): make the local worker actually consume the cpu/gpu queues

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,15 @@ services:
     image: girder/girder_worker
     # The dispatcher routes jobs to the "cpu"/"gpu" queues; locally one
     # worker consumes all of them, plus the legacy default queue.
-    command: -Q celery,cpu,gpu
+    #
+    # This has to override `entrypoint`, not `command`: the girder_worker image's
+    # /docker-entrypoint.sh ends in `$BIN -m girder_worker -l info` with no "$@",
+    # so anything passed as the command is silently discarded and the worker only
+    # ever consumes the default "celery" queue -- leaving every dispatched job
+    # parked in "cpu"/"gpu" with no consumer (worker interfaces never load).
+    # Bypassing that script is safe because its only other job is defaulting
+    # RABBITMQ_USER/PASS/HOST, which worker.env already provides.
+    entrypoint: ["python3", "-m", "girder_worker", "-l", "info", "-Q", "celery,cpu,gpu"]
     links:
       - girder
     volumes:


### PR DESCRIPTION
## Problem

On a local dev install, running any worker from the frontend hangs forever on the interface load step. Girder returns `200` for `POST /api/v1/worker_interface/request`, but no worker container is ever launched.

#1236 split worker dispatch across `cpu`/`gpu` Celery queues and pointed the local worker at them via docker-compose:

```yaml
  worker:
    image: girder/girder_worker
    command: -Q celery,cpu,gpu
```

That never took effect. The `girder_worker` image's `/docker-entrypoint.sh` ends in:

```bash
$BIN -m girder_worker -l info
```

with no `"$@"`, so the container command is silently discarded and the worker subscribes only to the default `celery` queue. Every dispatched job then parks in a queue nobody is listening to:

```
name     messages_ready  consumers
celery   0               1
local    0               1
cpu      3               0     <-- interface requests, nobody listening
```

`compute` on a GPU-labelled worker stalls identically once a `gpu` queue gets declared.

## Fix

Override `entrypoint` rather than `command`, so the queue list actually reaches Celery. Bypassing the entrypoint script is safe: its only other responsibility is defaulting `RABBITMQ_USER`/`PASS`/`HOST`, all of which `worker.env` already provides.

## Verification

After `docker compose up -d worker`:

```
$ docker exec worker ps -eo args | grep girder_worker
python3 -m girder_worker -l info -Q celery,cpu,gpu

$ docker exec broker rabbitmqctl list_queues name messages_ready consumers
celery   0  1
cpu      0  1
gpu      0  1
local    0  1
```

`cpu` and `gpu` went from 0 consumers to 1. The interface requests that had been parked in `cpu` dispatched immediately, ran to **exit 0**, and POSTed their interface back to Girder (`200 OK`) — reproduced against `annotations/sam_automatic_mask_generator`.

## Scope

This compose service is the only `girder_worker` definition in the repo. The `girder` container's own `-Q local` Celery worker (line 14) is untouched, and deployment configs live outside this repo, so nothing there changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)