### PR TITLE
Extract profile storage display into shared StorageUsageSection

### DIFF
--- a/src/__tests__/regressionChecklist.test.ts
+++ b/src/__tests__/regressionChecklist.test.ts
@@ -104,6 +104,8 @@ const NOT_OURS = new Set([
   ".venv",
   "__pycache__",
   ".pnpm-store",
+  // Review worktrees are checkouts of this repo, not part of it.
+  ".claude",
 ]);
 
 /**

--- a/src/components/StorageUsageSection.test.ts
+++ b/src/components/StorageUsageSection.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import StorageUsageSection from "./StorageUsageSection.vue";
+import { storageSeverityFromPercentage } from "@/utils/storage";
+
+const mockStore = vi.hoisted(() => ({
+  userStorageInfo: null as { used: number; quota: number | null } | null,
+  storageUsagePercentage: null as number | null,
+  get storageSeverity() {
+    return storageSeverityFromPercentage(this.storageUsagePercentage);
+  },
+}));
+
+vi.mock("@/store", () => ({ default: mockStore }));
+
+const GIGABYTE = 1024 ** 3;
+
+function mountWithStorage(info: { used: number; quota: number | null } | null) {
+  mockStore.userStorageInfo = info;
+  mockStore.storageUsagePercentage =
+    info?.quota != null ? (info.used / info.quota) * 100 : null;
+  return mount(StorageUsageSection);
+}
+
+describe("StorageUsageSection", () => {
+  it("renders nothing when storage info is unavailable", () => {
+    const wrapper = mountWithStorage(null);
+    expect(wrapper.text()).toBe("");
+  });
+
+  it("shows usage without a bar when there is no quota", () => {
+    const wrapper = mountWithStorage({ used: 40 * GIGABYTE, quota: null });
+    expect(wrapper.text()).toContain("40.00 GB");
+    expect(wrapper.text()).toContain("used (no storage limit)");
+    expect(wrapper.find(".v-progress-linear").exists()).toBe(false);
+  });
+
+  it("shows quota, percentage bar, and no warning below the threshold", () => {
+    const wrapper = mountWithStorage({
+      used: 50 * GIGABYTE,
+      quota: 100 * GIGABYTE,
+    });
+    expect(wrapper.text()).toContain("of 100.00 GB used");
+    expect(wrapper.text()).toContain("50.0% of storage limit used");
+    expect(wrapper.find(".v-progress-linear").exists()).toBe(true);
+    expect(wrapper.text()).not.toContain("Some operations may not work");
+  });
+
+  it("shows the warning once usage escalates past the warning threshold", () => {
+    const wrapper = mountWithStorage({
+      used: 92 * GIGABYTE,
+      quota: 100 * GIGABYTE,
+    });
+    expect(wrapper.text()).toContain("Some operations may not work");
+  });
+});

--- a/src/components/StorageUsageSection.vue
+++ b/src/components/StorageUsageSection.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="mb-3" v-if="storageInfo">
+    <div class="panel-section-title mb-1">Storage</div>
+    <p>
+      {{ formatSize(storageInfo.used) }}
+      <template v-if="storageInfo.quota != null">
+        of {{ formatSize(storageInfo.quota) }} used
+      </template>
+      <template v-else> used (no storage limit) </template>
+    </p>
+    <template v-if="usagePercentage != null">
+      <v-progress-linear
+        :model-value="Math.min(usagePercentage, 100)"
+        :color="usageColor"
+        height="8"
+        rounded
+        class="my-1"
+      />
+      <p :class="`text-${usageColor}`">
+        {{ usagePercentage.toFixed(1) }}% of storage limit used
+      </p>
+      <p
+        v-if="usageSeverity !== 'ok'"
+        class="text-caption text-medium-emphasis"
+      >
+        <v-icon size="small" :color="usageColor" class="mr-1">
+          mdi-alert-circle-outline
+        </v-icon>
+        Some operations may not work properly when this close to the storage
+        limit
+      </p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import store from "@/store";
+import { formatSize } from "@/utils/conversion";
+import { storageSeverityColor } from "@/utils/storage";
+
+const storageInfo = computed(() => store.userStorageInfo);
+const usagePercentage = computed(() => store.storageUsagePercentage);
+
+const usageSeverity = computed(() => store.storageSeverity);
+const usageColor = computed(() => storageSeverityColor(usageSeverity.value));
+</script>

--- a/src/layout/UserProfileSettings.test.ts
+++ b/src/layout/UserProfileSettings.test.ts
@@ -8,6 +8,9 @@ vi.mock("@/store", () => ({
     userName: "testuser",
     girderRest: { apiRoot: "http://localhost:8080/api/v1" },
     logout: vi.fn().mockResolvedValue(undefined),
+    userStorageInfo: { used: 10 * 1024 ** 3, quota: null },
+    storageUsagePercentage: null,
+    storageSeverity: "ok",
   },
   girderUrlFromApiRoot: (apiRoot: string) => apiRoot.replace("/api/v1", ""),
 }));
@@ -36,6 +39,12 @@ describe("UserProfileSettings", () => {
   it("displays Girder domain", () => {
     const wrapper = mountComponent();
     expect(wrapper.text()).toContain("http://localhost:8080");
+  });
+
+  it("renders the storage usage section", () => {
+    const wrapper = mountComponent();
+    expect(wrapper.text()).toContain("10.00 GB");
+    expect(wrapper.text()).toContain("used (no storage limit)");
   });
 
   it("calls logout and navigates on logout button click", async () => {

--- a/src/layout/UserProfileSettings.vue
+++ b/src/layout/UserProfileSettings.vue
@@ -13,38 +13,7 @@
           <div class="panel-section-title mb-1">Girder domain</div>
           <p>{{ girderUrlFromApiRoot(store.girderRest.apiRoot) }}</p>
         </div>
-        <div class="mb-3" v-if="storageInfo">
-          <div class="panel-section-title mb-1">Storage</div>
-          <p>
-            {{ formatSize(storageInfo.used) }}
-            <template v-if="storageInfo.quota != null">
-              of {{ formatSize(storageInfo.quota) }} used
-            </template>
-            <template v-else> used (no storage limit) </template>
-          </p>
-          <template v-if="usagePercentage != null">
-            <v-progress-linear
-              :model-value="Math.min(usagePercentage, 100)"
-              :color="usageColor"
-              height="8"
-              rounded
-              class="my-1"
-            />
-            <p :class="`text-${usageColor}`">
-              {{ usagePercentage.toFixed(1) }}% of storage limit used
-            </p>
-            <p
-              v-if="usagePercentage > 90"
-              class="text-caption text-medium-emphasis"
-            >
-              <v-icon size="small" :color="usageColor" class="mr-1">
-                mdi-alert-circle-outline
-              </v-icon>
-              Some operations may not work properly when this close to the
-              storage limit
-            </p>
-          </template>
-        </div>
+        <storage-usage-section />
         <v-btn variant="flat" color="error" size="small" @click="logout">
           Logout
         </v-btn>
@@ -54,18 +23,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
 import { useRouter } from "vue-router";
 import store, { girderUrlFromApiRoot } from "@/store";
-import { formatSize } from "@/utils/conversion";
-import { storageSeverityColor } from "@/utils/storage";
+import StorageUsageSection from "@/components/StorageUsageSection.vue";
 
 const router = useRouter();
-
-const storageInfo = computed(() => store.userStorageInfo);
-const usagePercentage = computed(() => store.storageUsagePercentage);
-
-const usageColor = computed(() => storageSeverityColor(store.storageSeverity));
 
 async function logout() {
   await store.logout();

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -34,7 +34,15 @@ export default mergeConfig(
       // files that appear under .tox/ after a backend `tox` run (they import
       // @playwright/test and aren't ours). Harmless on CI (no .tox dir), but
       // they cause spurious failures when running `pnpm test` locally.
-      exclude: [...configDefaults.exclude, "e2e/*", "db/**", "**/.tox/**"],
+      // "**/.claude/worktrees/**" likewise excludes stale test copies in
+      // leftover review worktrees.
+      exclude: [
+        ...configDefaults.exclude,
+        "e2e/*",
+        "db/**",
+        "**/.tox/**",
+        "**/.claude/worktrees/**",
+      ],
       root: fileURLToPath(new URL("./", import.meta.url)),
       setupFiles: [
         fileURLToPath(new URL("./test/setup.ts", import.meta.url)),


### PR DESCRIPTION
## Summary

The profile menu's storage display (usage text, quota progress bar, near-limit warning) was inlined in `UserProfileSettings.vue`, so nothing else could render it. This PR extracts it verbatim into a shared `src/components/StorageUsageSection.vue` so any other profile UI can show the same section by importing it. Appearance is unchanged.

No data plumbing was needed: `UserMenu.vue` already calls `fetchUserStorageInfo()` on every menu open, so any consumer of the section gets fresh data.

## Changes

- New `src/components/StorageUsageSection.vue` — the storage section, moved verbatim except the >90% warning now gates on `store.storageSeverity` instead of a hardcoded `90` (branch-review finding: keeps it in lockstep with `WARNING_PERCENTAGE` in `utils/storage.ts`)
- `src/layout/UserProfileSettings.vue` — renders `<storage-usage-section />`
- New `src/components/StorageUsageSection.test.ts` — four display states (hidden, no-limit, quota + bar, warning past threshold)
- `src/layout/UserProfileSettings.test.ts` — mock store gains storage members; asserts the section renders through the parent
- `vitest.config.js` + `src/__tests__/regressionChecklist.test.ts` — ignore stale checkouts under `.claude/worktrees/` (same class as the existing `.tox` exclusion; separate commit)

## Testing

- `pnpm tsc`, `pnpm lint`, full suite 3308/3308 green
- Live-verified in the browser: profile menu renders the storage section identically before and after the extraction, clean console on a fresh reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPYpR2c1XCN5uZHmGndP4S