### PR TITLE
Stop pruning saved property columns against sampled discovery

### DIFF
--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -156,6 +156,20 @@ Existing in-codebase idioms for writing once:
 
 Writes to genuinely *different* resources can't be merged (the configuration vs the dataset view are separate endpoints); say so at the call site rather than leaving it looking like an oversight.
 
+### Never reconcile persisted state against a partial source
+
+A reconcile-on-change watcher ("drop saved entries that no longer resolve") is only as correct as the set it validates against. When that set is a **sample, a page, a viewport-scoped cache, or anything else that is partial by design**, the watcher deletes valid user state — and because these stores persist through a *debounced* save (`main.scheduleAnnotationBrowserSave()` → `syncConfiguration`), the very next unrelated UI touch writes the deletion to the backend. The user sees nothing until the next session, when their columns/filters/plots are simply gone. Issue #1326: `updateDisplayedFromComputedProperties` pruned saved property columns against `computedPropertyPaths`, which in lazy (stub-only) mode is built from a 512-doc *sample*; three of five saved columns vanished from a real 708K-annotation dataset's configuration.
+
+Before writing (or reviewing) a prune, answer two questions:
+
+1. **Is the validating set complete?** Grep the getter to its source. `propertyValues` is a viewport-scoped merge cache in lazy mode; `annotations` holds stubs only; server-paginated lists hold one page. Any of those makes "not present ⇒ deleted" a false inference. An emptiness guard (`if (available.size === 0) return`) only covers *nothing loaded yet* — a **partially** loaded set sails straight past it, which is exactly why this shipped.
+2. **What is authoritative here?** Prune against the narrowest fact you can actually prove. For property paths in lazy mode that is "is this path's property still attached to the configuration" (`properties`), not "did this exact path appear in the sample". Different modes legitimately get different prune rules — branch on the mode rather than weakening both.
+
+Two follow-ons that apply to every such watcher:
+
+- **Skip the write when nothing changed.** A prune that only ever drops entries can compare lengths and return early. The replaced array's identity is a reactive dependency (in this case `AnnotationViewer` re-runs `ensureVisiblePropertyValues` on it, which can commit values and re-enter the same watcher), and these watchers run on *every* data change — every pan, in lazy mode.
+- **Reconciling on load is not the same as reconciling live.** `resolveAnnotationBrowserConfig` already drops paths whose property left the configuration at hydration time, against the authoritative `configuration.propertyIds`. Check whether the load-time reconcile already covers the case before making the live watcher do more than it can prove.
+
 ### Watching Getters That Rebuild Their Return Object
 
 `watch(() => someGetter, cb, { deep: true })` on a getter that returns a **new object on every read** fires on every dependency touch — including dependencies the getter reads but that don't change the output (`deep: true` skips the value comparison entirely). This shipped a real bug: a deep watch on `currentFilters` cleared the selection on every Z-scrub because the getter read `z` unconditionally. tsc/lint/reasoning all passed; only the live app caught it.

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -156,6 +156,20 @@ Existing in-codebase idioms for writing once:
 
 Writes to genuinely *different* resources can't be merged (the configuration vs the dataset view are separate endpoints); say so at the call site rather than leaving it looking like an oversight.
 
+### Never reconcile persisted state against a partial source
+
+A reconcile-on-change watcher ("drop saved entries that no longer resolve") is only as correct as the set it validates against. When that set is a **sample, a page, a viewport-scoped cache, or anything else that is partial by design**, the watcher deletes valid user state — and because these stores persist through a *debounced* save (`main.scheduleAnnotationBrowserSave()` → `syncConfiguration`), the very next unrelated UI touch writes the deletion to the backend. The user sees nothing until the next session, when their columns/filters/plots are simply gone. Issue #1326: `updateDisplayedFromComputedProperties` pruned saved property columns against `computedPropertyPaths`, which in lazy (stub-only) mode is built from a 512-doc *sample*; three of five saved columns vanished from a real 708K-annotation dataset's configuration.
+
+Before writing (or reviewing) a prune, answer two questions:
+
+1. **Is the validating set complete?** Grep the getter to its source. `propertyValues` is a viewport-scoped merge cache in lazy mode; `annotations` holds stubs only; server-paginated lists hold one page. Any of those makes "not present ⇒ deleted" a false inference. An emptiness guard (`if (available.size === 0) return`) only covers *nothing loaded yet* — a **partially** loaded set sails straight past it, which is exactly why this shipped.
+2. **What is authoritative here?** Prune against the narrowest fact you can actually prove. For property paths in lazy mode that is "is this path's property still attached to the configuration" (`properties`), not "did this exact path appear in the sample". Different modes legitimately get different prune rules — branch on the mode rather than weakening both.
+
+Two follow-ons that apply to every such watcher:
+
+- **Skip the write when nothing changed.** A prune that only ever drops entries can compare lengths and return early. The replaced array's identity is a reactive dependency (in this case `AnnotationViewer` re-runs `ensureVisiblePropertyValues` on it, which can commit values and re-enter the same watcher), and these watchers run on *every* data change — every pan, in lazy mode.
+- **Reconciling on load is not the same as reconciling live.** `resolveAnnotationBrowserConfig` already drops paths whose property left the configuration at hydration time, against the authoritative `configuration.propertyIds`. Check whether the load-time reconcile already covers the case before making the live watcher do more than it can prove.
+
 ### Watching Getters That Rebuild Their Return Object
 
 `watch(() => someGetter, cb, { deep: true })` on a getter that returns a **new object on every read** fires on every dependency touch — including dependencies the getter reads but that don't change the output (`deep: true` skips the value comparison entirely). This shipped a real bug: a deep watch on `currentFilters` cleared the selection on every Z-scrub because the getter read `z` unconditionally. tsc/lint/reasoning all passed; only the live app caught it.

--- a/codebaseDocumentation/ANNOTATION-STUBS.md
+++ b/codebaseDocumentation/ANNOTATION-STUBS.md
@@ -1213,6 +1213,55 @@ paths for the visible set, not per-column-lazy); D3 server aggregation for plots
 (plots and the properties panels still read the cache / load wholesale); D4 PV stubs; D5
 explicit LRU eviction (Stage 1/2 bound via visible-set scoping rather than an LRU counter).
 
+#### Sampled discovery is NOT authoritative — never prune saved state against it (issue #1326)
+
+`discoveredPropertyPaths` comes from `PROPERTY_PATH_SAMPLE_SIZE = 512` value docs, and the
+"property structure is homogeneous across a dataset" assumption that justifies the sample
+**does not hold** in general: properties are shape/tag-scoped
+(`canComputeAnnotationProperty`) and are computed at different times, so a property computed
+only for, say, `cell`-tagged polygons can be entirely absent from the sample while being
+computed for hundreds of thousands of annotations.
+
+`updateDisplayedFromComputedProperties` (the global watcher on `propertyValues`) used to
+prune `displayedPropertyPaths` against `computedPropertyPaths` in **both** modes. In lazy
+mode that meant pruning saved columns against a sample, and the next annotation-browser
+change (any filter tweak or column toggle) persisted the pruned list through the debounced
+`saveAnnotationBrowserConfig` — silently and permanently dropping columns from the
+configuration. Observed live on the 708K dataset: 3 of 5 saved columns disappeared between
+sessions.
+
+The prune is now mode-aware:
+
+| Mode | Path set pruned against | Skipped while |
+|---|---|---|
+| wholesale (client) | `computedPropertyPaths` (exact paths, derived from every loaded value — authoritative) | `computedPropertyPaths` is empty |
+| lazy (stub-only) | the **property ids** still attached to the configuration | `properties` is empty |
+
+A displayed column retained in lazy mode still renders: values are fetched by explicit path
+(`findByAnnotationIds` projection), never through discovery. The remaining consequence is
+that a path missing from the sample is not offered by `PropertyPicker` (it lists
+`computedPropertyPaths`), so such a column can be *removed* (the list header's
+`removePropertyColumn`) but not re-*added* until the sample happens to include it. Making
+discovery authoritative — a server-side distinct-path aggregation over the dataset's value
+docs — is the follow-up that would close that gap (see D3).
+
+**Regression checklist for property-path discovery / pruning** (all in
+`store/__tests__/properties.test.ts` unless noted):
+- Lazy mode keeps a displayed path the sample missed — "keeps a displayed path that the
+  sampled discovery missed".
+- Lazy mode still drops a path whose property left the configuration — "prunes a path whose
+  property left the configuration".
+- Neither mode prunes before its input has loaded — "keeps hydrated paths while the property
+  list has not loaded yet" and, for wholesale mode, `annotationBrowserConfig.test.ts` "keeps
+  hydrated paths while no property values are available yet".
+- Wholesale mode still prunes exact stale paths — `annotationBrowserConfig.test.ts` "still
+  prunes stale paths once values are available".
+- The action does not replace `displayedPropertyPaths` when nothing was pruned — "does not
+  replace the array when nothing is pruned". Cost invariant with no visible behavior: the
+  array identity is a reactive dependency (`AnnotationViewer` re-runs
+  `ensureVisiblePropertyValues` on it, which can commit values and re-enter this watcher),
+  and in lazy mode the action runs on **every** viewport-scoped value merge, i.e. every pan.
+
 #### Stage 2 — server-side filtered drawing (DONE 2026-06-20)
 
 Removes the **last wholesale-load path**: in lazy mode an active property filter no longer

--- a/src/store/__tests__/properties.test.ts
+++ b/src/store/__tests__/properties.test.ts
@@ -67,6 +67,76 @@ describe("resetPropertyState (Finding 7)", () => {
   });
 });
 
+// The pruner runs from a global watcher on propertyValues, and any later
+// annotation-browser change persists the pruned list into the configuration —
+// so a wrong prune here silently and permanently drops saved columns (#1326).
+describe("updateDisplayedFromComputedProperties in lazy mode", () => {
+  const setProperties = (ids: string[]) =>
+    (
+      properties as unknown as {
+        setPropertiesImpl: (props: { id: string; name: string }[]) => void;
+      }
+    ).setPropertiesImpl(ids.map((id) => ({ id, name: id })));
+
+  beforeEach(() => {
+    properties.resetPropertyState();
+    setProperties([]);
+    annotationMock.stubOnlyMode = true;
+  });
+
+  it("keeps a displayed path that the sampled discovery missed", () => {
+    // Only propA appeared in the bounded value-doc sample; propB is computed
+    // for the dataset but sits outside it.
+    setProperties(["propA", "propB"]);
+    properties.setDiscoveredPropertyPaths([["propA", "Area"]]);
+    properties.hydrateDisplayedPropertyPaths([
+      ["propA", "Area"],
+      ["propB", "MeanIntensity"],
+    ]);
+
+    properties.updateDisplayedFromComputedProperties();
+
+    expect(properties.displayedPropertyPaths).toEqual([
+      ["propA", "Area"],
+      ["propB", "MeanIntensity"],
+    ]);
+  });
+
+  it("prunes a path whose property left the configuration", () => {
+    setProperties(["propA"]);
+    properties.setDiscoveredPropertyPaths([["propA", "Area"]]);
+    properties.hydrateDisplayedPropertyPaths([
+      ["propA", "Area"],
+      ["deletedProp", "Area"],
+    ]);
+
+    properties.updateDisplayedFromComputedProperties();
+
+    expect(properties.displayedPropertyPaths).toEqual([["propA", "Area"]]);
+  });
+
+  it("keeps hydrated paths while the property list has not loaded yet", () => {
+    properties.hydrateDisplayedPropertyPaths([["propA", "Area"]]);
+
+    properties.updateDisplayedFromComputedProperties();
+
+    expect(properties.displayedPropertyPaths).toEqual([["propA", "Area"]]);
+  });
+
+  it("does not replace the array when nothing is pruned", () => {
+    // The array identity is a reactive dependency (AnnotationViewer refetches
+    // visible values on it), and this runs on every viewport value merge.
+    setProperties(["propA"]);
+    properties.setDiscoveredPropertyPaths([["propA", "Area"]]);
+    properties.hydrateDisplayedPropertyPaths([["propA", "Area"]]);
+    const before = properties.displayedPropertyPaths;
+
+    properties.updateDisplayedFromComputedProperties();
+
+    expect(properties.displayedPropertyPaths).toBe(before);
+  });
+});
+
 describe("ensureVisiblePropertyValues stale guard (Finding 6)", () => {
   beforeEach(() => {
     getPropertyValuesForIds.mockReset();

--- a/src/store/properties.ts
+++ b/src/store/properties.ts
@@ -438,18 +438,52 @@ export class Properties extends VuexModule {
   updateDisplayedFromComputedProperties() {
     // This action is called in a global watcher (see "setupWatchers" in main store)
     // When propertyValues changes, some paths may be removed
-    const availablePaths = new Set(
-      this.computedPropertyPaths.map((path) => serializePropertyPath(path)),
-    );
-    // While properties or values haven't been fetched yet for the current
-    // dataset, computedPropertyPaths is empty; pruning against it would wipe
-    // the paths just hydrated from the configuration. Skip until data arrives.
-    if (availablePaths.size === 0) {
+    const displayed = this.displayedPropertyPaths;
+    let newPaths: string[][];
+    if (annotations.stubOnlyMode) {
+      // Lazy mode: `computedPropertyPaths` comes from a sample of
+      // PROPERTY_PATH_SAMPLE_SIZE value docs, so a path can be computed for
+      // the dataset yet absent from that sample — properties are shape/tag
+      // scoped and computed at different times, so whole columns can miss it.
+      // Pruning against the sample dropped valid columns, and the debounced
+      // annotation-browser save then persisted the loss (#1326). The only
+      // authoritative signal here is whether the path's property is still
+      // attached to the configuration; a retained column still renders, since
+      // its values are fetched by explicit path (findByAnnotationIds) rather
+      // than through discovery.
+      // An empty property list means they haven't been fetched yet.
+      if (this.properties.length === 0) {
+        return;
+      }
+      const knownPropertyIds = new Set(this.properties.map(({ id }) => id));
+      newPaths = displayed.filter((displayedPath) =>
+        knownPropertyIds.has(displayedPath[0]),
+      );
+    } else {
+      // Wholesale mode: `computedPropertyPaths` is derived from every loaded
+      // value, so it is authoritative and exact paths can be pruned.
+      const availablePaths = new Set(
+        this.computedPropertyPaths.map((path) => serializePropertyPath(path)),
+      );
+      // While properties or values haven't been fetched yet for the current
+      // dataset, computedPropertyPaths is empty; pruning against it would wipe
+      // the paths just hydrated from the configuration. Skip until data
+      // arrives.
+      if (availablePaths.size === 0) {
+        return;
+      }
+      newPaths = displayed.filter((displayedPath) =>
+        availablePaths.has(serializePropertyPath(displayedPath)),
+      );
+    }
+    // Both branches only ever drop entries, so an unchanged length means an
+    // unchanged list. Skip the write then: the array identity is a reactive
+    // dependency (AnnotationViewer re-runs ensureVisiblePropertyValues on it,
+    // which can commit property values and re-enter this watcher), and in lazy
+    // mode this action runs on every viewport-scoped value merge.
+    if (newPaths.length === displayed.length) {
       return;
     }
-    const newPaths = this.displayedPropertyPaths.filter((displayedPath) =>
-      availablePaths.has(serializePropertyPath(displayedPath)),
-    );
     this.setDisplayedPropertyPaths(newPaths);
   }
 


### PR DESCRIPTION
Fixes #1326.

## The bug

On lazy (stub-only) datasets, displayed property columns saved in the configuration could silently disappear between sessions — observed live on a 708K-annotation dataset, where 3 of 5 saved columns vanished from the persisted `annotationBrowserConfig`.

`updateDisplayedFromComputedProperties` runs from the global watcher on `propertyValues` and dropped every displayed path missing from `computedPropertyPaths`. In lazy mode that set is built from a 512-doc sample (`fetchPropertyPathsSample`), and the sample is **not authoritative**: properties are shape/tag-scoped (`canComputeAnnotationProperty`) and computed at different times, so a property computed for hundreds of thousands of annotations can be absent from it entirely. The existing empty-set guard only covers "nothing loaded yet" — a *partially* loaded set sails straight past it. Any later annotation-browser change then persisted the pruned list through the debounced `saveAnnotationBrowserConfig`, making the loss permanent.

## The fix

The prune is now mode-aware:

| Mode | Pruned against | Skipped while |
|---|---|---|
| wholesale (client) | `computedPropertyPaths` — exact paths, derived from every loaded value (unchanged) | that set is empty |
| lazy (stub-only) | the **property ids** still attached to the configuration | `properties` is empty |

A column retained in lazy mode still renders its values: those are fetched by explicit path (`findByAnnotationIds` projection), never through discovery.

Also skip the write when nothing was pruned. Both branches only ever drop entries, so an unchanged length means an unchanged list, and the replaced array's identity is a reactive dependency — `AnnotationViewer` re-runs `ensureVisiblePropertyValues` on it, which can commit values and re-enter this same watcher, on every viewport-scoped merge (i.e. every pan in lazy mode).

## Verification

`pnpm tsc`, `pnpm lint:ci` and the full suite (3629 tests) are green. Four new lazy-mode cases in `src/store/__tests__/properties.test.ts`; confirmed via `git stash` that two of them fail without the fix (sampled-discovery retention, and the no-op guard) while the wholesale-mode tests in `annotationBrowserConfig.test.ts` still pass. Store-level only — no live reproduction, which would need a dataset above the stub-only threshold with sparsely-present properties.

## Not included, deliberately

The issue's alternative — a server-side distinct-path aggregation to make discovery authoritative — is left out: it is a full scan of the dataset's value docs on a public endpoint and deserves its own perf/rate-limiting discussion. One consequence remains because of that: a path missing from the sample still isn't offered by `PropertyPicker` (which lists `computedPropertyPaths`), so such a column can be *removed* via the list header but not re-*added* until the sample happens to include it.

## Docs and skills

- `codebaseDocumentation/ANNOTATION-STUBS.md` — the sampling limitation, the mode table, the remaining `PropertyPicker` gap, and a regression checklist naming the test behind each invariant.
- `.claude/skills/nimbus-frontend/SKILL.md` — the general rule this generalizes to: never reconcile persisted state against a partial source (sample, page, or viewport-scoped cache), and pair a debounced save with it at your peril. Both skill trees synced via `sync_skills.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0112HsRZ8GY7S9SBBudjiHuN)_