### PR TITLE
Remove duplicate Analysis palette button from the app bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -254,22 +254,6 @@
             </template>
           </v-tooltip>
           <v-tooltip
-            text="Analysis: plot object properties against each other and lasso-select objects to keep"
-          >
-            <template v-slot:activator="{ props: activatorProps }">
-              <button
-                v-bind="activatorProps"
-                type="button"
-                class="palette-ibtn"
-                :class="{ active: analysisPanel }"
-                aria-label="Analysis plots"
-                @click.stop="togglePalette('analysisPanel')"
-              >
-                <v-icon size="18">mdi-chart-scatter-plot</v-icon>
-              </button>
-            </template>
-          </v-tooltip>
-          <v-tooltip
             text="Snapshots for bookmarking and downloading cropped regions in your dataset"
           >
             <template v-slot:activator="{ props: activatorProps }">


### PR DESCRIPTION
## Summary

The app bar showed two identical scatter-plot buttons that both toggle the analysis panel. PR #1298 added the original; PR #1302 added the badged version (active-gate-count badge, dynamic tooltip and aria-label) directly above it and did not remove the original — a merge leftover, not intentional.

This removes the older, unbadged button and keeps the badged one.

## Testing

- `pnpm tsc` and `pnpm lint:ci` clean; one `mdi-chart-scatter-plot` occurrence remains in `App.vue`.
- Verified live: a single Analysis button renders, still toggles the panel, and still shows the gate-count badge ("1" for the saved lasso gate on the test dataset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGq81mT4MQShs86XTEMmam