### PR TITLE
Block mixed-dtype multi-source datasets

### DIFF
--- a/src/store/GirderAPI.ts
+++ b/src/store/GirderAPI.ts
@@ -1346,6 +1346,7 @@ export interface IHistogramOptions {
 
 export interface ITileMeta {
   [x: string]: any;
+  dtype?: string;
   IndexRange: any;
   levels: number;
   magnification: number;

--- a/src/views/dataset/MultiSourceConfiguration.test.ts
+++ b/src/views/dataset/MultiSourceConfiguration.test.ts
@@ -756,7 +756,7 @@ describe("MultiSourceConfiguration", () => {
       vm.tilesMetadata = [{ dtype: "uint16" }, { dtype: "uint8" }];
 
       expect(vm.submitError).toBe(
-        "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them.",
+        "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them. You will need to start over.",
       );
     });
 
@@ -1845,11 +1845,11 @@ describe("MultiSourceConfiguration", () => {
       expect(result).toBeNull();
       expect(mockAddMultiSourceMetadata).not.toHaveBeenCalled();
       expect(vm.generationErrorMessage).toBe(
-        "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them.",
+        "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them. You will need to start over.",
       );
       expect(wrapper.emitted("generationError")).toEqual([
         [
-          "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them.",
+          "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them. You will need to start over.",
         ],
       ]);
     });

--- a/src/views/dataset/MultiSourceConfiguration.test.ts
+++ b/src/views/dataset/MultiSourceConfiguration.test.ts
@@ -749,6 +749,26 @@ describe("MultiSourceConfiguration", () => {
   });
 
   describe("submitError", () => {
+    it("returns an error when source images use different pixel types", () => {
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      vm.initializing = false;
+      vm.tilesMetadata = [{ dtype: "uint16" }, { dtype: "uint8" }];
+
+      expect(vm.submitError).toBe(
+        "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them.",
+      );
+    });
+
+    it("allows source images with the same pixel type", () => {
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      vm.initializing = false;
+      vm.tilesMetadata = [{ dtype: "uint16" }, { dtype: "UINT16" }];
+
+      expect(vm.submitError).toBeNull();
+    });
+
     it("returns error when submit not enabled", () => {
       const wrapper = mountComponent();
       const vm = wrapper.vm as any;
@@ -1809,6 +1829,29 @@ describe("MultiSourceConfiguration", () => {
 
       const result = await vm.generateJson();
       expect(result).toBeNull();
+    });
+
+    it("blocks generation when source images use different pixel types", async () => {
+      const wrapper = mountComponent();
+      const vm = wrapper.vm as any;
+      await setupForSubmit(vm);
+      vm.tilesMetadata = [
+        { dtype: "uint16", frames: [{ Index: 0 }] },
+        { dtype: "uint8", frames: [{ Index: 0 }] },
+      ];
+
+      const result = await vm.generateJson();
+
+      expect(result).toBeNull();
+      expect(mockAddMultiSourceMetadata).not.toHaveBeenCalled();
+      expect(vm.generationErrorMessage).toBe(
+        "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them.",
+      );
+      expect(wrapper.emitted("generationError")).toEqual([
+        [
+          "Source images use different pixel types (uint16, uint8). Convert all source images to the same pixel type before combining them.",
+        ],
+      ]);
     });
 
     it("handles channel names from filename source", async () => {

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -1,5 +1,14 @@
 <template>
   <v-container>
+    <v-alert
+      v-if="mixedSourceDtypeError"
+      type="error"
+      variant="tonal"
+      density="compact"
+      class="my-4"
+    >
+      {{ mixedSourceDtypeError }}
+    </v-alert>
     <v-card class="pa-4 my-4">
       <v-list-subheader
         :data-tour="TOUR_ANCHORS.variables"
@@ -149,6 +158,15 @@
         density="compact"
       />
     </v-card>
+    <v-alert
+      v-if="assignmentError && !initializing"
+      type="error"
+      variant="tonal"
+      density="compact"
+      class="my-4"
+    >
+      {{ assignmentError }}
+    </v-alert>
     <v-card v-if="initializing" class="my-4">
       <v-card-title class="d-flex align-center">
         <v-progress-circular
@@ -350,18 +368,6 @@
       </div>
     </v-card>
     <v-row>
-      <v-col class="d-flex">
-        <v-alert
-          v-if="submitError"
-          type="error"
-          variant="tonal"
-          density="compact"
-          class="mr-4"
-        >
-          {{ submitError }}
-        </v-alert>
-        <v-spacer />
-      </v-col>
       <v-col class="d-flex justify-end">
         <v-checkbox
           :data-tour="TOUR_ANCHORS.transcodeCheckbox"
@@ -918,13 +924,10 @@ const mixedSourceDtypeError = computed((): string | null => {
   }
   return `Source images use different pixel types (${sourceDtypes.value.join(
     ", ",
-  )}). Convert all source images to the same pixel type before combining them.`;
+  )}). Convert all source images to the same pixel type before combining them. You will need to start over.`;
 });
 
-const submitError = computed((): string | null => {
-  if (mixedSourceDtypeError.value) {
-    return mixedSourceDtypeError.value;
-  }
+const assignmentError = computed((): string | null => {
   if (!submitEnabled()) {
     return "Not all variables are assigned";
   }
@@ -933,6 +936,10 @@ const submitError = computed((): string | null => {
   }
   return null;
 });
+
+const submitError = computed(
+  (): string | null => mixedSourceDtypeError.value ?? assignmentError.value,
+);
 
 const isRGBAssignmentValid = computed(() => {
   if (isMultiBandRGBFile.value && splitRGBBands.value) {

--- a/src/views/dataset/MultiSourceConfiguration.vue
+++ b/src/views/dataset/MultiSourceConfiguration.vue
@@ -378,7 +378,7 @@
           color="success"
           size="small"
           @click="submit"
-          :disabled="!submitEnabled() || !isRGBAssignmentValid || isUploading"
+          :disabled="!!submitError || isUploading"
         >
           <v-progress-circular size="16" v-if="isUploading" indeterminate />
           Submit
@@ -898,7 +898,33 @@ const assignmentItems = computed(() => {
     .map(assignmentOptionToAssignmentItem);
 });
 
+const sourceDtypes = computed(() =>
+  Array.from(
+    new Set(
+      (tilesMetadata.value ?? [])
+        .map((tile) =>
+          typeof tile.dtype === "string"
+            ? tile.dtype.trim().toLowerCase()
+            : null,
+        )
+        .filter((dtype): dtype is string => !!dtype),
+    ),
+  ),
+);
+
+const mixedSourceDtypeError = computed((): string | null => {
+  if (sourceDtypes.value.length <= 1) {
+    return null;
+  }
+  return `Source images use different pixel types (${sourceDtypes.value.join(
+    ", ",
+  )}). Convert all source images to the same pixel type before combining them.`;
+});
+
 const submitError = computed((): string | null => {
+  if (mixedSourceDtypeError.value) {
+    return mixedSourceDtypeError.value;
+  }
   if (!submitEnabled()) {
     return "Not all variables are assigned";
   }
@@ -1546,6 +1572,12 @@ async function submit() {
 }
 
 async function generateJson(): Promise<string | null> {
+  if (mixedSourceDtypeError.value) {
+    generationErrorMessage.value = mixedSourceDtypeError.value;
+    emit("generationError", generationErrorMessage.value);
+    return null;
+  }
+
   let channels: string[] | null = null;
   const channelAssignment = assignments.C?.value;
   if (channelAssignment) {


### PR DESCRIPTION
## What

- detect distinct source pixel types from each source image's tile metadata
- show incompatible-source errors prominently above Variables
- show assignment-specific validation between Variables and Assignments
- explicitly tell users with mixed source dtypes that they need to start over
- disable Submit when the source dtypes differ
- guard `generateJson()` as well, so quick-import and batch/programmatic submission paths cannot bypass the UI
- document `dtype` on `ITileMeta` and add regression coverage for mixed, matching, and case-normalized dtypes

## Why

Mixed-dtype sources are currently flattened into a TIFF with pages that do not form one consistent tifffile series. The odd-dtype page is dropped on read-back, producing non-contiguous channel indices and an unreadable large image.

This PR takes the conservative frontend approach: it prevents creation rather than silently choosing an intensity-conversion policy. A backend solution is feasible by promoting all sources to a common widest dtype with a straight cast (ideally through large_image's multi-source read path), but that data-policy change should be implemented and validated separately.

Fixes #1308.

## Impact

Users now get a prominent, actionable error before dataset creation instead of a dataset whose tile, histogram, and cache requests fail. Validation messages are placed next to the part of the configuration they describe, and same-dtype multi-source datasets are unchanged.

## Checks

- `pnpm tsc`
- `pnpm lint:ci`
- `pnpm exec vitest run src/views/dataset/MultiSourceConfiguration.test.ts --exclude '**/.claude/**' --exclude '**/.tox/**' --silent=passed-only` — 146 passed
- frontend suite excluding the repository-wide regression-checklist scanner — 189 files / 3,271 tests passed
- live browser verification on issue fixture `6a713f45c8e0001eaff7da25`:
  - mixed-`uint8`/`uint16` alert appears above Variables and includes the start-over instruction
  - assignment validation appears immediately before Assignments
  - Submit remains disabled

Known environment-only exception: `src/__tests__/regressionChecklist.test.ts` reports one failure because it recursively discovers Python test trees in the user-owned nested worktree at `.claude/worktrees/empty-csv-export-review-5280a3`. Its other 30 assertions pass; no files in that worktree are part of this PR.