### PR TITLE
Fix empty-subset CSV exports

### DIFF
--- a/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
+++ b/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
@@ -1,6 +1,7 @@
 # Empty-subset CSV export — review findings (PR #1299)
 
-Codex round 1 on `codex/fix-empty-csv-export` (head d634f5db), 2026-08-01.
+Codex rounds on `codex/fix-empty-csv-export`, 2026-08-01.
+Round 1: head d634f5db (F1–F3). Round 2: head c1b4a05e (F4).
 
 ## F1 (P1) — Stub-only mode loses the selected subset
 
@@ -66,3 +67,24 @@ All converted at the API boundary via `requireObjectId` → 400.
 **Status:** fixed (this branch) — tests:
 `test_export.py::testExportCsvRejectsMalformedInput`,
 `testExportJsonRejectsMalformedIds`.
+
+## F4 (P2, round 2) — Selected export scanned every stub
+
+`src/components/AnnotationBrowser/AnnotationCSVDialog.vue`
+
+The F1 fix routed the "selected" scope through `annotationsForIteration`,
+which in stub-only mode is an `Array.from` over the whole stub map — a
+dataset-sized allocation and O(N) scan to pick out ids already sitting in
+`selectedAnnotationIds`. (Cost-before-guard, again.)
+
+Fix: `exportAnnotationIds` derives ids straight from the selection/filter
+(never resolving objects), the download and count/preview-limit checks use
+only ids/`annotationCount`, and annotation *objects* materialize solely for
+the preview — which only runs within `PREVIEW_ANNOTATION_LIMIT` — resolved
+per id via the new O(1) store getter
+`annotationStore.getAnnotationOrStubFromId`.
+
+**Status:** fixed (this branch) — regression test:
+`AnnotationCSVDialog.test.ts` "selected-scope download never materializes the
+stub iteration array" (a throwing `annotationsForIteration` accessor), plus
+"selected-scope preview resolves stubs by id lookup".

--- a/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
+++ b/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
@@ -1,0 +1,68 @@
+# Empty-subset CSV export — review findings (PR #1299)
+
+Codex round 1 on `codex/fix-empty-csv-export` (head d634f5db), 2026-08-01.
+
+## F1 (P1) — Stub-only mode loses the selected subset
+
+`src/components/AnnotationBrowser/AnnotationCSVDialog.vue`
+
+In stub-only mode `annotationStore.annotations` is empty by design, so the
+"selected" (and "all") scopes computed from it yield `[]`, `isSubset` evaluates
+`0 < 0` = false, and the download omits `annotationIds` — the backend then
+exports every annotation despite the user's selection. The dialog's counts
+(`allAnnotationCount`, `hasActiveFilter`) read `annotations.length` too, so the
+radio labels show 0 and the filtered radio is wrongly disabled.
+
+Fix: derive scopes from the stub-aware getters — `annotationsForIteration`
+for the "selected"/"all" branches and `annotationCount` for every
+`annotations.length` comparison. The preview generator already narrows stubs
+via `isHydratedAnnotation`, so stubs flowing through `annotationsToExport` are
+already handled downstream.
+
+**Status:** fixed (this branch) — tests: `AnnotationCSVDialog.test.ts`
+"stub-only mode" describe block.
+
+## F2 (P2) — Empty subset still materializes all property values
+
+`.../server/api/export.py` `_generateCsvLines`
+
+The empty-subset guard lives in `_iterAnnotations`, but
+`_getPropertyValues(datasetObjectId)` — a full property-values collection scan
+into a dict — runs before it. A header-only export of a huge dataset still
+pays the dataset-wide DB and memory cost. (Cost-before-guard pattern.)
+
+Fix: return right after the header row when `parsedAnnotationIds` is an empty
+list, before `_getPropertyValues`.
+
+**Status:** fixed (this branch) — test:
+`test_export.py::testEmptySubsetSkipsPropertyValueFetch`.
+
+Noted, not done here: for small non-empty subsets `_getPropertyValues` still
+loads the whole dataset's values; filtering it by the requested annotation ids
+is a follow-up optimization.
+
+## F3 (P2) — annotationIds entries can 500 on the public endpoint
+
+`.../server/api/export.py` `exportCsv`
+
+Codex's exact example (`{"annotationIds": false}`) is already a 400: Girder
+validates the `jsonParam` schema (`jsonschema.validate` → `RestException`), so
+non-list values and non-string items never reach the handler, and `requireList`
+would be redundant. The real hole is malformed id *strings*: `["not-hex"]`
+passes the schema and `ObjectId(aid)` raises uncaught `InvalidId` → 500.
+
+Fix: convert with `requireObjectId` per entry and clamp with
+`validateAnnotationIdCount`. Pattern sweep over the same endpoint pair found
+the identical unguarded conversions:
+
+- `exportCsv`: `ObjectId(datasetId)` (schema requires a string, not valid hex)
+- `exportCsv`: `ObjectId(path[0])` in `_buildPropertyNameMap` for
+  `propertyPaths`
+- `exportJson` (the symmetric twin): `ObjectId(datasetId)` and
+  `ObjectId(configurationId)` from query params
+
+All converted at the API boundary via `requireObjectId` → 400.
+
+**Status:** fixed (this branch) — tests:
+`test_export.py::testExportCsvRejectsMalformedInput`,
+`testExportJsonRejectsMalformedIds`.

--- a/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
+++ b/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
@@ -3,7 +3,10 @@
 Codex rounds on `codex/fix-empty-csv-export`, 2026-08-01.
 Round 1: head d634f5db (F1–F3). Round 2: head c1b4a05e (F4).
 Round 3: head 4857c3eb (checklist below). Round 4: head 821b1e37 (F5).
-Round 5: head a35b5481 (F6).
+Round 5: head a35b5481 (F6). Round 6: head 1492fc97 (store-level tests for
+F5's deletion pruning — the dialog test mocks the store and could not catch
+a pruning regression; `src/store/annotation-delete.test.ts` exercises the
+real module).
 
 ## F1 (P1) — Stub-only mode loses the selected subset
 
@@ -163,6 +166,17 @@ getters: re-check these. Frontend tests live in
 - [ ] Dialog counts and radio enablement come from the stub-aware
   `annotationCount` —
   CSV: *"counts come from the stub-aware annotationCount"*
+
+### Destructive actions (deletion must not leave dangling id state)
+
+- [ ] Deleting prunes the deleted ids from `selectedAnnotationIds` (full
+  mode) — store: *"prunes deleted ids from the selection in full mode"*
+- [ ] Deleting prunes selection, hover, and the stub map in stub-only mode —
+  store: *"prunes selection, hover, and the stub map in stub-only mode"*
+- [ ] Deleting the hovered annotation clears `hoveredAnnotationId` —
+  store: *"clears the hovered id when the hovered annotation is deleted"*
+- [ ] Deleting an unrelated annotation preserves selection and hover —
+  store: *"keeps an unrelated hovered id and selection"*
 
 ### Cost (no visible behavior — regresses silently)
 

--- a/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
+++ b/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
@@ -88,3 +88,61 @@ per id via the new O(1) store getter
 `AnnotationCSVDialog.test.ts` "selected-scope download never materializes the
 stub iteration array" (a throwing `annotationsForIteration` accessor), plus
 "selected-scope preview resolves stubs by id lookup".
+
+## Regression checklist
+
+One line per invariant, each naming the test that holds it. When changing the
+CSV export dialog, the export endpoints, or the annotation store's stub
+getters: re-check these. Frontend tests live in
+`src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts` (CSV) and
+`src/store/ExportAPI.test.ts` (API); backend tests in
+`upenncontrast_annotation/test/test_export.py`.
+
+### Subset correctness (which rows end up in the file)
+
+- [ ] "Selected" scope exports exactly the selected ids in stub-only mode —
+  CSV: *selected scope sends the selected ids, not an omitted field*
+- [ ] "Selected" scope exports the selected ids in full mode —
+  CSV: *download sends the selected subset's ids*
+- [ ] "Filtered" scope exports the filtered ids in stub-only mode —
+  CSV: *filtered scope sends the filtered ids*
+- [ ] "All" scope omits `annotationIds` (full and stub-only) —
+  CSV: *download calls exportAPI.exportCsv with correct params*,
+  *all scope still omits annotationIds*
+- [ ] An explicitly empty subset survives the API layer (omitted field ≠
+  empty array) — ExportAPI: *omits annotationIds when no subset is
+  supplied*, *preserves an explicitly empty annotation subset*
+- [ ] The endpoint distinguishes omitted / subset / empty —
+  backend: `testExportCsvPreservesExactAnnotationSubset`,
+  `testIterAnnotationsDistinguishesNoneFromEmpty`
+- [ ] Dialog counts and radio enablement come from the stub-aware
+  `annotationCount` — CSV: *counts come from the stub-aware annotationCount*
+
+### Cost (no visible behavior — regresses silently)
+
+- [ ] A subset download never materializes the stub iteration array
+  (`annotationsForIteration` is dataset-sized in stub-only mode) —
+  CSV: *selected-scope download never materializes the stub iteration array*
+- [ ] Preview resolves annotation objects per id (O(1) lookups bounded by
+  `PREVIEW_ANNOTATION_LIMIT`), never by scanning —
+  CSV: *selected-scope preview resolves stubs by id lookup*
+- [ ] An empty-subset export skips the dataset-wide property-values scan —
+  backend: `testEmptySubsetSkipsPropertyValueFetch`
+
+### Boundary validation (public endpoints, 400 not 500)
+
+- [ ] Malformed `annotationIds` entries, `datasetId`, and `propertyPaths`
+  property ids on `/export/csv` are a clean 400 —
+  backend: `testExportCsvRejectsMalformedInput`
+- [ ] The `/export/json` twin rejects malformed `datasetId` and
+  `configurationId` the same way —
+  backend: `testExportJsonRejectsMalformedIds`
+
+### Process rules this feature proved
+
+- When a rule is added to one export scope, check its twins (all/filtered/
+  selected; download/preview/counts) — F1 and F4 were both one-of-N-paths
+  misses.
+- Put the cheap check (id counts) before the expensive work (object
+  materialization); validate ids at the API boundary because the CSV body
+  streams lazily and cannot 400 mid-stream.

--- a/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
+++ b/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
@@ -2,6 +2,7 @@
 
 Codex rounds on `codex/fix-empty-csv-export`, 2026-08-01.
 Round 1: head d634f5db (F1–F3). Round 2: head c1b4a05e (F4).
+Round 3: head 4857c3eb (checklist below). Round 4: head 821b1e37 (F5).
 
 ## F1 (P1) — Stub-only mode loses the selected subset
 
@@ -89,6 +90,27 @@ per id via the new O(1) store getter
 stub iteration array" (a throwing `annotationsForIteration` accessor), plus
 "selected-scope preview resolves stubs by id lookup".
 
+## F5 (P2, round 4) — Stale selection ids could widen a subset to "all"
+
+`AnnotationCSVDialog.vue` + `src/store/annotation.ts`
+
+`deleteAnnotations` removed the annotation/stub but never pruned
+`selectedAnnotationIds` (only the `deleteSelectedAnnotations` wrapper cleared
+it), so a context-menu delete left the deleted id selected. With F4's
+count-based subset check, 1 live + 1 stale selected id in a 2-annotation
+dataset compared equal to `annotationCount` → `annotationIds` omitted →
+whole dataset exported.
+
+Fix, both layers: `deleteAnnotations` now prunes deleted ids from the
+selection and clears a dangling `hoveredAnnotationId` (the same
+delete-leaves-paired-state-dangling shape the connection list was flagged
+for), and the dialog's selected scope filters ids through
+`getAnnotationOrStubFromId` before the count comparison — covering stale
+sources deletion pruning can't reach (e.g. undo).
+
+**Status:** fixed (this branch) — test: `AnnotationCSVDialog.test.ts`
+"stale selected ids never widen the export to the whole dataset".
+
 ## Regression checklist
 
 One line per invariant, each naming the test that holds it. When changing the
@@ -101,42 +123,47 @@ getters: re-check these. Frontend tests live in
 ### Subset correctness (which rows end up in the file)
 
 - [ ] "Selected" scope exports exactly the selected ids in stub-only mode —
-  CSV: *selected scope sends the selected ids, not an omitted field*
+  CSV: *"selected scope sends the selected ids, not an omitted field"*
 - [ ] "Selected" scope exports the selected ids in full mode —
-  CSV: *download sends the selected subset's ids*
+  CSV: *"download sends the selected subset's ids"*
 - [ ] "Filtered" scope exports the filtered ids in stub-only mode —
-  CSV: *filtered scope sends the filtered ids*
+  CSV: *"filtered scope sends the filtered ids"*
 - [ ] "All" scope omits `annotationIds` (full and stub-only) —
-  CSV: *download calls exportAPI.exportCsv with correct params*,
-  *all scope still omits annotationIds*
+  CSV: *"download calls exportAPI.exportCsv with correct params"*,
+  *"all scope still omits annotationIds"*
+- [ ] Stale ids lingering in the selection (delete/undo) are dropped before
+  the subset-vs-whole-dataset comparison —
+  CSV: *"stale selected ids never widen the export to the whole dataset"*
 - [ ] An explicitly empty subset survives the API layer (omitted field ≠
-  empty array) — ExportAPI: *omits annotationIds when no subset is
-  supplied*, *preserves an explicitly empty annotation subset*
+  empty array) — ExportAPI: *"omits annotationIds when no subset is
+  supplied"*, *"preserves an explicitly empty annotation subset"*
 - [ ] The endpoint distinguishes omitted / subset / empty —
-  backend: `testExportCsvPreservesExactAnnotationSubset`,
-  `testIterAnnotationsDistinguishesNoneFromEmpty`
+  backend: *"testExportCsvPreservesExactAnnotationSubset"*,
+  *"testIterAnnotationsDistinguishesNoneFromEmpty"*
 - [ ] Dialog counts and radio enablement come from the stub-aware
-  `annotationCount` — CSV: *counts come from the stub-aware annotationCount*
+  `annotationCount` —
+  CSV: *"counts come from the stub-aware annotationCount"*
 
 ### Cost (no visible behavior — regresses silently)
 
 - [ ] A subset download never materializes the stub iteration array
   (`annotationsForIteration` is dataset-sized in stub-only mode) —
-  CSV: *selected-scope download never materializes the stub iteration array*
+  CSV: *"selected-scope download never materializes the stub iteration
+  array"*
 - [ ] Preview resolves annotation objects per id (O(1) lookups bounded by
   `PREVIEW_ANNOTATION_LIMIT`), never by scanning —
-  CSV: *selected-scope preview resolves stubs by id lookup*
+  CSV: *"selected-scope preview resolves stubs by id lookup"*
 - [ ] An empty-subset export skips the dataset-wide property-values scan —
-  backend: `testEmptySubsetSkipsPropertyValueFetch`
+  backend: *"testEmptySubsetSkipsPropertyValueFetch"*
 
 ### Boundary validation (public endpoints, 400 not 500)
 
 - [ ] Malformed `annotationIds` entries, `datasetId`, and `propertyPaths`
   property ids on `/export/csv` are a clean 400 —
-  backend: `testExportCsvRejectsMalformedInput`
+  backend: *"testExportCsvRejectsMalformedInput"*
 - [ ] The `/export/json` twin rejects malformed `datasetId` and
   `configurationId` the same way —
-  backend: `testExportJsonRejectsMalformedIds`
+  backend: *"testExportJsonRejectsMalformedIds"*
 
 ### Process rules this feature proved
 

--- a/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
+++ b/codebaseDocumentation/EMPTY_CSV_EXPORT-REVIEW.md
@@ -3,6 +3,7 @@
 Codex rounds on `codex/fix-empty-csv-export`, 2026-08-01.
 Round 1: head d634f5db (F1–F3). Round 2: head c1b4a05e (F4).
 Round 3: head 4857c3eb (checklist below). Round 4: head 821b1e37 (F5).
+Round 5: head a35b5481 (F6).
 
 ## F1 (P1) — Stub-only mode loses the selected subset
 
@@ -111,6 +112,25 @@ sources deletion pruning can't reach (e.g. undo).
 **Status:** fixed (this branch) — test: `AnnotationCSVDialog.test.ts`
 "stale selected ids never widen the export to the whole dataset".
 
+## F6 (P2, round 5) — Filtered-scope count allocated the id array
+
+`AnnotationCSVDialog.vue`
+
+The filtered-scope twin of F4: `exportAnnotationCount` (evaluated on every
+render for the count label and preview-limit guard) reached through
+`exportAnnotationIds`, whose filtered branch maps the whole filtered array —
+potentially hundreds of thousands of stubs — into a second dataset-sized id
+array just to read its length. `annotationsToExport` also evaluated
+`exportAnnotationIds` before its own filtered early-return.
+
+Fix: the count reads `props.annotations.length` for the filtered scope (and
+`annotationCount` for "all"); `annotationsToExport` checks the filtered
+scope before touching `exportAnnotationIds`. The filtered id array is now
+built exactly once, at download time.
+
+**Status:** fixed (this branch) — test: `AnnotationCSVDialog.test.ts`
+"filtered-scope count/preview guard never allocates the id array".
+
 ## Regression checklist
 
 One line per invariant, each naming the test that holds it. When changing the
@@ -153,6 +173,9 @@ getters: re-check these. Frontend tests live in
 - [ ] Preview resolves annotation objects per id (O(1) lookups bounded by
   `PREVIEW_ANNOTATION_LIMIT`), never by scanning —
   CSV: *"selected-scope preview resolves stubs by id lookup"*
+- [ ] The filtered-scope count/preview guard reads a length, never building
+  the dataset-sized id array (built exactly once, at download) —
+  CSV: *"filtered-scope count/preview guard never allocates the id array"*
 - [ ] An empty-subset export skips the dataset-wide property-values scan —
   backend: *"testEmptySubsetSkipsPropertyValueFetch"*
 

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
@@ -26,6 +26,10 @@ from ..models.property import AnnotationProperty as PropertyModel
 from ..models.collection import Collection as CollectionModel
 from ..models.datasetView import DatasetView as DatasetViewModel
 from ..helpers.serialization import orJsonDefaults
+from ..helpers.validation import (
+    requireObjectId,
+    validateAnnotationIdCount,
+)
 
 
 @dataclass
@@ -174,7 +178,7 @@ class Export(Resource):
         }
         """
         # Permission check - will raise RestException if access denied
-        datasetObjectId = ObjectId(datasetId)
+        datasetObjectId = requireObjectId(datasetId, "datasetId")
         Folder().load(
             datasetObjectId,
             user=self.getCurrentUser(),
@@ -182,7 +186,10 @@ class Export(Resource):
             exc=True
         )
 
-        configObjectId = ObjectId(configurationId) if configurationId else None
+        configObjectId = (
+            requireObjectId(configurationId, "configurationId")
+            if configurationId else None
+        )
 
         # Ensure filename ends with .json
         safe_filename = (
@@ -375,7 +382,7 @@ class Export(Resource):
         filename = body.get("filename", "export.csv")
 
         # Permission check
-        datasetObjectId = ObjectId(datasetId)
+        datasetObjectId = requireObjectId(datasetId, "datasetId")
         Folder().load(
             datasetObjectId,
             user=self.getCurrentUser(),
@@ -383,13 +390,21 @@ class Export(Resource):
             exc=True
         )
 
-        # Property paths are already parsed from JSON body
+        # The jsonParam schema guarantees shapes (lists of strings), but not
+        # that id strings are valid ObjectIds. Convert them all here at the
+        # API boundary: the CSV body is generated lazily while streaming, so
+        # an InvalidId raised there could not become a clean 400 anymore.
         parsedPropertyPaths = propertyPaths or []
+        for path in parsedPropertyPaths:
+            if path:
+                requireObjectId(path[0], "propertyPaths property id")
 
         parsedAnnotationIds = None
         if annotationIds is not None:
+            validateAnnotationIdCount(len(annotationIds))
             parsedAnnotationIds = [
-                ObjectId(aid) for aid in annotationIds
+                requireObjectId(aid, "annotationIds entry")
+                for aid in annotationIds
             ]
 
         # Validate delimiter
@@ -457,6 +472,11 @@ class Export(Resource):
             else:
                 headerRow.append(col.name)
         yield delimiter.join(headerRow) + '\n'
+
+        # An explicitly empty subset has no rows, so skip the dataset-wide
+        # property-values scan below entirely.
+        if parsedAnnotationIds is not None and not parsedAnnotationIds:
+            return
 
         # Load all property values for the dataset
         propertyValues = self._getPropertyValues(datasetObjectId)

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/server/api/export.py
@@ -319,7 +319,10 @@ class Export(Resource):
                     },
                     "annotationIds": {
                         "type": "array",
-                        "description": "Array of annotation IDs to filter",
+                        "description": (
+                            "Annotation IDs to export. Omit for all "
+                            "annotations; an empty array exports none."
+                        ),
                         "items": {"type": "string"}
                     },
                     "undefinedValue": {
@@ -384,7 +387,7 @@ class Export(Resource):
         parsedPropertyPaths = propertyPaths or []
 
         parsedAnnotationIds = None
-        if annotationIds:
+        if annotationIds is not None:
             parsedAnnotationIds = [
                 ObjectId(aid) for aid in annotationIds
             ]
@@ -543,10 +546,12 @@ class Export(Resource):
         return columns, includedPaths
 
     def _iterAnnotations(self, datasetId, annotationIds):
-        """Iterate annotations, chunking $in queries to stay under limit."""
-        if not annotationIds:
+        """Iterate annotations, preserving an explicitly empty subset."""
+        if annotationIds is None:
             for ann in self._annotationModel.find({"datasetId": datasetId}):
                 yield ann
+            return
+        if not annotationIds:
             return
 
         IN_CHUNK_SIZE = 500000

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
@@ -1,4 +1,7 @@
+import json
+
 import pytest
+from pytest_girder.assertions import assertStatusOk
 
 from upenncontrast_annotation.server.models.annotation import Annotation
 from upenncontrast_annotation.server.models.connections import (
@@ -148,6 +151,52 @@ class TestExport:
         ann1_id = str(annotations[0]["_id"])
         assert ann1_id in result["annotationPropertyValues"]
         assert "test_property" in result["annotationPropertyValues"][ann1_id]
+
+    def testIterAnnotationsDistinguishesNoneFromEmpty(self, admin):
+        """An omitted ID filter exports all; an empty subset exports none."""
+        dataset, annotations, _ = createDatasetWithData(admin)
+        export = Export()
+
+        assert len(list(export._iterAnnotations(dataset["_id"], None))) == 2
+
+        picked = [annotations[0]["_id"]]
+        assert [
+            annotation["_id"]
+            for annotation in export._iterAnnotations(
+                dataset["_id"], picked
+            )
+        ] == picked
+
+        assert list(export._iterAnnotations(dataset["_id"], [])) == []
+
+    def testExportCsvPreservesExactAnnotationSubset(
+        self, admin, server
+    ):
+        """The endpoint distinguishes all, one, and no annotations."""
+        dataset, annotations, _ = createDatasetWithData(admin)
+        baseBody = {
+            "datasetId": str(dataset["_id"]),
+            "propertyPaths": [],
+        }
+
+        def exportLines(annotationIds="omitted"):
+            body = baseBody.copy()
+            if annotationIds != "omitted":
+                body["annotationIds"] = annotationIds
+            response = server.request(
+                path="/export/csv",
+                method="POST",
+                user=admin,
+                body=json.dumps(body),
+                type="application/json",
+                isJson=False,
+            )
+            assertStatusOk(response)
+            return b"".join(response.body).decode().splitlines()
+
+        assert len(exportLines()) == 3
+        assert len(exportLines([str(annotations[0]["_id"])])) == 2
+        assert len(exportLines([])) == 1
 
     def testExportJsonWithConfiguration(self, admin):
         """Test export with a specific configuration."""

--- a/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
+++ b/devops/girder/plugins/AnnotationPlugin/upenncontrast_annotation/test/test_export.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from pytest_girder.assertions import assertStatusOk
+from pytest_girder.assertions import assertStatus, assertStatusOk
 
 from upenncontrast_annotation.server.models.annotation import Annotation
 from upenncontrast_annotation.server.models.connections import (
@@ -197,6 +197,77 @@ class TestExport:
         assert len(exportLines()) == 3
         assert len(exportLines([str(annotations[0]["_id"])])) == 2
         assert len(exportLines([])) == 1
+
+    def testEmptySubsetSkipsPropertyValueFetch(self, admin, monkeypatch):
+        """An explicitly empty subset must not scan property values."""
+        dataset, _, _ = createDatasetWithData(admin)
+        export = Export()
+
+        def failFetch(datasetId):
+            raise AssertionError(
+                "property values fetched for an empty subset"
+            )
+
+        monkeypatch.setattr(export, "_getPropertyValues", failFetch)
+        lines = list(export._generateCsvLines(
+            dataset["_id"], [], parsedAnnotationIds=[]
+        ))
+        assert len(lines) == 1  # header only
+
+    def testExportCsvRejectsMalformedInput(self, admin, server):
+        """Malformed ids must be a clean 400 on this public endpoint."""
+        dataset, _, _ = createDatasetWithData(admin)
+
+        def postCsv(body):
+            return server.request(
+                path="/export/csv",
+                method="POST",
+                user=admin,
+                body=json.dumps(body),
+                type="application/json",
+                isJson=False,
+            )
+
+        datasetId = str(dataset["_id"])
+        # Non-list annotationIds is caught by the jsonParam schema.
+        assertStatus(
+            postCsv({"datasetId": datasetId, "annotationIds": False}), 400
+        )
+        # A malformed id string passes the schema but must not 500.
+        assertStatus(
+            postCsv({"datasetId": datasetId, "annotationIds": ["nope"]}),
+            400,
+        )
+        assertStatus(postCsv({"datasetId": "nope"}), 400)
+        assertStatus(
+            postCsv({"datasetId": datasetId, "propertyPaths": [["nope"]]}),
+            400,
+        )
+
+    def testExportJsonRejectsMalformedIds(self, admin, server):
+        """The JSON export twin gets the same boundary validation."""
+        dataset, _, _ = createDatasetWithData(admin)
+
+        response = server.request(
+            path="/export/json",
+            method="GET",
+            user=admin,
+            params={"datasetId": "nope"},
+            isJson=False,
+        )
+        assertStatus(response, 400)
+
+        response = server.request(
+            path="/export/json",
+            method="GET",
+            user=admin,
+            params={
+                "datasetId": str(dataset["_id"]),
+                "configurationId": "nope",
+            },
+            isJson=False,
+        )
+        assertStatus(response, 400)
 
     def testExportJsonWithConfiguration(self, admin):
         """Test export with a specific configuration."""

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/store/annotation", () => ({
     annotations: [] as any[],
     annotationsForIteration: [] as any[],
     annotationCount: 0,
+    getAnnotationOrStubFromId: () => undefined,
     selectedAnnotationIds: new Set<string>(),
   },
 }));
@@ -112,19 +113,34 @@ const samplePropertyPaths = [
   ["propC", "sub3"],
 ];
 
+// defineProperty (not plain assignment) so a test that swapped a member for a
+// throwing accessor can still be reset by the next helper call.
+function defineStoreMember(key: string, value: any) {
+  Object.defineProperty(annotationStore, key, {
+    value,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+}
+
+function setStoreItems(items: any[], { stubOnly = false } = {}) {
+  const byId = new Map(items.map((item) => [item.id, item]));
+  defineStoreMember("annotations", stubOnly ? [] : items);
+  defineStoreMember("annotationsForIteration", items);
+  defineStoreMember("annotationCount", items.length);
+  defineStoreMember("getAnnotationOrStubFromId", (id: string) => byId.get(id));
+}
+
 // In full mode annotations, annotationsForIteration, and annotationCount all
 // describe the same collection; set them together so the mock can't drift.
 function setStoreAnnotations(annotations: any[]) {
-  (annotationStore as any).annotations = annotations;
-  (annotationStore as any).annotationsForIteration = annotations;
-  (annotationStore as any).annotationCount = annotations.length;
+  setStoreItems(annotations);
 }
 
 // Stub-only mode: annotations[] is empty by design, metadata lives in stubs.
 function setStoreStubs(stubs: any[]) {
-  (annotationStore as any).annotations = [];
-  (annotationStore as any).annotationsForIteration = stubs;
-  (annotationStore as any).annotationCount = stubs.length;
+  setStoreItems(stubs, { stubOnly: true });
 }
 
 function mountComponent(propsOverrides: any = {}) {
@@ -417,6 +433,38 @@ describe("AnnotationCSVDialog", () => {
       await vm.download();
       const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
       expect(arg.annotationIds).toEqual(["s1", "s2"]);
+    });
+
+    it("selected-scope download never materializes the stub iteration array", async () => {
+      // On a large dataset annotationsForIteration is an Array.from over the
+      // whole stub map; the download path already has the ids and must not
+      // pay that dataset-sized allocation-and-scan.
+      (annotationStore as any).selectedAnnotationIds = new Set(["s2"]);
+      Object.defineProperty(annotationStore, "annotationsForIteration", {
+        get() {
+          throw new Error("annotationsForIteration was materialized");
+        },
+        configurable: true,
+      });
+      const wrapper = mountComponent({ annotations: sampleStubs });
+      const vm = wrapper.vm as any;
+      vm.annotationScope = "selected";
+      vm.propertyExportMode = "all";
+      await vm.download();
+      const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+      expect(arg.annotationIds).toEqual(["s2"]);
+    });
+
+    it("selected-scope preview resolves stubs by id lookup", async () => {
+      (annotationStore as any).selectedAnnotationIds = new Set(["s1", "s3"]);
+      const wrapper = mountComponent({ annotations: sampleStubs });
+      const vm = wrapper.vm as any;
+      vm.annotationScope = "selected";
+      vm.propertyExportMode = "all";
+      const csv = await vm.generateCSVStringForAnnotations();
+      expect(csv).toContain("s1");
+      expect(csv).toContain("s3");
+      expect(csv).not.toContain("s2");
     });
 
     it("counts come from the stub-aware annotationCount", () => {

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -38,6 +38,8 @@ vi.mock("@/store/properties", () => ({
 vi.mock("@/store/annotation", () => ({
   default: {
     annotations: [] as any[],
+    annotationsForIteration: [] as any[],
+    annotationCount: 0,
     selectedAnnotationIds: new Set<string>(),
   },
 }));
@@ -110,6 +112,21 @@ const samplePropertyPaths = [
   ["propC", "sub3"],
 ];
 
+// In full mode annotations, annotationsForIteration, and annotationCount all
+// describe the same collection; set them together so the mock can't drift.
+function setStoreAnnotations(annotations: any[]) {
+  (annotationStore as any).annotations = annotations;
+  (annotationStore as any).annotationsForIteration = annotations;
+  (annotationStore as any).annotationCount = annotations.length;
+}
+
+// Stub-only mode: annotations[] is empty by design, metadata lives in stubs.
+function setStoreStubs(stubs: any[]) {
+  (annotationStore as any).annotations = [];
+  (annotationStore as any).annotationsForIteration = stubs;
+  (annotationStore as any).annotationCount = stubs.length;
+}
+
 function mountComponent(propsOverrides: any = {}) {
   return shallowMount(AnnotationCSVDialog, {
     props: {
@@ -136,7 +153,7 @@ describe("AnnotationCSVDialog", () => {
       batchFetchResources: vi.fn().mockResolvedValue(undefined),
       watchFolder: vi.fn().mockReturnValue({ name: "Folder" }),
     };
-    (annotationStore as any).annotations = sampleAnnotations;
+    setStoreAnnotations(sampleAnnotations);
     (annotationStore as any).selectedAnnotationIds = new Set<string>();
     (propertyStore as any).displayedPropertyPaths = [["propA", "sub1"]];
     (propertyStore as any).getFullNameFromPath = vi.fn((path: string[]) => {
@@ -168,7 +185,7 @@ describe("AnnotationCSVDialog", () => {
       datasetId: "ds1",
       color: null,
     }));
-    (annotationStore as any).annotations = manyAnnotations;
+    setStoreAnnotations(manyAnnotations);
     const wrapper = mountComponent({ annotations: manyAnnotations });
     const vm = wrapper.vm as any;
     expect(vm.isTooLargeForPreview).toBe(true);
@@ -294,6 +311,7 @@ describe("AnnotationCSVDialog", () => {
       datasetId: "ds1",
       color: null,
     }));
+    setStoreAnnotations(manyAnnotations);
     const wrapper = mountComponent({ annotations: manyAnnotations });
     const vm = wrapper.vm as any;
     vm.dialog = true;
@@ -339,6 +357,75 @@ describe("AnnotationCSVDialog", () => {
     // When exporting all annotations (not a subset), annotationIds is omitted
     // to avoid exceeding MongoDB's BSON size limit
     expect(arg.annotationIds).toBeUndefined();
+  });
+
+  it("download sends the selected subset's ids", async () => {
+    (annotationStore as any).selectedAnnotationIds = new Set(["ann1"]);
+    const wrapper = mountComponent();
+    const vm = wrapper.vm as any;
+    vm.annotationScope = "selected";
+    vm.propertyExportMode = "all";
+    await vm.download();
+    const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+    expect(arg.annotationIds).toEqual(["ann1"]);
+  });
+
+  describe("stub-only mode", () => {
+    // In stub-only mode annotationStore.annotations is empty by design; the
+    // dialog must derive scopes from the stub-aware store members instead.
+    const sampleStubs = ["s1", "s2", "s3"].map((id) => ({
+      id,
+      centroid: { x: 0, y: 0 },
+      location: { XY: 0, Z: 0, Time: 0 },
+      shape: "polygon",
+      channel: 0,
+      tags: [],
+      color: null,
+    }));
+
+    beforeEach(() => {
+      setStoreStubs(sampleStubs);
+    });
+
+    it("selected scope sends the selected ids, not an omitted field", async () => {
+      (annotationStore as any).selectedAnnotationIds = new Set(["s1", "s3"]);
+      const wrapper = mountComponent({ annotations: sampleStubs });
+      const vm = wrapper.vm as any;
+      vm.annotationScope = "selected";
+      vm.propertyExportMode = "all";
+      await vm.download();
+      const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+      expect(arg.annotationIds).toEqual(["s1", "s3"]);
+    });
+
+    it("all scope still omits annotationIds", async () => {
+      const wrapper = mountComponent({ annotations: sampleStubs });
+      const vm = wrapper.vm as any;
+      vm.annotationScope = "all";
+      vm.propertyExportMode = "all";
+      await vm.download();
+      const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+      expect(arg.annotationIds).toBeUndefined();
+    });
+
+    it("filtered scope sends the filtered ids", async () => {
+      const filteredStubs = sampleStubs.slice(0, 2);
+      const wrapper = mountComponent({ annotations: filteredStubs });
+      const vm = wrapper.vm as any;
+      vm.annotationScope = "filtered";
+      vm.propertyExportMode = "all";
+      await vm.download();
+      const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+      expect(arg.annotationIds).toEqual(["s1", "s2"]);
+    });
+
+    it("counts come from the stub-aware annotationCount", () => {
+      const wrapper = mountComponent({ annotations: sampleStubs.slice(0, 1) });
+      const vm = wrapper.vm as any;
+      expect(vm.allAnnotationCount).toBe(3);
+      // One of three passes the filter, so the filtered radio is enabled.
+      expect(vm.hasActiveFilter).toBe(true);
+    });
   });
 
   it("generateCSVStringForAnnotations produces CSV with headers", async () => {

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -467,6 +467,32 @@ describe("AnnotationCSVDialog", () => {
       expect(csv).not.toContain("s2");
     });
 
+    it("filtered-scope count/preview guard never allocates the id array", async () => {
+      // Twin of the selected-scope allocation test: with a filter matching
+      // hundreds of thousands of stubs, the count and preview-limit checks
+      // must read props.annotations.length only; the dataset-sized id array
+      // may be built exactly once, at download time.
+      const filteredStubs = sampleStubs.slice(0, 2);
+      let mapCalls = 0;
+      const spiedAnnotations = Object.assign([...filteredStubs], {
+        map(...args: Parameters<typeof Array.prototype.map>) {
+          mapCalls++;
+          return Array.prototype.map.apply(this, args);
+        },
+      });
+      const wrapper = mountComponent({ annotations: spiedAnnotations });
+      const vm = wrapper.vm as any;
+      vm.annotationScope = "filtered";
+      vm.propertyExportMode = "all";
+      expect(vm.exportAnnotationCount).toBe(2);
+      expect(vm.isTooLargeForPreview).toBe(false);
+      expect(mapCalls).toBe(0);
+      await vm.download();
+      const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+      expect(arg.annotationIds).toEqual(["s1", "s2"]);
+      expect(mapCalls).toBe(1);
+    });
+
     it("stale selected ids never widen the export to the whole dataset", async () => {
       // A deleted annotation can linger in selectedAnnotationIds (e.g. a
       // context-menu delete, or an undo). If stale ids counted toward the

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.test.ts
@@ -467,6 +467,26 @@ describe("AnnotationCSVDialog", () => {
       expect(csv).not.toContain("s2");
     });
 
+    it("stale selected ids never widen the export to the whole dataset", async () => {
+      // A deleted annotation can linger in selectedAnnotationIds (e.g. a
+      // context-menu delete, or an undo). If stale ids counted toward the
+      // "is this the whole dataset" comparison, selecting 1 live + 1 stale
+      // id in a 2-annotation dataset would omit annotationIds and export
+      // everything.
+      setStoreStubs(sampleStubs.slice(0, 2)); // s1, s2 live
+      (annotationStore as any).selectedAnnotationIds = new Set([
+        "s1",
+        "deleted-id",
+      ]);
+      const wrapper = mountComponent({ annotations: sampleStubs.slice(0, 2) });
+      const vm = wrapper.vm as any;
+      vm.annotationScope = "selected";
+      vm.propertyExportMode = "all";
+      await vm.download();
+      const arg = (store.exportAPI.exportCsv as any).mock.calls[0][0];
+      expect(arg.annotationIds).toEqual(["s1"]);
+    });
+
     it("counts come from the stub-aware annotationCount", () => {
       const wrapper = mountComponent({ annotations: sampleStubs.slice(0, 1) });
       const vm = wrapper.vm as any;

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -400,7 +400,14 @@ const bulkExportError = ref("");
 // O(subset) even when the stub map holds the whole dataset.
 const exportAnnotationIds = computed((): string[] | null => {
   if (annotationScope.value === "selected") {
-    return Array.from(annotationStore.selectedAnnotationIds);
+    // Drop selection ids that no longer resolve (a delete or undo can leave
+    // stale ids behind): counted against annotationCount below, a stale id
+    // could make a real subset look like the whole dataset and silently
+    // widen the export.
+    const resolve = annotationStore.getAnnotationOrStubFromId;
+    return Array.from(annotationStore.selectedAnnotationIds).filter(
+      (id) => resolve(id) !== undefined,
+    );
   }
   if (annotationScope.value === "filtered") {
     return props.annotations.map((annotation) => annotation.id);

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -415,22 +415,32 @@ const exportAnnotationIds = computed((): string[] | null => {
   return null;
 });
 
-const exportAnnotationCount = computed(() =>
-  exportAnnotationIds.value === null
-    ? annotationStore.annotationCount
-    : exportAnnotationIds.value.length,
-);
+// Count without building the id array: the filter can match hundreds of
+// thousands of stubs, and this drives the count label and preview-limit
+// guard on every render. Only the "selected" branch touches
+// exportAnnotationIds, whose selected path is O(selection).
+const exportAnnotationCount = computed(() => {
+  if (annotationScope.value === "filtered") {
+    return props.annotations.length;
+  }
+  if (annotationScope.value === "selected") {
+    return exportAnnotationIds.value?.length ?? 0;
+  }
+  return annotationStore.annotationCount;
+});
 
 // Annotation rows for the client-side preview. Only read when the export is
 // within PREVIEW_ANNOTATION_LIMIT (the count check above never materializes
-// anything), so the id lookups here stay bounded by the preview limit.
+// anything), so the id lookups here stay bounded by the preview limit. The
+// filtered branch comes first so this never evaluates exportAnnotationIds'
+// dataset-sized filtered id array.
 const annotationsToExport = computed((): TAnnotationOrStub[] => {
+  if (annotationScope.value === "filtered") {
+    return props.annotations;
+  }
   const ids = exportAnnotationIds.value;
   if (ids === null) {
     return annotationStore.annotationsForIteration;
-  }
-  if (annotationScope.value === "filtered") {
-    return props.annotations;
   }
   const resolve = annotationStore.getAnnotationOrStubFromId;
   return ids

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -172,7 +172,7 @@
             <v-alert type="info" variant="tonal" class="mb-4">
               Preview is not available for more than
               {{ PREVIEW_ANNOTATION_LIMIT }} annotations ({{
-                annotationsToExport.length
+                exportAnnotationCount
               }}
               annotations to export). Download will export using the server.
             </v-alert>
@@ -394,22 +394,48 @@ const bulkExporting = ref(false);
 const bulkExportProgress = ref(0);
 const bulkExportError = ref("");
 
-const annotationsToExport = computed((): TAnnotationOrStub[] => {
+// The ids to export; null means "every annotation" (the download omits the
+// field so the backend exports all without a dataset-sized $in query). Ids
+// only — never resolves annotation objects, so a subset download costs
+// O(subset) even when the stub map holds the whole dataset.
+const exportAnnotationIds = computed((): string[] | null => {
   if (annotationScope.value === "selected") {
-    const ids = annotationStore.selectedAnnotationIds;
-    return annotationStore.annotationsForIteration.filter((a) => ids.has(a.id));
+    return Array.from(annotationStore.selectedAnnotationIds);
+  }
+  if (annotationScope.value === "filtered") {
+    return props.annotations.map((annotation) => annotation.id);
+  }
+  return null;
+});
+
+const exportAnnotationCount = computed(() =>
+  exportAnnotationIds.value === null
+    ? annotationStore.annotationCount
+    : exportAnnotationIds.value.length,
+);
+
+// Annotation rows for the client-side preview. Only read when the export is
+// within PREVIEW_ANNOTATION_LIMIT (the count check above never materializes
+// anything), so the id lookups here stay bounded by the preview limit.
+const annotationsToExport = computed((): TAnnotationOrStub[] => {
+  const ids = exportAnnotationIds.value;
+  if (ids === null) {
+    return annotationStore.annotationsForIteration;
   }
   if (annotationScope.value === "filtered") {
     return props.annotations;
   }
-  return annotationStore.annotationsForIteration;
+  const resolve = annotationStore.getAnnotationOrStubFromId;
+  return ids
+    .map(resolve)
+    .filter((annotation): annotation is TAnnotationOrStub => !!annotation);
 });
 
 const { loadingDatasets, collectionDatasets, configuration, allDatasetsLabel } =
   useCollectionDatasets(dialog, exportScope);
 
 const isTooLargeForPreview = computed(() => {
-  return annotationsToExport.value.length > PREVIEW_ANNOTATION_LIMIT;
+  return exportAnnotationCount.value > PREVIEW_ANNOTATION_LIMIT;
 });
 
 const canUseClipboard = computed(() => {
@@ -635,15 +661,14 @@ async function downloadSingleDataset() {
   try {
     // Only send annotationIds when exporting a subset, to avoid
     // exceeding MongoDB's 16MB BSON query size limit.
-    const exportAnnotations = annotationsToExport.value;
-    const isSubset = exportAnnotations.length < annotationStore.annotationCount;
+    const exportIds = exportAnnotationIds.value;
+    const isSubset =
+      exportIds !== null && exportIds.length < annotationStore.annotationCount;
 
     await store.exportAPI.exportCsv({
       datasetId: store.dataset.id,
       propertyPaths: getIncludedPropertyPaths(),
-      ...(isSubset
-        ? { annotationIds: exportAnnotations.map((a) => a.id) }
-        : {}),
+      ...(isSubset ? { annotationIds: exportIds } : {}),
       undefinedValue: getUndefinedValueString(),
       delimiter: fileDelimiter.value,
       sanitizeColumnNames: sanitizeColumnNames.value,

--- a/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
+++ b/src/components/AnnotationBrowser/AnnotationCSVDialog.vue
@@ -376,13 +376,17 @@ const isDownloading = ref(false);
 
 const annotationScope = ref<"all" | "filtered" | "selected">("all");
 
-const allAnnotationCount = computed(() => annotationStore.annotations.length);
+// Counts and scopes read the stub-aware store members (annotationCount,
+// annotationsForIteration): in stub-only mode annotations[] is empty by
+// design, and deriving from it would silently turn a subset export into a
+// full export.
+const allAnnotationCount = computed(() => annotationStore.annotationCount);
 const filteredAnnotationCount = computed(() => props.annotations.length);
 const selectedAnnotationCount = computed(
   () => annotationStore.selectedAnnotationIds.size,
 );
 const hasActiveFilter = computed(
-  () => props.annotations.length < annotationStore.annotations.length,
+  () => props.annotations.length < annotationStore.annotationCount,
 );
 
 const exportScope = ref<"current" | "all">("current");
@@ -390,15 +394,15 @@ const bulkExporting = ref(false);
 const bulkExportProgress = ref(0);
 const bulkExportError = ref("");
 
-const annotationsToExport = computed(() => {
+const annotationsToExport = computed((): TAnnotationOrStub[] => {
   if (annotationScope.value === "selected") {
     const ids = annotationStore.selectedAnnotationIds;
-    return annotationStore.annotations.filter((a) => ids.has(a.id));
+    return annotationStore.annotationsForIteration.filter((a) => ids.has(a.id));
   }
   if (annotationScope.value === "filtered") {
     return props.annotations;
   }
-  return annotationStore.annotations;
+  return annotationStore.annotationsForIteration;
 });
 
 const { loadingDatasets, collectionDatasets, configuration, allDatasetsLabel } =
@@ -632,8 +636,7 @@ async function downloadSingleDataset() {
     // Only send annotationIds when exporting a subset, to avoid
     // exceeding MongoDB's 16MB BSON query size limit.
     const exportAnnotations = annotationsToExport.value;
-    const isSubset =
-      exportAnnotations.length < annotationStore.annotations.length;
+    const isSubset = exportAnnotations.length < annotationStore.annotationCount;
 
     await store.exportAPI.exportCsv({
       datasetId: store.dataset.id,

--- a/src/store/ExportAPI.test.ts
+++ b/src/store/ExportAPI.test.ts
@@ -50,6 +50,20 @@ describe("ExportAPI", () => {
       const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
       expect(body.sanitizeColumnNames).toBe(false);
     });
+
+    it("omits annotationIds when no subset is supplied", async () => {
+      await api.exportCsv({ datasetId: "ds1" });
+
+      const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+      expect(body).not.toHaveProperty("annotationIds");
+    });
+
+    it("preserves an explicitly empty annotation subset", async () => {
+      await api.exportCsv({ datasetId: "ds1", annotationIds: [] });
+
+      const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+      expect(body.annotationIds).toEqual([]);
+    });
   });
 
   describe("exportBulkCsv", () => {

--- a/src/store/ExportAPI.ts
+++ b/src/store/ExportAPI.ts
@@ -129,7 +129,11 @@ export default class ExportAPI {
     const body = {
       datasetId: options.datasetId,
       propertyPaths: options.propertyPaths || [],
-      annotationIds: options.annotationIds || [],
+      // Omitting the field means "every annotation"; a present array is an
+      // exact subset, including the empty subset.
+      ...(options.annotationIds !== undefined
+        ? { annotationIds: options.annotationIds }
+        : {}),
       undefinedValue: options.undefinedValue ?? "",
       delimiter: options.delimiter || ",",
       sanitizeColumnNames: options.sanitizeColumnNames ?? false,

--- a/src/store/annotation-delete.test.ts
+++ b/src/store/annotation-delete.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for deletion-state cleanup in the annotation store.
+ *
+ * Bug (PR #1299 review, finding F5): `deleteAnnotations` removed the
+ * annotation/stub but left the deleted id in `selectedAnnotationIds` (only
+ * the `deleteSelectedAnnotations` wrapper cleared the selection) and left a
+ * dangling `hoveredAnnotationId`. A stale selected id then counted toward
+ * the CSV export's subset-vs-whole-dataset comparison and could silently
+ * widen a subset export to the whole dataset.
+ *
+ * These tests exercise the REAL store module (the CSV dialog test mocks the
+ * store, so it cannot catch a regression in the pruning itself), in both
+ * full and stub-only modes — a direct `deleteAnnotations([id])` is exactly
+ * what the context-menu delete dispatches.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// deleteAnnotations only touches these dependencies; mock them to avoid
+// pulling in the full store/geojs graph.
+vi.mock("./index", () => ({
+  default: {
+    isLoggedIn: true,
+    dataset: null,
+    annotationsAPI: {
+      deleteMultipleAnnotations: vi.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+vi.mock("./sync", () => ({
+  default: { setSaving: vi.fn() },
+}));
+vi.mock("./jobs", () => ({
+  default: {},
+  createProgressEventCallback: () => () => {},
+  createErrorEventCallback: () => () => {},
+}));
+vi.mock("./progress", () => ({
+  default: {
+    create: vi.fn().mockResolvedValue("progress-1"),
+    complete: vi.fn(),
+  },
+}));
+vi.mock("geojs", () => ({
+  default: { util: { pointInPolygon: () => false } },
+}));
+// Imported for a type only, but the import is not type-only, so it would
+// pull the tool-creation component graph into this unit test.
+vi.mock("@/tools/creation/templates/AnnotationConfiguration.vue", () => ({}));
+
+import annotationStore from "./annotation";
+import { AnnotationShape } from "./model";
+
+function makeAnnotation(id: string) {
+  return {
+    id,
+    channel: 0,
+    location: { XY: 0, Z: 0, Time: 0 },
+    coordinates: [{ x: 0, y: 0 }],
+    shape: AnnotationShape.Point,
+    tags: [],
+    datasetId: "ds",
+    name: null,
+    color: null,
+  };
+}
+
+function makeStub(id: string) {
+  return {
+    id,
+    centroid: { x: 0, y: 0 },
+    location: { XY: 0, Z: 0, Time: 0 },
+    shape: AnnotationShape.Polygon,
+    channel: 0,
+    tags: [],
+    color: null,
+  };
+}
+
+describe("deleteAnnotations state cleanup", () => {
+  beforeEach(() => {
+    annotationStore.setAnnotations([]);
+    annotationStore.setStubOnlyMode(false);
+    annotationStore.setSelected([]);
+    annotationStore.setHoveredAnnotationId(null);
+  });
+
+  it("prunes deleted ids from the selection in full mode", async () => {
+    annotationStore.setAnnotations([
+      makeAnnotation("a"),
+      makeAnnotation("b"),
+      makeAnnotation("c"),
+    ]);
+    annotationStore.setSelected(["a", "c"]);
+    await annotationStore.deleteAnnotations(["c"]);
+    expect([...annotationStore.selectedAnnotationIds]).toEqual(["a"]);
+    expect(annotationStore.annotations.map((a) => a.id)).toEqual(["a", "b"]);
+  });
+
+  it("clears the hovered id when the hovered annotation is deleted", async () => {
+    annotationStore.setAnnotations([makeAnnotation("a"), makeAnnotation("b")]);
+    annotationStore.setHoveredAnnotationId("b");
+    await annotationStore.deleteAnnotations(["b"]);
+    expect(annotationStore.hoveredAnnotationId).toBeNull();
+  });
+
+  it("keeps an unrelated hovered id and selection", async () => {
+    annotationStore.setAnnotations([makeAnnotation("a"), makeAnnotation("b")]);
+    annotationStore.setSelected(["a"]);
+    annotationStore.setHoveredAnnotationId("a");
+    await annotationStore.deleteAnnotations(["b"]);
+    expect([...annotationStore.selectedAnnotationIds]).toEqual(["a"]);
+    expect(annotationStore.hoveredAnnotationId).toBe("a");
+  });
+
+  it("prunes selection, hover, and the stub map in stub-only mode", async () => {
+    annotationStore.setStubsFromServer([makeStub("s1"), makeStub("s2")]);
+    annotationStore.setStubOnlyMode(true);
+    annotationStore.setSelected(["s1", "s2"]);
+    annotationStore.setHoveredAnnotationId("s2");
+    await annotationStore.deleteAnnotations(["s2"]);
+    expect([...annotationStore.selectedAnnotationIds]).toEqual(["s1"]);
+    expect(annotationStore.hoveredAnnotationId).toBeNull();
+    expect(annotationStore.annotationStubs.has("s2")).toBe(false);
+    expect(annotationStore.annotationCount).toBe(1);
+  });
+});

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -171,6 +171,27 @@ export class Annotations extends VuexModule {
     };
   }
 
+  /**
+   * Resolve an id to whatever representation is loaded — hydrated, full, or
+   * raw stub — without materializing the whole stub map. Unlike
+   * `getAnnotationFromId`, this returns non-point stubs as-is (typed as the
+   * honest union), so callers that only need stub fields can look ids up in
+   * O(1) instead of scanning `annotationsForIteration`.
+   */
+  get getAnnotationOrStubFromId() {
+    return (annotationId: string): TAnnotationOrStub | undefined => {
+      const hydrated = this.hydratedAnnotations.get(annotationId);
+      if (hydrated) {
+        return hydrated;
+      }
+      const idx = this.annotationIdToIdx[annotationId];
+      if (idx !== undefined) {
+        return this.annotations[idx];
+      }
+      return this.annotationStubs.get(annotationId);
+    };
+  }
+
   get annotationTags() {
     const tagSet: Set<string> = new Set();
     if (this.stubOnlyMode) {

--- a/src/store/annotation.ts
+++ b/src/store/annotation.ts
@@ -1386,6 +1386,17 @@ export class Annotations extends VuexModule {
           ),
         );
       }
+      // Prune id-holding UI state so nothing keeps referencing the deleted
+      // annotations (a stale selection id can widen a subset CSV export to
+      // the whole dataset; a stale hover id dangles like the connection-list
+      // case did).
+      this.unselectAnnotations(ids);
+      if (
+        this.hoveredAnnotationId !== null &&
+        ids.includes(this.hoveredAnnotationId)
+      ) {
+        this.setHoveredAnnotationId(null);
+      }
     } finally {
       // Always set the state back to false, even if there's an error
       sync.setSaving(false);


### PR DESCRIPTION
## Summary

- define `annotationIds` as an exact optional CSV export subset: omitted exports all, a non-empty array exports those annotations, and an empty array exports none
- preserve that distinction in the frontend request serializer and backend iterator
- document the endpoint contract and cover it at both the client and live endpoint boundaries

## Root cause

The client converted an omitted ID filter to `[]`, while the backend treated both omitted and empty lists as “export all.” Any filtered export resolving to zero annotations could therefore silently download the whole dataset—the opposite of the requested scope.

## Impact

Existing “Export all” and non-empty subset exports are unchanged. An explicitly empty filtered subset now produces a header-only CSV instead of exporting every annotation.

## Validation

- `pnpm test src/store/ExportAPI.test.ts --run` — 11 passed
- backend export tests — 32 passed
- `pnpm tsc`
- `pnpm lint:ci`
- `flake8` on the two touched Python files
- full backend suite — 359 passed; one unrelated MongoDB setup error occurred in `testUpdateIgnoresUnknownFields`, and that test passed immediately when rerun alone