### PR TITLE
Validate worker roles before submission to prevent accessor mismatches

### DIFF
--- a/.agents/skills/nimbusimage-analyze/references/gotchas.md
+++ b/.agents/skills/nimbusimage-analyze/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/.agents/skills/nimbusimage-analyze/references/gotchas.md
+++ b/.agents/skills/nimbusimage-analyze/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/.agents/skills/nimbusimage-annotations/references/gotchas.md
+++ b/.agents/skills/nimbusimage-annotations/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/.agents/skills/nimbusimage-annotations/references/gotchas.md
+++ b/.agents/skills/nimbusimage-annotations/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/.agents/skills/nimbusimage-images/references/gotchas.md
+++ b/.agents/skills/nimbusimage-images/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/.agents/skills/nimbusimage-images/references/gotchas.md
+++ b/.agents/skills/nimbusimage-images/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/.agents/skills/nimbusimage-workers/SKILL.md
+++ b/.agents/skills/nimbusimage-workers/SKILL.md
@@ -18,6 +18,41 @@ There are two kinds of workers:
 - **Annotation workers** — create annotations (points, polygons) on image data
 - **Property workers** — compute measurement values for existing annotations
 
+## RULE: worker accessors are NOT interchangeable
+
+Each worker kind has its own accessor, and they submit to **different endpoints with different payload formats**:
+
+- **Annotation workers** → `ds.annotations.compute(...)` → `POST /upenn_annotation/compute`
+- **Property workers** → create/get a `Property`, then `ds.properties.compute(prop, ...)` → `POST /annotation_property/{id}/compute`
+
+**Never** pass a property-worker image to `ds.annotations.compute`, and **never** pass an annotation-worker image to `ds.properties.compute`. Neither accessor validates the worker's role, so the job submits fine and then crashes inside the worker with a confusing error.
+
+The wire formats differ in a way that makes the crash recognizable:
+
+- Annotation compute sends a **list-valued** top-level `tags` field — the tags to put on *created* annotations — plus `assignment`, `tile`, `connectTo`, `type="worker"`, and `id=""`.
+- Property compute sends `tags` as a **dict**: `{"tags": [...], "exclusive": bool}` — an annotation *filter* selecting which existing annotations to measure.
+
+So if a property worker crashes with `AttributeError: 'list' object has no attribute 'get'` while reading `tags`, and its payload contains `assignment`/`tile`/`connectTo`, list-valued `tags`, `type="worker"`, and `id=""` — that is an **accessor/endpoint mismatch**: the job was submitted through `ds.annotations.compute`. It is *not* malformed tag serialization to be normalized inside the worker; fix the caller, not the worker.
+
+```python
+# WRONG — blob_intensity_worker is a PROPERTY worker; this submits an
+# annotation-compute payload (list-valued tags, assignment, tile, connectTo)
+# and the worker crashes: AttributeError: 'list' object has no attribute 'get'
+job = ds.annotations.compute(
+    image="properties/blob_intensity_worker:latest",
+    channel=0,
+    tags=["blobs"],
+    worker_interface={"Channel": 0},
+)
+
+# RIGHT — go through the property accessor
+prop = ds.properties.get_or_create("Blob Intensity", shape="polygon")
+ds.properties.register(prop.id)
+job = ds.properties.compute(prop, worker_interface={"Channel": 0})
+```
+
+To tell which kind a worker is, check its Docker labels by **key presence** (see "Discovering workers" below).
+
 ## Discovering workers
 
 ```python
@@ -28,10 +63,13 @@ client = ni.connect()
 # List all available worker images on the server
 workers = client.list_workers()
 for image, labels in workers.items():
-    is_ann = labels.get("isAnnotationWorker") == "true"
-    is_prop = labels.get("isPropertyWorker") == "true"
+    # Role labels are MARKER labels: they are commonly set with an
+    # empty-string value (docker build --label isPropertyWorker), so
+    # detect the role by KEY PRESENCE, never by comparing the value.
+    is_annotation = "isAnnotationWorker" in labels
+    is_property = "isPropertyWorker" in labels
     print(f"{image}: {labels.get('interfaceName', '')} "
-          f"[ann={is_ann}, prop={is_prop}]")
+          f"[ann={is_annotation}, prop={is_property}]")
 
 # Get the parameter interface for a specific worker
 interface = client.get_worker_interface("annotations/random_squares:latest")
@@ -40,10 +78,12 @@ for param_name, spec in interface.items():
 ```
 
 Worker labels include:
-- `isAnnotationWorker` / `isPropertyWorker` — what kind of worker it is
+- `isAnnotationWorker` / `isPropertyWorker` — role markers; check with `"isAnnotationWorker" in labels`, not `== "true"` (the value is usually the empty string). A worker may carry both roles.
 - `interfaceName` — display name
 - `description` — what it does
 - `annotationShape` — shape it produces (point, polygon, etc.)
+
+Do **not** infer the role from the image path prefix (`annotations/...`, `properties/...`): registry-qualified images may have arbitrary prefixes (e.g. `ghcr.io/lab/blob_intensity_worker:latest`). The labels are the only reliable signal.
 
 ## Running annotation workers
 
@@ -229,6 +269,7 @@ values = ds.properties.get_values()
 
 ## Important notes
 
+- Match the accessor to the worker's role: annotation workers via `ds.annotations.compute`, property workers via `ds.properties.compute`. See the rule at the top of this skill.
 - Worker parameter keys must match the interface exactly (e.g., `"Square size"` not `"square_size"`). Check with `client.get_worker_interface()`.
 - The `connect_to` dict must always include `"tags"` — use `{"tags": []}` for no connections.
 - Property workers require the property to be created and registered before running.

--- a/.agents/skills/nimbusimage-workers/SKILL.md
+++ b/.agents/skills/nimbusimage-workers/SKILL.md
@@ -25,7 +25,7 @@ Each worker kind has its own accessor, and they submit to **different endpoints 
 - **Annotation workers** → `ds.annotations.compute(...)` → `POST /upenn_annotation/compute`
 - **Property workers** → create/get a `Property`, then `ds.properties.compute(prop, ...)` → `POST /annotation_property/{id}/compute`
 
-**Never** pass a property-worker image to `ds.annotations.compute`, and **never** pass an annotation-worker image to `ds.properties.compute`. Neither accessor validates the worker's role, so the job submits fine and then crashes inside the worker with a confusing error.
+**Never** pass a property-worker image to `ds.annotations.compute`, and **never** pass an annotation-worker image to `ds.properties.compute`. Both accessors now cross-check the image's role labels against `/worker_interface/available` before submitting and raise `ValueError` naming the correct accessor on a known mismatch — but the check is best-effort (an image missing from the listing, carrying no role labels, or an inaccessible discovery endpoint passes through unvalidated), so a mismatch can still submit and then crash inside the worker with a confusing error.
 
 The wire formats differ in a way that makes the crash recognizable:
 

--- a/.agents/skills/nimbusimage-workers/references/gotchas.md
+++ b/.agents/skills/nimbusimage-workers/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/.agents/skills/nimbusimage-workers/references/gotchas.md
+++ b/.agents/skills/nimbusimage-workers/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/.agents/skills/nimbusimage/references/gotchas.md
+++ b/.agents/skills/nimbusimage/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/.agents/skills/nimbusimage/references/gotchas.md
+++ b/.agents/skills/nimbusimage/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/nimbusimage/nimbusimage/_workers.py
+++ b/nimbusimage/nimbusimage/_workers.py
@@ -1,0 +1,94 @@
+"""Worker role validation shared by the compute accessors.
+
+Annotation workers and property workers are submitted through different
+endpoints with different payload formats, and neither endpoint checks
+that the Docker image actually matches its worker kind. Submitting a
+property worker through ``ds.annotations.compute`` (or vice versa)
+produces a job that starts fine and then crashes inside the worker with
+a confusing error — e.g. ``AttributeError: 'list' object has no
+attribute 'get'`` when a property worker receives an annotation-compute
+body whose ``tags`` field is a list instead of a filter dict.
+
+This module cross-checks the image's role labels from
+``GET /worker_interface/available`` before submitting, so the mismatch
+fails immediately, client-side, with a message naming the correct
+accessor.
+"""
+
+from __future__ import annotations
+
+import girder_client
+
+ANNOTATION_ROLE_LABEL = "isAnnotationWorker"
+PROPERTY_ROLE_LABEL = "isPropertyWorker"
+
+_MISMATCH_MESSAGES = {
+    # required_label -> message when only the opposite label is present
+    ANNOTATION_ROLE_LABEL: (
+        "'{image}' is a property worker (its Docker labels have "
+        "isPropertyWorker but not isAnnotationWorker). Submitting it "
+        "through ds.annotations.compute sends an annotation-compute "
+        "payload (list-valued tags, assignment, tile, connectTo) that "
+        "crashes property workers with \"AttributeError: 'list' object "
+        "has no attribute 'get'\". Create or get a Property and use "
+        "ds.properties.compute(prop, ...) instead."
+    ),
+    PROPERTY_ROLE_LABEL: (
+        "'{image}' is an annotation worker (its Docker labels have "
+        "isAnnotationWorker but not isPropertyWorker). Submitting it "
+        "through ds.properties.compute sends a property-compute payload "
+        "(tags as a {{'tags': [...], 'exclusive': bool}} filter dict) "
+        "that annotation workers cannot handle. Use "
+        "ds.annotations.compute(...) instead."
+    ),
+}
+
+
+def check_worker_role(
+    gc: girder_client.GirderClient, image: str, required_label: str
+) -> None:
+    """Raise ``ValueError`` if ``image`` is known to have the wrong role.
+
+    Role labels (``isAnnotationWorker`` / ``isPropertyWorker``) are
+    Docker *marker* labels: their presence defines the role and their
+    value is commonly the empty string, so detection is by key presence
+    only — never by comparing the value, and never by inspecting the
+    image path prefix.
+
+    The check is best-effort and only rejects a *known* mismatch — the
+    image lacks ``required_label`` but carries the opposite role label.
+    Submission proceeds unvalidated when the role cannot be determined:
+    the discovery endpoint errors, the image is not in the listing, or
+    the image carries no role labels at all. A worker labeled with both
+    roles is valid for either accessor.
+
+    Args:
+        gc: The girder client to query.
+        image: Docker image name as passed to the compute accessor.
+        required_label: ``ANNOTATION_ROLE_LABEL`` or
+            ``PROPERTY_ROLE_LABEL`` — the role the calling accessor
+            requires.
+
+    Raises:
+        ValueError: If the image carries the opposite role label and
+            not the required one. The message names the correct
+            accessor to use.
+    """
+    try:
+        workers = gc.get("/worker_interface/available")
+    except girder_client.HttpError:
+        return
+    if not isinstance(workers, dict):
+        return
+    labels = workers.get(image)
+    if not isinstance(labels, dict) or required_label in labels:
+        return
+    wrong_label = (
+        PROPERTY_ROLE_LABEL
+        if required_label == ANNOTATION_ROLE_LABEL
+        else ANNOTATION_ROLE_LABEL
+    )
+    if wrong_label in labels:
+        raise ValueError(
+            _MISMATCH_MESSAGES[required_label].format(image=image)
+        )

--- a/nimbusimage/nimbusimage/annotations.py
+++ b/nimbusimage/nimbusimage/annotations.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
+from nimbusimage._workers import ANNOTATION_ROLE_LABEL, check_worker_role
 from nimbusimage.jobs import Job
 from nimbusimage.models import Annotation, Location
 
@@ -275,6 +276,14 @@ class AnnotationAccessor:
         Returns:
             A Job object. Call ``job.wait()`` to block until completion.
 
+        Raises:
+            ValueError: If ``location`` and ``assignment`` conflict, if
+                ``connect_to`` lacks a ``tags`` key, or if ``image`` is
+                a property worker (its role labels from
+                ``/worker_interface/available`` have ``isPropertyWorker``
+                but not ``isAnnotationWorker``) — property workers must
+                run through ``ds.properties.compute`` instead.
+
         Note:
             The worker container uses ``WorkerClient`` from the
             ``worker_client`` package, which requires all of these keys
@@ -308,6 +317,12 @@ class AnnotationAccessor:
                 "connect_to must contain a 'tags' key "
                 "(e.g., {'tags': ['nucleus'], 'channel': 0})"
             )
+
+        # Reject property workers before submitting: they crash on the
+        # annotation-compute payload (list-valued tags) after the job
+        # has already started. After the cheap argument checks above so
+        # bad arguments fail without an HTTP round-trip.
+        check_worker_role(self._gc, image, ANNOTATION_ROLE_LABEL)
 
         body = {
             "datasetId": self._dataset_id,

--- a/nimbusimage/nimbusimage/properties.py
+++ b/nimbusimage/nimbusimage/properties.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from nimbusimage._workers import PROPERTY_ROLE_LABEL, check_worker_role
 from nimbusimage.jobs import Job
 from nimbusimage.models import Property
 
@@ -181,7 +182,12 @@ class PropertyAccessor:
             A Job object. Call ``job.wait()`` to block until completion.
 
         Raises:
-            ValueError: If the property has no ``id`` or ``image``.
+            ValueError: If the property has no ``id`` or ``image``, or
+                if its ``image`` is an annotation worker (its role
+                labels from ``/worker_interface/available`` have
+                ``isAnnotationWorker`` but not ``isPropertyWorker``) —
+                annotation workers must run through
+                ``ds.annotations.compute`` instead.
         """
         if not property.id:
             raise ValueError(
@@ -190,6 +196,10 @@ class PropertyAccessor:
             )
         if not property.image:
             raise ValueError("Property must have a Docker image set")
+
+        # Reject annotation workers before submitting: they cannot
+        # handle the property-compute payload (dict-valued tags filter).
+        check_worker_role(self._gc, property.image, PROPERTY_ROLE_LABEL)
 
         body = property.to_dict()
         # The worker reads params.get("id") to identify which property

--- a/nimbusimage/pyproject.toml
+++ b/nimbusimage/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nimbusimage"
-version = "0.1.2"
+version = "0.2.0"
 description = "Python API for NimbusImage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/nimbusimage/tests/test_worker_roles.py
+++ b/nimbusimage/tests/test_worker_roles.py
@@ -1,0 +1,226 @@
+"""Tests for worker role validation in the compute accessors.
+
+Annotation and property workers submit through different endpoints with
+different payload formats. Passing a property-worker image to
+``ds.annotations.compute`` used to submit successfully and then crash
+inside the worker (``AttributeError: 'list' object has no attribute
+'get'``); the accessors now cross-check the image's role labels from
+``GET /worker_interface/available`` and fail fast client-side.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nimbusimage.annotations import AnnotationAccessor
+from nimbusimage.jobs import Job
+from nimbusimage.models import Property
+from nimbusimage.properties import PropertyAccessor
+
+
+PROPERTY_IMAGE = "properties/blob_intensity_worker:latest"
+ANNOTATION_IMAGE = "annotations/random_squares:latest"
+
+# Role labels are Docker MARKER labels: presence defines the role and
+# the value is commonly the empty string. Empty-string values are used
+# throughout these tests on purpose — a truthiness or == "true" check
+# would treat them as absent and let the mismatch through.
+WORKERS = {
+    PROPERTY_IMAGE: {
+        "isUPennContrastWorker": "",
+        "isPropertyWorker": "",
+        "annotationShape": "polygon",
+        "interfaceName": "Blob Intensity",
+    },
+    ANNOTATION_IMAGE: {
+        "isUPennContrastWorker": "",
+        "isAnnotationWorker": "",
+        "annotationShape": "polygon",
+        "interfaceName": "Random Squares",
+    },
+}
+
+
+def make_property(image):
+    return Property(
+        id="prop_001",
+        name="Blob Intensity",
+        shape="polygon",
+        image=image,
+        tags={"exclusive": False, "tags": []},
+        worker_interface={"Channel": 0},
+    )
+
+
+@pytest.fixture
+def gc_with_workers(mock_gc):
+    mock_gc.get.return_value = dict(WORKERS)
+    mock_gc.post.return_value = [{"_id": "job_1", "status": 1}]
+    return mock_gc
+
+
+class TestAnnotationComputeRejectsPropertyWorker:
+    def test_property_worker_raises_before_post(self, gc_with_workers):
+        accessor = AnnotationAccessor(gc_with_workers, "ds_001")
+
+        with pytest.raises(ValueError, match="property worker"):
+            accessor.compute(image=PROPERTY_IMAGE, tags=["blobs"])
+        # Must fail before any job is submitted.
+        gc_with_workers.post.assert_not_called()
+
+    def test_error_names_correct_accessor(self, gc_with_workers):
+        accessor = AnnotationAccessor(gc_with_workers, "ds_001")
+
+        with pytest.raises(
+            ValueError, match=r"ds\.properties\.compute"
+        ):
+            accessor.compute(image=PROPERTY_IMAGE)
+
+    def test_role_comes_from_labels_not_image_prefix(self, mock_gc):
+        """A registry-qualified image whose path contains
+        'annotations/' is still rejected when its labels say it is a
+        property worker — the role must never be inferred from the
+        image path prefix."""
+        image = "ghcr.io/lab/annotations/blob_intensity:latest"
+        mock_gc.get.return_value = {
+            image: {"isPropertyWorker": ""},
+        }
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        with pytest.raises(ValueError, match="property worker"):
+            accessor.compute(image=image)
+
+    def test_annotation_worker_passes(self, gc_with_workers):
+        accessor = AnnotationAccessor(gc_with_workers, "ds_001")
+
+        job = accessor.compute(image=ANNOTATION_IMAGE, tags=["squares"])
+        assert isinstance(job, Job)
+        gc_with_workers.get.assert_called_with(
+            "/worker_interface/available"
+        )
+
+
+class TestPropertyComputeRejectsAnnotationWorker:
+    def test_annotation_worker_raises_before_post(self, gc_with_workers):
+        accessor = PropertyAccessor(gc_with_workers, "ds_001")
+
+        with pytest.raises(ValueError, match="annotation worker"):
+            accessor.compute(make_property(ANNOTATION_IMAGE))
+        gc_with_workers.post.assert_not_called()
+
+    def test_error_names_correct_accessor(self, gc_with_workers):
+        accessor = PropertyAccessor(gc_with_workers, "ds_001")
+
+        with pytest.raises(
+            ValueError, match=r"ds\.annotations\.compute"
+        ):
+            accessor.compute(make_property(ANNOTATION_IMAGE))
+
+    def test_property_worker_passes(self, gc_with_workers):
+        accessor = PropertyAccessor(gc_with_workers, "ds_001")
+
+        job = accessor.compute(make_property(PROPERTY_IMAGE))
+        assert isinstance(job, Job)
+        gc_with_workers.get.assert_called_with(
+            "/worker_interface/available"
+        )
+
+
+class TestDualRoleWorker:
+    """A worker may carry both role labels and is valid for either
+    accessor."""
+
+    @pytest.fixture
+    def gc_dual(self, mock_gc):
+        mock_gc.get.return_value = {
+            "dual:latest": {
+                "isAnnotationWorker": "",
+                "isPropertyWorker": "",
+            },
+        }
+        mock_gc.post.return_value = [{"_id": "job_1", "status": 1}]
+        return mock_gc
+
+    def test_allowed_via_annotations(self, gc_dual):
+        job = AnnotationAccessor(gc_dual, "ds_001").compute(
+            image="dual:latest"
+        )
+        assert isinstance(job, Job)
+
+    def test_allowed_via_properties(self, gc_dual):
+        job = PropertyAccessor(gc_dual, "ds_001").compute(
+            make_property("dual:latest")
+        )
+        assert isinstance(job, Job)
+
+
+class TestValidationIsBestEffort:
+    """When the role cannot be determined, submission proceeds — the
+    check only rejects a KNOWN mismatch."""
+
+    def _submit_both(self, mock_gc):
+        mock_gc.post.return_value = [{"_id": "job_1", "status": 1}]
+        job_a = AnnotationAccessor(mock_gc, "ds_001").compute(
+            image="unknown:latest"
+        )
+        job_p = PropertyAccessor(mock_gc, "ds_001").compute(
+            make_property("unknown:latest")
+        )
+        assert isinstance(job_a, Job)
+        assert isinstance(job_p, Job)
+
+    def test_image_not_in_listing(self, mock_gc):
+        mock_gc.get.return_value = dict(WORKERS)
+        self._submit_both(mock_gc)
+
+    def test_no_role_labels(self, mock_gc):
+        mock_gc.get.return_value = {
+            "unknown:latest": {"interfaceName": "Mystery"},
+        }
+        self._submit_both(mock_gc)
+
+    def test_discovery_endpoint_http_error(self, mock_gc):
+        from girder_client import HttpError
+
+        mock_gc.get.side_effect = HttpError(
+            status=403,
+            text="forbidden",
+            url="/worker_interface/available",
+            method="GET",
+        )
+        self._submit_both(mock_gc)
+
+    def test_non_dict_listing_response(self, mock_gc):
+        mock_gc.get.return_value = None
+        self._submit_both(mock_gc)
+
+    def test_unconfigured_mock_listing(self, mock_gc):
+        """A bare MagicMock listing (as in older tests that never
+        configure gc.get) is not a dict and must not break compute."""
+        mock_gc.get.return_value = MagicMock()
+        self._submit_both(mock_gc)
+
+
+class TestCheapChecksStillFailFirst:
+    """Argument validation stays ahead of the role check, so bad
+    arguments fail without an HTTP round-trip."""
+
+    def test_connect_to_missing_tags_skips_discovery(self, mock_gc):
+        accessor = AnnotationAccessor(mock_gc, "ds_001")
+
+        with pytest.raises(ValueError, match="tags"):
+            accessor.compute(
+                image=PROPERTY_IMAGE, connect_to={"channel": 0}
+            )
+        mock_gc.get.assert_not_called()
+
+    def test_property_without_id_skips_discovery(self, mock_gc):
+        accessor = PropertyAccessor(mock_gc, "ds_001")
+        prop = Property(
+            id=None, name="Area", shape="polygon",
+            image=ANNOTATION_IMAGE,
+        )
+
+        with pytest.raises(ValueError, match="saved to the server"):
+            accessor.compute(prop)
+        mock_gc.get.assert_not_called()

--- a/plugins/nimbusimage/references/gotchas.md
+++ b/plugins/nimbusimage/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/plugins/nimbusimage/references/gotchas.md
+++ b/plugins/nimbusimage/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/plugins/nimbusimage/skills/analyze/references/gotchas.md
+++ b/plugins/nimbusimage/skills/analyze/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/plugins/nimbusimage/skills/analyze/references/gotchas.md
+++ b/plugins/nimbusimage/skills/analyze/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/plugins/nimbusimage/skills/annotations/references/gotchas.md
+++ b/plugins/nimbusimage/skills/annotations/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/plugins/nimbusimage/skills/annotations/references/gotchas.md
+++ b/plugins/nimbusimage/skills/annotations/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/plugins/nimbusimage/skills/images/references/gotchas.md
+++ b/plugins/nimbusimage/skills/images/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/plugins/nimbusimage/skills/images/references/gotchas.md
+++ b/plugins/nimbusimage/skills/images/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/plugins/nimbusimage/skills/nimbusimage/references/gotchas.md
+++ b/plugins/nimbusimage/skills/nimbusimage/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/plugins/nimbusimage/skills/nimbusimage/references/gotchas.md
+++ b/plugins/nimbusimage/skills/nimbusimage/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 

--- a/plugins/nimbusimage/skills/workers/SKILL.md
+++ b/plugins/nimbusimage/skills/workers/SKILL.md
@@ -18,6 +18,41 @@ There are two kinds of workers:
 - **Annotation workers** — create annotations (points, polygons) on image data
 - **Property workers** — compute measurement values for existing annotations
 
+## RULE: worker accessors are NOT interchangeable
+
+Each worker kind has its own accessor, and they submit to **different endpoints with different payload formats**:
+
+- **Annotation workers** → `ds.annotations.compute(...)` → `POST /upenn_annotation/compute`
+- **Property workers** → create/get a `Property`, then `ds.properties.compute(prop, ...)` → `POST /annotation_property/{id}/compute`
+
+**Never** pass a property-worker image to `ds.annotations.compute`, and **never** pass an annotation-worker image to `ds.properties.compute`. Neither accessor validates the worker's role, so the job submits fine and then crashes inside the worker with a confusing error.
+
+The wire formats differ in a way that makes the crash recognizable:
+
+- Annotation compute sends a **list-valued** top-level `tags` field — the tags to put on *created* annotations — plus `assignment`, `tile`, `connectTo`, `type="worker"`, and `id=""`.
+- Property compute sends `tags` as a **dict**: `{"tags": [...], "exclusive": bool}` — an annotation *filter* selecting which existing annotations to measure.
+
+So if a property worker crashes with `AttributeError: 'list' object has no attribute 'get'` while reading `tags`, and its payload contains `assignment`/`tile`/`connectTo`, list-valued `tags`, `type="worker"`, and `id=""` — that is an **accessor/endpoint mismatch**: the job was submitted through `ds.annotations.compute`. It is *not* malformed tag serialization to be normalized inside the worker; fix the caller, not the worker.
+
+```python
+# WRONG — blob_intensity_worker is a PROPERTY worker; this submits an
+# annotation-compute payload (list-valued tags, assignment, tile, connectTo)
+# and the worker crashes: AttributeError: 'list' object has no attribute 'get'
+job = ds.annotations.compute(
+    image="properties/blob_intensity_worker:latest",
+    channel=0,
+    tags=["blobs"],
+    worker_interface={"Channel": 0},
+)
+
+# RIGHT — go through the property accessor
+prop = ds.properties.get_or_create("Blob Intensity", shape="polygon")
+ds.properties.register(prop.id)
+job = ds.properties.compute(prop, worker_interface={"Channel": 0})
+```
+
+To tell which kind a worker is, check its Docker labels by **key presence** (see "Discovering workers" below).
+
 ## Discovering workers
 
 ```python
@@ -28,10 +63,13 @@ client = ni.connect()
 # List all available worker images on the server
 workers = client.list_workers()
 for image, labels in workers.items():
-    is_ann = labels.get("isAnnotationWorker") == "true"
-    is_prop = labels.get("isPropertyWorker") == "true"
+    # Role labels are MARKER labels: they are commonly set with an
+    # empty-string value (docker build --label isPropertyWorker), so
+    # detect the role by KEY PRESENCE, never by comparing the value.
+    is_annotation = "isAnnotationWorker" in labels
+    is_property = "isPropertyWorker" in labels
     print(f"{image}: {labels.get('interfaceName', '')} "
-          f"[ann={is_ann}, prop={is_prop}]")
+          f"[ann={is_annotation}, prop={is_property}]")
 
 # Get the parameter interface for a specific worker
 interface = client.get_worker_interface("annotations/random_squares:latest")
@@ -40,10 +78,12 @@ for param_name, spec in interface.items():
 ```
 
 Worker labels include:
-- `isAnnotationWorker` / `isPropertyWorker` — what kind of worker it is
+- `isAnnotationWorker` / `isPropertyWorker` — role markers; check with `"isAnnotationWorker" in labels`, not `== "true"` (the value is usually the empty string). A worker may carry both roles.
 - `interfaceName` — display name
 - `description` — what it does
 - `annotationShape` — shape it produces (point, polygon, etc.)
+
+Do **not** infer the role from the image path prefix (`annotations/...`, `properties/...`): registry-qualified images may have arbitrary prefixes (e.g. `ghcr.io/lab/blob_intensity_worker:latest`). The labels are the only reliable signal.
 
 ## Running annotation workers
 
@@ -229,6 +269,7 @@ values = ds.properties.get_values()
 
 ## Important notes
 
+- Match the accessor to the worker's role: annotation workers via `ds.annotations.compute`, property workers via `ds.properties.compute`. See the rule at the top of this skill.
 - Worker parameter keys must match the interface exactly (e.g., `"Square size"` not `"square_size"`). Check with `client.get_worker_interface()`.
 - The `connect_to` dict must always include `"tags"` — use `{"tags": []}` for no connections.
 - Property workers require the property to be created and registered before running.

--- a/plugins/nimbusimage/skills/workers/SKILL.md
+++ b/plugins/nimbusimage/skills/workers/SKILL.md
@@ -25,7 +25,7 @@ Each worker kind has its own accessor, and they submit to **different endpoints 
 - **Annotation workers** → `ds.annotations.compute(...)` → `POST /upenn_annotation/compute`
 - **Property workers** → create/get a `Property`, then `ds.properties.compute(prop, ...)` → `POST /annotation_property/{id}/compute`
 
-**Never** pass a property-worker image to `ds.annotations.compute`, and **never** pass an annotation-worker image to `ds.properties.compute`. Neither accessor validates the worker's role, so the job submits fine and then crashes inside the worker with a confusing error.
+**Never** pass a property-worker image to `ds.annotations.compute`, and **never** pass an annotation-worker image to `ds.properties.compute`. Both accessors now cross-check the image's role labels against `/worker_interface/available` before submitting and raise `ValueError` naming the correct accessor on a known mismatch — but the check is best-effort (an image missing from the listing, carrying no role labels, or an inaccessible discovery endpoint passes through unvalidated), so a mismatch can still submit and then crash inside the worker with a confusing error.
 
 The wire formats differ in a way that makes the crash recognizable:
 

--- a/plugins/nimbusimage/skills/workers/references/gotchas.md
+++ b/plugins/nimbusimage/skills/workers/references/gotchas.md
@@ -23,7 +23,7 @@ Things that will trip you up if you don't know about them.
 
 ## Do not cross worker accessors
 
-Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). The payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter). Both accessors cross-check the image's role labels against `/worker_interface/available` and raise `ValueError` on a known mismatch, but the check is best-effort — an unlisted or unlabeled image passes through unvalidated.
 
 Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
 

--- a/plugins/nimbusimage/skills/workers/references/gotchas.md
+++ b/plugins/nimbusimage/skills/workers/references/gotchas.md
@@ -4,6 +4,7 @@ Things that will trip you up if you don't know about them.
 
 ## Contents
 
+- [Do not cross worker accessors](#do-not-cross-worker-accessors)
 - [connect_to must have tags key](#connect_to-must-have-tags-key)
 - [Worker parameter keys are exact strings](#worker-parameter-keys-are-exact-strings)
 - [id vs _id](#id-vs-_id)
@@ -19,6 +20,14 @@ Things that will trip you up if you don't know about them.
 - [Collections and configurations](#collections--configurations)
 - [Safe sharing](#never-call-raw-put-folderidaccess--use-dssharing)
 - [Avoid raw girder-client](#generally-avoid-dropping-to-client_gc-raw-girder-client)
+
+## Do not cross worker accessors
+
+Annotation workers run through `ds.annotations.compute(...)` (`POST /upenn_annotation/compute`); property workers run through `ds.properties.compute(prop, ...)` (`POST /annotation_property/{id}/compute`). Neither accessor validates the worker's role, and the payloads differ: annotation compute sends **list-valued** top-level `tags` (output tags) plus `assignment`, `tile`, `connectTo`, `type="worker"`, `id=""`; property compute sends `tags` as a dict `{"tags": [...], "exclusive": bool}` (an annotation filter).
+
+Diagnostic signature: a property worker (e.g. `properties/blob_intensity_worker`) crashing with `AttributeError: 'list' object has no attribute 'get'`, with a payload containing list-valued `tags`, `assignment`/`tile`/`connectTo`, `type="worker"`, and `id=""` — it was submitted through `ds.annotations.compute`. Fix the caller to use `ds.properties.compute`; do not "normalize" tags inside the worker.
+
+Determine a worker's role from its Docker labels by key presence — `"isAnnotationWorker" in labels` / `"isPropertyWorker" in labels` — not by comparing values (they're marker labels, usually empty strings) and not from the image path prefix.
 
 ## connect_to must have tags key
 


### PR DESCRIPTION
## Summary

Add client-side validation to prevent submitting workers through the wrong compute accessor. Annotation workers and property workers use different endpoints with incompatible payload formats; submitting a property worker through `ds.annotations.compute` (or vice versa) produces a job that crashes inside the worker with a confusing error like `AttributeError: 'list' object has no attribute 'get'`.

Both accessors now cross-check the image's role labels from `GET /worker_interface/available` before submitting and raise `ValueError` naming the correct accessor on a known mismatch. The check is best-effort and only rejects a *known* mismatch — submission proceeds unvalidated when the role cannot be determined (discovery endpoint errors, image not in listing, or no role labels).

## Key Changes

- **New module `nimbusimage/_workers.py`**: Shared worker role validation logic
  - `check_worker_role()` function queries `/worker_interface/available` and validates role labels
  - Detects role by *key presence* (not value comparison) — role labels are Docker marker labels commonly set with empty-string values
  - Best-effort validation: only rejects known mismatches, allows submission when role is uncertain
  - Clear error messages naming the correct accessor to use

- **Updated `AnnotationAccessor.compute()`**: Calls `check_worker_role()` with `ANNOTATION_ROLE_LABEL` after cheap argument validation
  - Rejects property workers before job submission
  - Updated docstring with new `ValueError` conditions

- **Updated `PropertyAccessor.compute()`**: Calls `check_worker_role()` with `PROPERTY_ROLE_LABEL` after cheap argument validation
  - Rejects annotation workers before job submission
  - Updated docstring with new `ValueError` conditions

- **Comprehensive test suite** (`nimbusimage/tests/test_worker_roles.py`): 226 lines covering
  - Annotation accessor rejects property workers
  - Property accessor rejects annotation workers
  - Error messages name the correct accessor
  - Role detection by label key presence, not image path prefix
  - Dual-role workers (both labels) are valid for either accessor
  - Best-effort validation: unknown images, missing labels, HTTP errors, and non-dict responses all allow submission
  - Cheap argument checks still fail before role validation (no unnecessary HTTP round-trips)

- **Documentation updates**: Added "RULE: worker accessors are NOT interchangeable" section to all worker-related skill docs
  - Explains the two accessor types and their different endpoints/payload formats
  - Shows the wire format differences that cause crashes
  - Provides correct and incorrect usage examples
  - Clarifies role detection by label key presence, not image path prefix
  - Updated "Discovering workers" examples to check labels correctly

## Implementation Details

- Role labels are Docker *marker* labels: presence defines the role, value is commonly empty string
- Detection uses `"isAnnotationWorker" in labels` (key presence), never `== "true"` or truthiness checks
- A worker may carry both role labels and is valid for either accessor
- Validation happens after cheap argument checks so bad arguments fail without HTTP overhead
- Graceful degradation: if discovery endpoint is inaccessible, image is unknown, or labels are missing, submission proceeds (the check only rejects a *known* mismatch)
- Error messages are specific and actionable, naming the correct accessor and explaining the payload format difference

https://claude.ai/code/session_01WQM9q21H9yJR7GU4ci9d9x