### PR TITLE
docs(readme): document the stale girder_worker image trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,18 @@ wget "https://huggingface.co/rajlab/sam_vit_b/resolve/main/encoder.onnx" -O enco
 Start docker images for the backend:
 
 ```sh
+docker compose pull
 docker compose build
 docker compose up -d
 ```
+
+Do not skip `docker compose pull`. The `worker` service runs the prebuilt
+`girder/girder_worker` image rather than one built from this repo, so
+`docker compose build` never updates it -- not even with `--no-cache` -- and
+`docker compose up` reuses whatever copy is already cached locally. If you
+installed some time ago, you can silently be running a years-old worker image.
+See [worker interfaces never load](#worker-interfaces-never-load) for the
+symptom this causes.
 
 This will set up Girder (backend) running on `http://localhost:8080`
 
@@ -114,6 +123,44 @@ chmod +x build_workers.sh
 ```
 
 That will install all the workers. The machine learning workers will run on CPU on Linux if a GPU is not available, although will run much more slowly.
+
+### Worker interfaces never load
+
+If selecting a worker in the UI hangs forever on the interface load step -- no
+error in the browser, in the Girder log, or in the worker log -- the usual cause
+is a stale `girder/girder_worker` image.
+
+Girder routes jobs to the `cpu` and `gpu` Celery queues, and `docker-compose.yaml`
+subscribes the local worker to both via `command: -Q celery,cpu,gpu`. But
+`girder_worker` images built before 2025-02-17 have a `/docker-entrypoint.sh`
+that does not forward its arguments, so that queue list is silently discarded and
+the worker subscribes only to the default `celery` queue. Jobs then pile up in
+`cpu`/`gpu` with nothing consuming them. Girder still returns `200` for the
+dispatch request, and no worker container is ever launched, so there is nothing
+to see in any log.
+
+Check the age of your image:
+
+```sh
+docker inspect girder/girder_worker:latest --format '{{.Created}}'
+```
+
+Confirm the queue subscriptions and look for a queue with zero consumers:
+
+```sh
+docker exec worker ps -eo args | grep girder_worker
+# expect: ... -Q celery,cpu,gpu   (only "-l info" means the arguments were dropped)
+
+docker compose exec broker rabbitmqctl list_queues name messages_ready consumers
+# every queue should have >= 1 consumer; cpu or gpu at 0 is the bug
+```
+
+The fix is to update the image and recreate the container:
+
+```sh
+docker compose pull worker
+docker compose up -d worker
+```
 
 ## Login details
 


### PR DESCRIPTION
Supersedes #1296, which fixed the symptom rather than the cause.

## The failure

On a local install, selecting any worker in the UI hangs forever on the interface load step. There is no error in the browser, the Girder log, or the worker log — `POST /api/v1/worker_interface/request` returns `200` and no worker container is ever launched.

The jobs are sitting in a queue nobody is listening to:

```
name     messages_ready  consumers
celery   0               1
local    0               1
cpu      3               0     <-- interface requests, nobody listening
```

## The cause

`girder_worker` images built before **2025-02-17** (upstream girder_worker `e9c975f9`, "Improve Docker entrypoint") have a `/docker-entrypoint.sh` ending in:

```bash
$BIN -m girder_worker -l info
```

with no `"$@"`. The `-Q celery,cpu,gpu` this repo sets on the worker service is silently discarded, and the worker subscribes only to the default `celery` queue — while #1236's dispatcher routes jobs to `cpu`/`gpu`. Current images forward arguments correctly:

```bash
celery -A girder_worker.app worker -l INFO $@
```

What makes this so hard to diagnose is that the image is **pulled, not built**. The service has `image:` and no `build:`, so `docker compose build` never updates it — not even `--no-cache` — and `docker compose up` reuses whatever is cached. Rebuilding from scratch, the obvious first thing to try, cannot fix it. An install from a while ago keeps using its original image indefinitely.

## The change

Documentation only:

- `docker compose pull` added to the backend startup steps, with a note on why it cannot be skipped.
- A **Worker interfaces never load** troubleshooting section: how to check the image age, how to confirm queue subscriptions and spot a queue with zero consumers, and the fix.

## Why not #1296

#1296 overrode `entrypoint:` so the queue list reached Celery regardless of image age. It works — I verified it on both the old and current images — but it makes the symptom vanish while leaving the install on a years-old worker image, and it diverges from upstream's invocation.

Verified on an affected install: the cached image dated from **2022-11-17**, and `docker compose pull worker && docker compose up -d worker` resolved it with **no change to this repo's compose configuration**. Afterwards the worker runs `celery -A girder_worker.app worker -l INFO -Q celery,cpu,gpu` and all four queues have a consumer.

Production is unaffected — any deployment on an image newer than 2025-02-17 already honors the existing `command:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)