### PR TITLE
HUD says when filters or gates are narrowing its counts

### DIFF
--- a/.agents/skills/nimbus-frontend/SKILL.md
+++ b/.agents/skills/nimbus-frontend/SKILL.md
@@ -27,6 +27,20 @@ Rules:
 - Before trusting a new watcher test, make it FAIL once (revert the fix, or
   assert the opposite) — this one passed for the wrong reason first.
 
+Two related mock traps, both of which make a test assert against something
+the component never touched:
+
+- **A `vi.mock` factory captures the spy it closes over.** Reassigning
+  `mocks.someAction = vi.fn()` in `beforeEach` leaves the component calling
+  the *original* spy while the test asserts on the new one — "expected spy
+  to be called, number of calls: 0" with obviously working code. Use
+  `mocks.someAction.mockClear()` instead.
+- **A plain-object store mock is not reactive**, so a component watching
+  `() => store.something` never fires when a test assigns to it. If the
+  behavior under test is a watcher on store state, wrap the mock's default
+  export in `reactive()` (`vi.mock("@/store", async () => { const { reactive }
+  = await import("vue"); return { default: reactive({ … }) }; })`).
+
 ## Component Patterns
 
 ### Script Setup (Composition API)
@@ -506,6 +520,38 @@ Use the API classes from store — never put `girderRest.get(...)` in components
 import store from "@/store";
 const result = await store.api.someMethod();
 ```
+
+## Opening a palette from a component that has no palette registry
+
+App.vue owns palette (right/left panel) visibility in local refs, so a
+component mounted under the route tree — anything inside `ImageViewer` /
+`AnnotationViewer` — cannot open one by emitting an event. Ask through the
+main store instead: `store.requestPaletteOpen(["analysisPanel",
+"filtersPanel"])` sets `paletteOpenRequests`; App.vue watches it, opens each
+in order, and clears the list. Order matters — open the *primary* palette
+first, then its companion (Filters hosts alongside Analysis and the Object
+Browser); the other order closes the palette just opened.
+`TRequestablePalette` in `model.ts` is a subset of App.vue's `PaletteId`, so
+keep them in step — that is what makes a renamed palette a compile error
+rather than a click that does nothing. Same shape as the older
+`isAnnotationPanelOpen` hatch used by the Timelapse panel.
+
+## A count computed after filtering must say it was filtered
+
+Every count the UI prints from `filteredAnnotations`, `viewportAnnotationCount`,
+or any id set that survived filters/gates is a *filtered* number. Printed
+without a cue, it reads as data loss the moment a filter is restored from a
+saved configuration — the reported case was a HUD reading "Showing 826 of 826
+in view" in a viewport visibly holding thousands, because a saved lasso gate
+cut 708,983 to 72,925.
+
+- The cue belongs **next to the number**, not on a palette badge across the
+  window. A badge that was visible the whole time did not prevent the report.
+- Count constraints through `src/utils/activeConstraints.ts` —
+  `collectActiveConstraints` / `countActiveConstraints` — never with a fresh
+  ad-hoc sum. The Filters badge, the Analysis badge and the HUD suffix all
+  read that one list; a new narrowing filter that skips it is invisible on
+  all three. See `codebaseDocumentation/ACTIVE_CONSTRAINT_CUES.md`.
 
 ## Logging
 

--- a/.claude/skills/nimbus-frontend/SKILL.md
+++ b/.claude/skills/nimbus-frontend/SKILL.md
@@ -27,6 +27,20 @@ Rules:
 - Before trusting a new watcher test, make it FAIL once (revert the fix, or
   assert the opposite) — this one passed for the wrong reason first.
 
+Two related mock traps, both of which make a test assert against something
+the component never touched:
+
+- **A `vi.mock` factory captures the spy it closes over.** Reassigning
+  `mocks.someAction = vi.fn()` in `beforeEach` leaves the component calling
+  the *original* spy while the test asserts on the new one — "expected spy
+  to be called, number of calls: 0" with obviously working code. Use
+  `mocks.someAction.mockClear()` instead.
+- **A plain-object store mock is not reactive**, so a component watching
+  `() => store.something` never fires when a test assigns to it. If the
+  behavior under test is a watcher on store state, wrap the mock's default
+  export in `reactive()` (`vi.mock("@/store", async () => { const { reactive }
+  = await import("vue"); return { default: reactive({ … }) }; })`).
+
 ## Component Patterns
 
 ### Script Setup (Composition API)
@@ -506,6 +520,38 @@ Use the API classes from store — never put `girderRest.get(...)` in components
 import store from "@/store";
 const result = await store.api.someMethod();
 ```
+
+## Opening a palette from a component that has no palette registry
+
+App.vue owns palette (right/left panel) visibility in local refs, so a
+component mounted under the route tree — anything inside `ImageViewer` /
+`AnnotationViewer` — cannot open one by emitting an event. Ask through the
+main store instead: `store.requestPaletteOpen(["analysisPanel",
+"filtersPanel"])` sets `paletteOpenRequests`; App.vue watches it, opens each
+in order, and clears the list. Order matters — open the *primary* palette
+first, then its companion (Filters hosts alongside Analysis and the Object
+Browser); the other order closes the palette just opened.
+`TRequestablePalette` in `model.ts` is a subset of App.vue's `PaletteId`, so
+keep them in step — that is what makes a renamed palette a compile error
+rather than a click that does nothing. Same shape as the older
+`isAnnotationPanelOpen` hatch used by the Timelapse panel.
+
+## A count computed after filtering must say it was filtered
+
+Every count the UI prints from `filteredAnnotations`, `viewportAnnotationCount`,
+or any id set that survived filters/gates is a *filtered* number. Printed
+without a cue, it reads as data loss the moment a filter is restored from a
+saved configuration — the reported case was a HUD reading "Showing 826 of 826
+in view" in a viewport visibly holding thousands, because a saved lasso gate
+cut 708,983 to 72,925.
+
+- The cue belongs **next to the number**, not on a palette badge across the
+  window. A badge that was visible the whole time did not prevent the report.
+- Count constraints through `src/utils/activeConstraints.ts` —
+  `collectActiveConstraints` / `countActiveConstraints` — never with a fresh
+  ad-hoc sum. The Filters badge, the Analysis badge and the HUD suffix all
+  read that one list; a new narrowing filter that skips it is invisible on
+  all three. See `codebaseDocumentation/ACTIVE_CONSTRAINT_CUES.md`.
 
 ## Logging
 

--- a/codebaseDocumentation/ACTIVE_CONSTRAINT_CUES.md
+++ b/codebaseDocumentation/ACTIVE_CONSTRAINT_CUES.md
@@ -41,9 +41,12 @@ place that decides what counts as "something is narrowing the object set":
 The filters store keeps its two existing getters but they now *count the one
 list* — `activeFilterCount` = `countActiveConstraints(activeConstraints,
 "filters")`, `activeAnalysisGateCount` = the `"analysis"` half — and gains
-`activeConstraints` / `activeConstraintCount` for the HUD. The semantics are
-unchanged (each badge still counts only what its own panel can show); what
-changes is that they can no longer drift from each other or from the HUD.
+`activeConstraints` / `activeConstraintCount` for the HUD. Each badge still
+counts only what its own panel can show, and they can no longer drift from
+each other or from the HUD. One deliberate semantic change (Codex review):
+an enabled values-mode property filter whose values list is empty no longer
+counts anywhere — it is a documented pass-all no-op, so the old badge count
+included a "filter" that filtered nothing.
 
 **The HUD suffix.** `computeRenderCoverage` takes `constraintCount` and returns
 `constraintLabel` — `"(1 filter applied)"` / `"(3 filters applied)"` — rendered
@@ -60,6 +63,15 @@ told their numbers are narrowed, and the tooltip names what did it.
 - **Not gated on stub mode.** The counts are filtered in client mode too, so
   the suffix appears wherever the HUD appears. It does not change *when* the
   HUD appears: the show rule is still stub mode or active downsampling.
+
+**The passing count.** The HUD's second line grows the narrowed population:
+`"708,983 total annotations (289,469 passing filters)"`. `computeRenderCoverage`
+takes `passingCount` and returns `passingLabel`, gated on the same
+`constraintCount > 0` condition as `constraintLabel` — with nothing narrowing
+the set the passing count equals the total, so saying it would repeat the
+number. The component feeds it `filterStore.filteredAnnotations.length`, which
+the drawing path (AnnotationViewer) already computes reactively, so the read is
+a cached-getter lookup, not a new pass over the dataset.
 
 **Reaching the palette registry.** The HUD is mounted deep inside
 `ImageViewer.vue`, with no path to App.vue's palette state, so it asks through
@@ -80,6 +92,12 @@ Change any of this and re-check these. Each item names the test that holds it.
   not, and a region still being drawn (`emptyROIFilter`) is not — *"collects
   every filter kind the Filters panel exposes"*, *"does not count disabled
   filters"*
+- An enabled values-mode property filter with an empty values list is not
+  collected: emptying the textarea writes `values: []` meaning "do not
+  filter", the filtering path passes everything for it, and the backend drops
+  it (`dropNoOpPropertyFilters`) — announcing it would claim narrowing the
+  viewer contradicts (Codex review on PR #1332) — *"does not count an enabled
+  values filter whose values list is empty"*
 - A gate counts only when enabled **and** drawn **and** resolved: an unresolved
   gate constrains nothing, so announcing it would contradict the viewer, which
   is showing more — *"counts a gate only once it is enabled, drawn AND
@@ -118,6 +136,15 @@ Change any of this and re-check these. Each item names the test that holds it.
 - Null when no constraint is active; pluralized otherwise — *"says nothing
   about constraints when none is active"*, *"announces active constraints,
   pluralized"*
+- The passing count appears only while something narrows the set, and only
+  when a count was supplied — *"reports how many objects pass the active
+  constraints"*, *"omits the passing count when nothing is narrowing the
+  set"*, *"omits the passing count when the caller has none to report"*
+- On the HUD it shares the total's line, in one interpolation so template
+  whitespace handling cannot drop the space between them
+  (`RenderCoverageIndicator.test.ts`) — *"shows how many objects pass next to
+  the total when narrowed"*, *"keeps the total line bare when nothing is
+  narrowing the set"*
 
 **Palette requests (`src/App.test.ts`)**
 - A request opens every palette it names and is then cleared, so the same

--- a/codebaseDocumentation/ACTIVE_CONSTRAINT_CUES.md
+++ b/codebaseDocumentation/ACTIVE_CONSTRAINT_CUES.md
@@ -1,0 +1,137 @@
+# Active-constraint cues: telling the user why the counts are small
+
+**Status:** Implemented (2026-08-15). Issue #1328.
+
+## Problem
+
+The render-coverage HUD (`RenderCoverageIndicator.vue`, top-center over the
+canvas) reports **filtered** counts: `viewportAnnotationCount` /
+`viewportRenderedCount` are computed from the id set that already survived
+filters and analysis gates (`updateVisibilityAndHydration`, Steps 2 and 5b in
+`src/store/annotation.ts`). Nothing in the widget said so.
+
+A saved 16-vertex lasso gate (Area × PECAM1) restored from a configuration at
+load resolved 72,925 of 708,983 annotations (10.3%), and the HUD read
+
+> Showing 826 of 826 in view
+
+in a viewport that visibly held thousands of objects. For an expert user that
+reads as data loss, not as filtering. The `1` badge on the Analysis palette
+icon was present the whole time and was not enough: it lives at the edge of the
+window, far from the number the user is actually reading, and it says nothing
+about the count it explains.
+
+## Design
+
+**One list, three surfaces.** `src/utils/activeConstraints.ts` is now the only
+place that decides what counts as "something is narrowing the object set":
+
+- `collectActiveConstraints(input)` → `IActiveConstraint[]`, pure data. Each
+  entry carries its `source` (`"filters"` or `"analysis"`), its `kind`, and
+  just enough detail to name it later (a property filter's path, a gate's
+  axes). Filters panel first, then gates in plot order.
+- `countActiveConstraints(list, source?)` → the badges' numbers when a source
+  is given, the HUD's number when it is not.
+- `describeConstraint` / `summarizeActiveConstraints(list, resolveName)` →
+  `"1 lasso gate on Area × PECAM1; 1 tag filter"`. Naming a property path needs
+  the properties store, which is why phrasing is separate from collecting: the
+  collectors run inside a filters-store getter and must not pull a store
+  dependency into it.
+
+The filters store keeps its two existing getters but they now *count the one
+list* — `activeFilterCount` = `countActiveConstraints(activeConstraints,
+"filters")`, `activeAnalysisGateCount` = the `"analysis"` half — and gains
+`activeConstraints` / `activeConstraintCount` for the HUD. The semantics are
+unchanged (each badge still counts only what its own panel can show); what
+changes is that they can no longer drift from each other or from the HUD.
+
+**The HUD suffix.** `computeRenderCoverage` takes `constraintCount` and returns
+`constraintLabel` — `"(1 filter applied)"` / `"(3 filters applied)"` — rendered
+as a warning-tinted, dotted-underlined button on the same line as
+"Showing 826 of 826 in view". "filter" covers gates too: the reader is being
+told their numbers are narrowed, and the tooltip names what did it.
+
+- **Tooltip** (native `title`, also the `aria-label`, since the visible text is
+  only a count): *"Objects are narrowed by 1 lasso gate on Area × PECAM1;
+  1 tag filter. Click to open Analysis and Filters."*
+- **Click** opens the panels that own the active constraints — Analysis first,
+  then Filters, because Filters is a *companion* palette that hosts alongside
+  Analysis; the other order would close the one just opened.
+- **Not gated on stub mode.** The counts are filtered in client mode too, so
+  the suffix appears wherever the HUD appears. It does not change *when* the
+  HUD appears: the show rule is still stub mode or active downsampling.
+
+**Reaching the palette registry.** The HUD is mounted deep inside
+`ImageViewer.vue`, with no path to App.vue's palette state, so it asks through
+the store: `main.requestPaletteOpen(["analysisPanel", "filtersPanel"])` sets
+`paletteOpenRequests`, App.vue watches it, opens each palette in order and
+clears the list (so the same request twice in a row is still seen as a change).
+This generalizes the existing `isAnnotationPanelOpen` escape hatch used by the
+Timelapse panel. `TRequestablePalette` (in `model.ts`) is a subset of App.vue's
+`PaletteId`, so renaming a palette id fails to compile rather than silently
+never opening anything.
+
+## Regression checklist
+
+Change any of this and re-check these. Each item names the test that holds it.
+
+**What counts as a constraint (`src/utils/__tests__/activeConstraints.test.ts`)**
+- Every filter kind the Filters panel exposes is collected, disabled rows are
+  not, and a region still being drawn (`emptyROIFilter`) is not — *"collects
+  every filter kind the Filters panel exposes"*, *"does not count disabled
+  filters"*
+- A gate counts only when enabled **and** drawn **and** resolved: an unresolved
+  gate constrains nothing, so announcing it would contradict the viewer, which
+  is showing more — *"counts a gate only once it is enabled, drawn AND
+  resolved"*
+- Each panel's count is its own; the HUD's count is both — *"counts each
+  panel's own constraints separately"*, *"counts everything narrowing the set
+  when no panel is given"*
+- Phrases name the gate's plane and the filtered property, collapse duplicates
+  with pluralization, and degrade rather than invent: a half-configured gate
+  drops the plane instead of implying a one-dimensional gate, and an
+  unresolvable property path drops the name — *"names the gate's plane and the
+  filters alongside it"*, *"collapses identical constraints into a pluralized
+  count"*, *"omits the plane of a half-configured gate rather than implying one
+  axis"*, *"falls back to no property name when the path no longer resolves"*
+
+**Badges still count only their own panel (`src/store/__tests__/activeFilterCount.test.ts`)**
+- The store getters delegating to the shared collector did not change what they
+  count: gates stay off the Filters badge — *"stays 0 for a resolved, enabled
+  gate"*, *"counts only the panel's own filters alongside a gate"*
+
+**The HUD (`src/components/RenderCoverageIndicator.test.ts`)**
+- No suffix when nothing is narrowing — *"says nothing about constraints when
+  none is active"*
+- The count sits on the same line as the numbers it explains — *"appends the
+  constraint count next to the counts it explains"*
+- The tooltip names the constraints and is mirrored into `aria-label` — *"names
+  the active constraints in its tooltip"*
+- Clicking opens the owning panel, Analysis before Filters — *"opens the panel
+  that owns the constraint when clicked"*, *"opens Analysis before Filters so
+  the companion stacks beside it"*
+- The suffix is not gated on stub mode — *"shows the constraint suffix outside
+  stub mode too"* (and `renderCoverage.test.ts`, *"announces constraints
+  outside stub mode too"*)
+
+**The label itself (`src/utils/__tests__/renderCoverage.test.ts`)**
+- Null when no constraint is active; pluralized otherwise — *"says nothing
+  about constraints when none is active"*, *"announces active constraints,
+  pluralized"*
+
+**Palette requests (`src/App.test.ts`)**
+- A request opens every palette it names and is then cleared, so the same
+  request can be made again — *"opens the palettes a store request asks for,
+  then clears the request"*
+- An empty request is a no-op — *"ignores an empty palette request"*
+- The store mock is `reactive` for these: a plain object never fires the
+  watcher, so both tests would pass vacuously against a broken wiring.
+
+## Notes for future changes
+
+- **Add a narrowing constraint anywhere → add it to `collectActiveConstraints`.**
+  That is the single place all three surfaces read; a new filter kind that
+  skips it is invisible on every one of them, not just the HUD.
+- The HUD's suffix says "filter" for gates as well. If gate and filter ever
+  need to be distinguished in the visible text, the split already exists in the
+  data (`source`) — only the phrasing would change.

--- a/codebaseDocumentation/ANALYSIS_PANEL.md
+++ b/codebaseDocumentation/ANALYSIS_PANEL.md
@@ -404,7 +404,9 @@ Change any of this and re-check these. Each item names the test that holds it.
 - Gates count on the **Analysis** badge, never the Filters badge, so neither
   button claims a filter its own panel cannot show — *"stays 0 for a
   resolved, enabled gate"*, *"counts only the panel's own filters alongside a
-  gate"*, *"keeps the two badges independent"*
+  gate"*, *"keeps the two badges independent"*. Both badges and the
+  render-coverage HUD count one shared list, so a gate can never be surfaced
+  by one and missed by another — see `ACTIVE_CONSTRAINT_CUES.md`
 - A drawn but unresolved gate constrains nothing, so drawing never flashes empty — *"does not constrain a drawn gate until its ids have been resolved"*
 - Multiple enabled gates AND (not union); disabling one drops its constraint but keeps its polygon; clearing restores — *"ANDs the enabled resolved gates into filteredAnnotations"*
 - An empty resolved gate filters everything out, and is not treated as "no gate" — *"treats an empty resolved gate as filtering everything out"*

--- a/codebaseDocumentation/SERVER_GATING.md
+++ b/codebaseDocumentation/SERVER_GATING.md
@@ -335,7 +335,10 @@ the cap **nothing changes**.
   (`activeAnalysisGateCount`), which counts gates rather than ids and so
   works unchanged above the cap. Note that badge is on Analysis, not
   Filters: `activeFilterCount` deliberately excludes gates, because each
-  badge counts only what its own panel can display.
+  badge counts only what its own panel can display. (Since #1328 both counts
+  come from one shared list, and the render-coverage HUD prints their sum as
+  "(N filters applied)" beside the counts it explains — see
+  `ACTIVE_CONSTRAINT_CUES.md`.)
 
 ### What Phase 1 explicitly does not do
 

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -6,21 +6,29 @@ vi.mock("@/utils/log", () => ({
   logError: vi.fn(),
 }));
 
-vi.mock("@/store", () => ({
-  default: {
-    isLoggedIn: false,
-    girderUser: null,
-    dataset: null,
-    setToolTemplateList: vi.fn(),
-    setIsAnnotationPanelOpen: vi.fn(),
-    api: {
-      getUserPrivateFolder: vi.fn().mockResolvedValue({ _id: "folder-1" }),
-    },
-    initializeUploadWorkflow: vi.fn(),
-    isAnnotationPanelOpen: false,
-    annotationPanel: false,
-  },
-}));
+// Reactive: App.vue watches the store for palette-open requests (the escape
+// hatch used by components with no access to the palette registry), and a
+// plain object would never fire that watcher.
+vi.mock("@/store", async () => {
+  const { reactive } = await import("vue");
+  return {
+    default: reactive({
+      isLoggedIn: false,
+      girderUser: null,
+      dataset: null,
+      setToolTemplateList: vi.fn(),
+      setIsAnnotationPanelOpen: vi.fn(),
+      api: {
+        getUserPrivateFolder: vi.fn().mockResolvedValue({ _id: "folder-1" }),
+      },
+      initializeUploadWorkflow: vi.fn(),
+      isAnnotationPanelOpen: false,
+      annotationPanel: false,
+      paletteOpenRequests: [] as string[],
+      setPaletteOpenRequests: vi.fn(),
+    }),
+  };
+});
 
 vi.mock("@/store/properties", () => ({
   default: {
@@ -130,6 +138,8 @@ describe("App", () => {
     (store as any).api = {
       getUserPrivateFolder: vi.fn().mockResolvedValue({ _id: "folder-1" }),
     };
+    (store as any).paletteOpenRequests = [];
+    (store as any).setPaletteOpenRequests = vi.fn();
     (propertyStore as any).uncomputedCountByProperty = {};
     (filterStore as any).activeFilterCount = 0;
     (filterStore as any).activeAnalysisGateCount = 0;
@@ -424,6 +434,31 @@ describe("App", () => {
     (filterStore as any).activeAnalysisGateCount = 3;
     wrapper = mountComponent({ name: "datasetview" });
     expect((wrapper.vm as any).analysisTooltip).toContain("(3 gates active)");
+  });
+
+  // -- Palette-open requests from components with no palette registry --
+  //
+  // The render-coverage HUD lives inside ImageViewer, far below the route
+  // component, so it asks for a panel through the store rather than by event.
+  it("opens the palettes a store request asks for, then clears the request", async () => {
+    const wrapper = mountComponent({ name: "datasetview" });
+    const vm = wrapper.vm as any;
+    (store as any).paletteOpenRequests = ["analysisPanel", "filtersPanel"];
+    await nextTick();
+    // Both, not one: Filters is a companion that hosts alongside Analysis, so
+    // a gate and a tag filter can be shown together.
+    expect(vm.analysisPanel).toBe(true);
+    expect(vm.filtersPanel).toBe(true);
+    // Cleared, so asking for the same palette again is still seen as a change.
+    expect(store.setPaletteOpenRequests).toHaveBeenCalledWith([]);
+  });
+
+  it("ignores an empty palette request", async () => {
+    const wrapper = mountComponent({ name: "datasetview" });
+    (store as any).paletteOpenRequests = [];
+    await nextTick();
+    expect((wrapper.vm as any).filtersPanel).toBe(false);
+    expect(store.setPaletteOpenRequests).not.toHaveBeenCalled();
   });
 
   // -- Computed: filteredToursByCategory --

--- a/src/App.vue
+++ b/src/App.vue
@@ -1272,6 +1272,23 @@ watch(
   },
 );
 
+// Same escape hatch, generalized: a component with no access to the palette
+// registry (the render-coverage HUD, deep inside ImageViewer) asks for a
+// palette by id and this opens it. Cleared immediately so the next request for
+// the same palette is still seen as a change.
+watch(
+  () => store.paletteOpenRequests,
+  (requests) => {
+    if (requests.length === 0) {
+      return;
+    }
+    for (const id of requests) {
+      openPalette(id);
+    }
+    store.setPaletteOpenRequests([]);
+  },
+);
+
 watch(routeName, () => datasetChanged());
 
 // Left palettes mount/unmount with the dataset view, so (re)attach their

--- a/src/components/RenderCoverageIndicator.test.ts
+++ b/src/components/RenderCoverageIndicator.test.ts
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   viewportRenderedCount: 826,
   viewportAnnotationCount: 826,
   stubOnlyMode: true,
+  // The component only reads .length, so a real array is not needed.
+  filteredAnnotationCount: 289469,
 }));
 
 vi.mock("@/store", () => ({
@@ -46,6 +48,9 @@ vi.mock("@/store/filters", () => ({
   default: {
     get activeConstraints() {
       return mocks.constraints;
+    },
+    get filteredAnnotations() {
+      return { length: mocks.filteredAnnotationCount };
     },
   },
 }));
@@ -111,6 +116,21 @@ describe("RenderCoverageIndicator", () => {
     expect(wrapper.find(".render-coverage__label").text()).toBe(
       "Showing 826 of 826 in view (1 filter applied)",
     );
+  });
+
+  it("shows how many objects pass next to the total when narrowed", () => {
+    mocks.constraints = [GATE_CONSTRAINT];
+    const suffix = mountIndicator().find(".render-coverage__suffix");
+    // One line: the total AND the narrowed population, so the user can read
+    // both without opening a panel. (The mock's stub map is empty → 0 total.)
+    expect(suffix.text()).toBe(
+      `0 total annotations (${(289469).toLocaleString()} passing filters)`,
+    );
+  });
+
+  it("keeps the total line bare when nothing is narrowing the set", () => {
+    const suffix = mountIndicator().find(".render-coverage__suffix");
+    expect(suffix.text()).toBe("0 total annotations");
   });
 
   it("names the active constraints in its tooltip", () => {

--- a/src/components/RenderCoverageIndicator.test.ts
+++ b/src/components/RenderCoverageIndicator.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The HUD is where users look when they suspect missing data, so what it says
+ * about active filters/gates — and what clicking that says-so does — is pinned
+ * here. The counts it prints are computed AFTER filters and gates; a restored
+ * lasso gate once made it read "Showing 826 of 826 in view" in a viewport that
+ * visibly held thousands, with the only cue a badge on a far-away palette icon.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import { IActiveConstraint } from "@/utils/activeConstraints";
+
+const mocks = vi.hoisted(() => ({
+  requestPaletteOpen: vi.fn(),
+  constraints: [] as IActiveConstraint[],
+  stubs: new Map<string, unknown>(),
+  viewportRenderedCount: 826,
+  viewportAnnotationCount: 826,
+  stubOnlyMode: true,
+}));
+
+vi.mock("@/store", () => ({
+  default: {
+    requestPaletteOpen: mocks.requestPaletteOpen,
+  },
+}));
+
+vi.mock("@/store/annotation", () => ({
+  default: {
+    get stubOnlyMode() {
+      return mocks.stubOnlyMode;
+    },
+    get annotationStubs() {
+      return mocks.stubs;
+    },
+    get viewportRenderedCount() {
+      return mocks.viewportRenderedCount;
+    },
+    get viewportAnnotationCount() {
+      return mocks.viewportAnnotationCount;
+    },
+    visibilityConfig: { stubThreshold: 50000 },
+  },
+}));
+
+vi.mock("@/store/filters", () => ({
+  default: {
+    get activeConstraints() {
+      return mocks.constraints;
+    },
+  },
+}));
+
+vi.mock("@/store/properties", () => ({
+  default: {
+    getFullNameFromPath: (path: string[]) =>
+      ({ "p.Area": "Area", "p.PECAM1": "PECAM1" })[path.join(".")] ?? null,
+  },
+}));
+
+import RenderCoverageIndicator from "./RenderCoverageIndicator.vue";
+
+const GATE_CONSTRAINT: IActiveConstraint = {
+  source: "analysis",
+  kind: "gate",
+  xAxis: { type: "property", path: ["p", "Area"] },
+  yAxis: { type: "property", path: ["p", "PECAM1"] },
+};
+
+const TAG_CONSTRAINT: IActiveConstraint = { source: "filters", kind: "tag" };
+
+function mountIndicator() {
+  return shallowMount(RenderCoverageIndicator, {
+    global: {
+      stubs: {
+        VMenu: { template: "<div><slot name='activator' :props='{}' /></div>" },
+        VBtn: true,
+        VCard: true,
+        VCardTitle: true,
+        VCardText: true,
+        VisibilitySettings: true,
+      },
+    },
+  });
+}
+
+describe("RenderCoverageIndicator", () => {
+  beforeEach(() => {
+    // Cleared, never reassigned: the module factory captured this very spy,
+    // so a fresh vi.fn() here would leave the component calling the old one.
+    mocks.requestPaletteOpen.mockClear();
+    mocks.constraints = [];
+    mocks.stubOnlyMode = true;
+    mocks.viewportRenderedCount = 826;
+    mocks.viewportAnnotationCount = 826;
+  });
+
+  it("says nothing about constraints when none is active", () => {
+    const wrapper = mountIndicator();
+    expect(wrapper.text()).toContain("Showing 826 of 826 in view");
+    expect(wrapper.find(".render-coverage__constraints").exists()).toBe(false);
+  });
+
+  it("appends the constraint count next to the counts it explains", () => {
+    mocks.constraints = [GATE_CONSTRAINT];
+    const wrapper = mountIndicator();
+    const suffix = wrapper.find(".render-coverage__constraints");
+    expect(suffix.text()).toBe("(1 filter applied)");
+    // On the same line as the number that reads like data loss, not on a
+    // palette icon at the edge of the window — and reading as one sentence,
+    // which template whitespace handling is free to break.
+    expect(wrapper.find(".render-coverage__label").text()).toBe(
+      "Showing 826 of 826 in view (1 filter applied)",
+    );
+  });
+
+  it("names the active constraints in its tooltip", () => {
+    mocks.constraints = [GATE_CONSTRAINT, TAG_CONSTRAINT];
+    const suffix = mountIndicator().find(".render-coverage__constraints");
+    expect(suffix.text()).toBe("(2 filters applied)");
+    expect(suffix.attributes("title")).toBe(
+      "Objects are narrowed by 1 lasso gate on Area × PECAM1; 1 tag filter. " +
+        "Click to open Analysis and Filters.",
+    );
+    // aria-label carries the same sentence: the suffix's own text is only a
+    // count, which tells a screen-reader user nothing about what to clear.
+    expect(suffix.attributes("aria-label")).toBe(suffix.attributes("title"));
+  });
+
+  it("opens the panel that owns the constraint when clicked", async () => {
+    mocks.constraints = [TAG_CONSTRAINT];
+    await mountIndicator()
+      .find(".render-coverage__constraints")
+      .trigger("click");
+    expect(mocks.requestPaletteOpen).toHaveBeenCalledWith(["filtersPanel"]);
+  });
+
+  it("opens Analysis before Filters so the companion stacks beside it", async () => {
+    mocks.constraints = [GATE_CONSTRAINT, TAG_CONSTRAINT];
+    await mountIndicator()
+      .find(".render-coverage__constraints")
+      .trigger("click");
+    expect(mocks.requestPaletteOpen).toHaveBeenCalledWith([
+      "analysisPanel",
+      "filtersPanel",
+    ]);
+  });
+
+  it("shows the constraint suffix outside stub mode too", () => {
+    // Client mode with the render budget clipping the view: the counts are
+    // filtered here as well, so the cue must not be gated on stub mode.
+    mocks.stubOnlyMode = false;
+    mocks.viewportRenderedCount = 100;
+    mocks.viewportAnnotationCount = 45000;
+    mocks.constraints = [TAG_CONSTRAINT];
+    const wrapper = mountIndicator();
+    expect(wrapper.find(".render-coverage").exists()).toBe(true);
+    expect(wrapper.find(".render-coverage__constraints").text()).toBe(
+      "(1 filter applied)",
+    );
+  });
+});

--- a/src/components/RenderCoverageIndicator.vue
+++ b/src/components/RenderCoverageIndicator.vue
@@ -7,6 +7,21 @@
   >
     <span class="render-coverage__label">
       {{ coverage.shownLabel }}
+      <!-- Both counts above are computed AFTER filters and analysis gates, so
+           a restored gate can make the HUD read "826 of 826" in a viewport
+           that visibly holds thousands. The suffix says narrowing is active,
+           its tooltip says which, and clicking it opens the panel that owns
+           it — the palette badges are too far from the count being read. -->
+      <button
+        v-if="coverage.constraintLabel"
+        type="button"
+        class="render-coverage__constraints"
+        :title="constraintTooltip"
+        :aria-label="constraintTooltip"
+        @click="openConstraintPanels"
+      >
+        {{ coverage.constraintLabel }}
+      </button>
     </span>
     <div class="render-coverage__track">
       <div
@@ -42,7 +57,12 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import store from "@/store";
 import annotationStore from "@/store/annotation";
+import filterStore from "@/store/filters";
+import propertyStore from "@/store/properties";
+import { TRequestablePalette } from "@/store/model";
+import { summarizeActiveConstraints } from "@/utils/activeConstraints";
 import { computeRenderCoverage } from "@/utils/renderCoverage";
 import VisibilitySettings from "@/components/VisibilitySettings.vue";
 
@@ -64,14 +84,52 @@ const stubMode = computed(
       annotationStore.visibilityConfig.stubThreshold,
 );
 
+// Filters AND analysis gates, from the one list the app-bar badges count too
+// (utils/activeConstraints.ts), so the three surfaces cannot disagree.
+const constraints = computed(() => filterStore.activeConstraints);
+
 const coverage = computed(() =>
   computeRenderCoverage({
     stubMode: stubMode.value,
     viewportShown: annotationStore.viewportRenderedCount,
     viewportTotal: annotationStore.viewportAnnotationCount,
     loaded: annotationStore.annotationStubs.size,
+    constraintCount: constraints.value.length,
   }),
 );
+
+// Which palettes own the active constraints, Analysis first: it is a primary
+// palette, and Filters is a companion that hosts alongside it — opening them
+// the other way round would close the one just opened.
+const constraintPalettes = computed<TRequestablePalette[]>(() => {
+  const palettes: TRequestablePalette[] = [];
+  if (
+    constraints.value.some((constraint) => constraint.source === "analysis")
+  ) {
+    palettes.push("analysisPanel");
+  }
+  if (constraints.value.some((constraint) => constraint.source === "filters")) {
+    palettes.push("filtersPanel");
+  }
+  return palettes;
+});
+
+const PALETTE_NAMES: Record<TRequestablePalette, string> = {
+  analysisPanel: "Analysis",
+  filtersPanel: "Filters",
+};
+
+const constraintTooltip = computed(() => {
+  const summary = summarizeActiveConstraints(constraints.value, (path) =>
+    propertyStore.getFullNameFromPath(path),
+  );
+  const names = constraintPalettes.value.map((id) => PALETTE_NAMES[id]);
+  return `Objects are narrowed by ${summary}. Click to open ${names.join(" and ")}.`;
+});
+
+function openConstraintPanels() {
+  store.requestPaletteOpen(constraintPalettes.value);
+}
 </script>
 
 <style lang="scss" scoped>
@@ -100,6 +158,31 @@ const coverage = computed(() =>
   font-weight: 600;
   letter-spacing: 0.02em;
   white-space: nowrap;
+}
+
+.render-coverage__constraints {
+  // A real <button> (it is clickable and focusable), stripped back to text so
+  // it reads as part of the sentence rather than as a form control.
+  background: none;
+  border: 0;
+  padding: 0;
+  // Explicit, so the gap does not depend on how the template's whitespace
+  // survives compilation.
+  margin-left: 4px;
+  // Warning-tinted and underlined: the reason the counts are smaller than the
+  // eye expects, sitting on the line the user is actually reading.
+  color: rgb(var(--v-theme-warning));
+  font: inherit;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  // Re-enable clicks on just this button (the container is click-through).
+  pointer-events: auto;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline solid;
+  }
 }
 
 .render-coverage__suffix {

--- a/src/components/RenderCoverageIndicator.vue
+++ b/src/components/RenderCoverageIndicator.vue
@@ -29,7 +29,14 @@
         :style="{ width: `${(coverage.fraction * 100).toFixed(1)}%` }"
       />
     </div>
-    <span class="render-coverage__suffix">{{ coverage.totalLabel }}</span>
+    <!-- One interpolation (not sibling nodes) so the space between the total
+         and the passing count cannot be dropped by template whitespace
+         handling. -->
+    <span class="render-coverage__suffix">{{
+      coverage.passingLabel
+        ? `${coverage.totalLabel} ${coverage.passingLabel}`
+        : coverage.totalLabel
+    }}</span>
 
     <v-menu :close-on-content-click="false" location="bottom end" offset="6">
       <template #activator="{ props: menuProps }">
@@ -95,6 +102,10 @@ const coverage = computed(() =>
     viewportTotal: annotationStore.viewportAnnotationCount,
     loaded: annotationStore.annotationStubs.size,
     constraintCount: constraints.value.length,
+    // Already computed by the drawing path (AnnotationViewer renders from this
+    // getter), so reading its length here is a cached-getter lookup, not a new
+    // pass over the dataset.
+    passingCount: filterStore.filteredAnnotations.length,
   }),
 );
 

--- a/src/store/filters.ts
+++ b/src/store/filters.ts
@@ -20,6 +20,11 @@ import {
   buildListFilters,
   buildPropertyListFilters,
 } from "@/utils/annotationListFilters";
+import {
+  IActiveConstraint,
+  collectActiveConstraints,
+  countActiveConstraints,
+} from "@/utils/activeConstraints";
 import { createSequenceGuard } from "@/utils/sequenceGuard";
 import { idListSignature } from "@/utils/signatures";
 
@@ -29,7 +34,6 @@ import {
   IAnalysisGateFilterTerm,
   IAnalysisGatePlotRequest,
   IAnalysisPlot,
-  IAnnotationFilter,
   ITagAnnotationFilter,
   IPropertyAnnotationFilter,
   IROIAnnotationFilter,
@@ -661,16 +665,11 @@ export class Filters extends VuexModule {
     }
   }
 
-  // How many gates are narrowing the filtered set. Counted from the plots
-  // rather than from activeAnalysisGateSets so the badge never materializes a
-  // Set per gate just to read its length.
+  // How many gates are narrowing the filtered set. Counted from the shared
+  // constraint list (never from activeAnalysisGateSets, which would
+  // materialize a Set per gate just to read its length).
   get activeAnalysisGateCount(): number {
-    return this.analysisPlots.filter(
-      (plot) =>
-        plot.gateEnabled &&
-        plot.gate !== null &&
-        this.analysisGateIds[plot.id] !== undefined,
-    ).length;
+    return countActiveConstraints(this.activeConstraints, "analysis");
   }
 
   // The gates that actually narrow the filtered set right now, in plot order.
@@ -1294,17 +1293,31 @@ export class Filters extends VuexModule {
   // rendered "Filters: 1" on a button whose panel then displayed nothing —
   // the badge pointed at a filter the user could not find or clear.
   get activeFilterCount() {
-    const countEnabled = (filterList: IAnnotationFilter[]) =>
-      filterList.filter((filter: IAnnotationFilter) => filter.enabled).length;
-    return (
-      (this.tagFilter.enabled ? 1 : 0) +
-      (this.onlyCurrentFrame ? 1 : 0) +
-      (this.selectionFilter.enabled ? 1 : 0) +
-      (main.showAnnotationsFromHiddenLayers ? 0 : 1) +
-      countEnabled(this.propertyFilters) +
-      countEnabled(this.roiFilters) +
-      countEnabled(this.annotationIdFilters)
-    );
+    return countActiveConstraints(this.activeConstraints, "filters");
+  }
+
+  // EVERYTHING narrowing the object set, both panels' worth, as pure data
+  // (see utils/activeConstraints.ts). The two badges above and the
+  // render-coverage HUD's "(N filters applied)" suffix all count this one
+  // list, so a constraint can never be surfaced by one and missed by another.
+  get activeConstraints(): IActiveConstraint[] {
+    return collectActiveConstraints({
+      tagFilter: this.tagFilter,
+      onlyCurrentFrame: this.onlyCurrentFrame,
+      selectionFilter: this.selectionFilter,
+      showAnnotationsFromHiddenLayers: main.showAnnotationsFromHiddenLayers,
+      propertyFilters: this.propertyFilters,
+      roiFilters: this.roiFilters,
+      annotationIdFilters: this.annotationIdFilters,
+      analysisPlots: this.analysisPlots,
+      analysisGateIds: this.analysisGateIds,
+    });
+  }
+
+  // The count the HUD reads: filters AND gates, since both narrow the same set
+  // and the user reading "Showing 826 of 826 in view" cannot tell which did it.
+  get activeConstraintCount(): number {
+    return this.activeConstraints.length;
   }
 
   @Mutation

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -77,6 +77,7 @@ import {
   IAnnotationBrowserConfig,
   IUserStorageQuota,
   TAnnotationBrowserTab,
+  TRequestablePalette,
 } from "./model";
 import {
   buildAnnotationBrowserConfig,
@@ -406,6 +407,12 @@ export class Main extends VuexModule {
 
   isAnnotationPanelOpen: boolean = false;
   annotationBrowserTab: TAnnotationBrowserTab = "objects";
+  // Palettes something has asked App.vue to open, in the order they should be
+  // opened (a companion palette after its host stays open alongside it).
+  // Same escape hatch as isAnnotationPanelOpen, for components with no path to
+  // the palette registry — here, the render-coverage HUD deep inside
+  // ImageViewer. App.vue opens them and clears the list.
+  paletteOpenRequests: TRequestablePalette[] = [];
   annotationPanelBadge: boolean = false;
   isHelpPanelOpen: boolean = false;
   isAnalyzeDialogOpen: boolean = false;
@@ -1341,6 +1348,21 @@ export class Main extends VuexModule {
   public openAnnotationBrowserTab(tab: TAnnotationBrowserTab) {
     this.setAnnotationBrowserTab(tab);
     this.setIsAnnotationPanelOpen(true);
+  }
+
+  @Mutation
+  public setPaletteOpenRequests(palettes: TRequestablePalette[]) {
+    this.paletteOpenRequests = palettes;
+  }
+
+  /**
+   * Ask App.vue to open these palettes (see `paletteOpenRequests`). App.vue
+   * clears the request once it has honoured it, so asking for the same palette
+   * twice in a row still opens it the second time.
+   */
+  @Action
+  public requestPaletteOpen(palettes: TRequestablePalette[]) {
+    this.setPaletteOpenRequests(palettes);
   }
 
   @Mutation

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -443,6 +443,13 @@ export type TTimelapseTrackColoring = "track" | "uniform";
 /** Which tab the Object Browser is showing. */
 export type TAnnotationBrowserTab = "objects" | "connections";
 
+/**
+ * Palettes that a component with no access to App.vue's palette registry may
+ * ask to have opened (see `paletteOpenRequests` in the main store). These are
+ * a subset of App.vue's `PaletteId`, which is where opening actually happens.
+ */
+export type TRequestablePalette = "filtersPanel" | "analysisPanel";
+
 export type TVolumeViewMode = "2d" | "3d";
 
 export type TVolumeBlendMode = "composite" | "mip";

--- a/src/utils/__tests__/activeConstraints.test.ts
+++ b/src/utils/__tests__/activeConstraints.test.ts
@@ -132,6 +132,31 @@ describe("collectActiveConstraints", () => {
     ).toEqual([]);
   });
 
+  it("does not count an enabled values filter whose values list is empty", () => {
+    // Emptying the values textarea deliberately writes `values: []`, which the
+    // filtering path treats as pass-all (filters.ts) and the backend drops
+    // (dropNoOpPropertyFilters). Counting it would make the HUD claim the
+    // counts are narrowed while the viewer shows everything.
+    const noOp = {
+      ...propertyFilter(true, ["p", "Area"]),
+      valuesOrRange: PropertyFilterMode.Values,
+    };
+    expect(
+      collectActiveConstraints(input({ propertyFilters: [noOp] })),
+    ).toEqual([]);
+    expect(
+      collectActiveConstraints(
+        input({ propertyFilters: [{ ...noOp, values: undefined }] }),
+      ),
+    ).toEqual([]);
+    // With values present the same filter narrows, so it is counted again.
+    expect(
+      collectActiveConstraints(
+        input({ propertyFilters: [{ ...noOp, values: [3] }] }),
+      ),
+    ).toHaveLength(1);
+  });
+
   it("counts a gate only once it is enabled, drawn AND resolved", () => {
     const plot = {
       id: "p1",

--- a/src/utils/__tests__/activeConstraints.test.ts
+++ b/src/utils/__tests__/activeConstraints.test.ts
@@ -1,0 +1,291 @@
+/**
+ * The one list every "something is narrowing your objects" surface counts: the
+ * app-bar Filters badge, the app-bar Analysis badge, and the render-coverage
+ * HUD suffix. The counting used to live in the store getters alone, so the HUD
+ * had nothing to read and a restored gate could shrink the HUD's numbers with
+ * no cue anywhere near them.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  IActiveConstraintsInput,
+  collectActiveConstraints,
+  countActiveConstraints,
+  describeAxis,
+  summarizeActiveConstraints,
+} from "@/utils/activeConstraints";
+import { PropertyFilterMode } from "@/store/model";
+
+const GATE = {
+  categoryKeyVersion: 1 as const,
+  vertices: [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+  ],
+  xCategories: null,
+  yCategories: null,
+};
+
+function input(
+  overrides: Partial<IActiveConstraintsInput> = {},
+): IActiveConstraintsInput {
+  return {
+    tagFilter: { id: "tagFilter", exclusive: false, enabled: false, tags: [] },
+    onlyCurrentFrame: false,
+    selectionFilter: {
+      id: "selection",
+      exclusive: true,
+      enabled: false,
+      annotationIds: [],
+    },
+    showAnnotationsFromHiddenLayers: true,
+    propertyFilters: [],
+    roiFilters: [],
+    annotationIdFilters: [],
+    analysisPlots: [],
+    analysisGateIds: {},
+    ...overrides,
+  };
+}
+
+function propertyFilter(enabled: boolean, path: string[]) {
+  return {
+    id: `pf-${path.join("-")}`,
+    exclusive: false,
+    enabled,
+    propertyPath: path,
+    range: { min: 0, max: 5 },
+    valuesOrRange: PropertyFilterMode.Range,
+    values: [],
+  };
+}
+
+// Names come from the properties store in the app; the collectors stay free of
+// it so they can run inside a store getter.
+const resolveName = (path: string[]) =>
+  ({ "p.Area": "Area", "p.PECAM1": "PECAM1" })[path.join(".")] ?? null;
+
+describe("collectActiveConstraints", () => {
+  it("is empty when nothing narrows the object set", () => {
+    expect(collectActiveConstraints(input())).toEqual([]);
+  });
+
+  it("collects every filter kind the Filters panel exposes", () => {
+    const constraints = collectActiveConstraints(
+      input({
+        tagFilter: {
+          id: "tagFilter",
+          exclusive: false,
+          enabled: true,
+          tags: ["nucleus"],
+        },
+        onlyCurrentFrame: true,
+        selectionFilter: {
+          id: "selection",
+          exclusive: true,
+          enabled: true,
+          annotationIds: ["a"],
+        },
+        showAnnotationsFromHiddenLayers: false,
+        propertyFilters: [propertyFilter(true, ["p", "Area"])],
+        roiFilters: [
+          { id: "roi-0", exclusive: false, enabled: true, roi: [] },
+          { id: "roi-1", exclusive: false, enabled: false, roi: [] },
+        ],
+        annotationIdFilters: [
+          {
+            id: "list-0",
+            exclusive: false,
+            enabled: true,
+            annotationIds: ["b"],
+          },
+        ],
+      }),
+    );
+    expect(constraints.map((constraint) => constraint.kind)).toEqual([
+      "tag",
+      "currentFrame",
+      "selection",
+      "hiddenLayers",
+      "property",
+      "roi",
+      "annotationId",
+    ]);
+    expect(
+      constraints.every((constraint) => constraint.source === "filters"),
+    ).toBe(true);
+  });
+
+  it("does not count disabled filters", () => {
+    expect(
+      collectActiveConstraints(
+        input({
+          tagFilter: {
+            id: "tagFilter",
+            exclusive: false,
+            enabled: false,
+            tags: ["nucleus"],
+          },
+          propertyFilters: [propertyFilter(false, ["p", "Area"])],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("counts a gate only once it is enabled, drawn AND resolved", () => {
+    const plot = {
+      id: "p1",
+      xAxis: { type: "property" as const, path: ["p", "Area"] },
+      yAxis: { type: "property" as const, path: ["p", "PECAM1"] },
+      gate: GATE,
+      gateEnabled: true,
+    };
+    // Enabled + drawn but unresolved: an unresolved gate constrains nothing,
+    // so the viewer shows MORE than the final answer — nothing to announce.
+    expect(
+      collectActiveConstraints(input({ analysisPlots: [plot] })),
+    ).toHaveLength(0);
+    expect(
+      collectActiveConstraints(
+        input({ analysisPlots: [{ ...plot, gateEnabled: false }] }),
+      ),
+    ).toHaveLength(0);
+    expect(
+      collectActiveConstraints(
+        input({ analysisPlots: [{ ...plot, gate: null }] }),
+      ),
+    ).toHaveLength(0);
+
+    const constraints = collectActiveConstraints(
+      input({ analysisPlots: [plot], analysisGateIds: { p1: ["a"] } }),
+    );
+    expect(constraints).toHaveLength(1);
+    expect(constraints[0].source).toBe("analysis");
+    expect(constraints[0].kind).toBe("gate");
+  });
+});
+
+describe("countActiveConstraints", () => {
+  const constraints = collectActiveConstraints(
+    input({
+      tagFilter: {
+        id: "tagFilter",
+        exclusive: false,
+        enabled: true,
+        tags: ["nucleus"],
+      },
+      propertyFilters: [propertyFilter(true, ["p", "Area"])],
+      analysisPlots: [
+        {
+          id: "p1",
+          xAxis: null,
+          yAxis: null,
+          gate: GATE,
+          gateEnabled: true,
+        },
+      ],
+      analysisGateIds: { p1: ["a"] },
+    }),
+  );
+
+  it("counts each panel's own constraints separately", () => {
+    expect(countActiveConstraints(constraints, "filters")).toBe(2);
+    expect(countActiveConstraints(constraints, "analysis")).toBe(1);
+  });
+
+  it("counts everything narrowing the set when no panel is given", () => {
+    // The HUD's number: the user reading "826 of 826 in view" cannot tell
+    // which panel did the narrowing, so both count.
+    expect(countActiveConstraints(constraints)).toBe(3);
+  });
+});
+
+describe("describeAxis", () => {
+  it("names categorical axes from the shared axis table", () => {
+    expect(
+      describeAxis({ type: "categorical", key: "tags" }, resolveName),
+    ).toBe("Tags");
+  });
+
+  it("names property axes through the resolver", () => {
+    expect(
+      describeAxis({ type: "property", path: ["p", "Area"] }, resolveName),
+    ).toBe("Area");
+  });
+
+  it("is null for an axis that has not been chosen", () => {
+    expect(describeAxis(null, resolveName)).toBeNull();
+  });
+});
+
+describe("summarizeActiveConstraints", () => {
+  it("names the gate's plane and the filters alongside it", () => {
+    const constraints = collectActiveConstraints(
+      input({
+        tagFilter: {
+          id: "tagFilter",
+          exclusive: false,
+          enabled: true,
+          tags: ["nucleus"],
+        },
+        analysisPlots: [
+          {
+            id: "p1",
+            xAxis: { type: "property", path: ["p", "Area"] },
+            yAxis: { type: "property", path: ["p", "PECAM1"] },
+            gate: GATE,
+            gateEnabled: true,
+          },
+        ],
+        analysisGateIds: { p1: ["a"] },
+      }),
+    );
+    expect(summarizeActiveConstraints(constraints, resolveName)).toBe(
+      "1 tag filter; 1 lasso gate on Area × PECAM1",
+    );
+  });
+
+  it("collapses identical constraints into a pluralized count", () => {
+    const constraints = collectActiveConstraints(
+      input({
+        propertyFilters: [
+          propertyFilter(true, ["p", "Area"]),
+          propertyFilter(true, ["p", "Area"]),
+          propertyFilter(true, ["p", "PECAM1"]),
+        ],
+      }),
+    );
+    expect(summarizeActiveConstraints(constraints, resolveName)).toBe(
+      "2 property filters on Area; 1 property filter on PECAM1",
+    );
+  });
+
+  it("omits the plane of a half-configured gate rather than implying one axis", () => {
+    const constraints = collectActiveConstraints(
+      input({
+        analysisPlots: [
+          {
+            id: "p1",
+            xAxis: { type: "property", path: ["p", "Area"] },
+            yAxis: null,
+            gate: GATE,
+            gateEnabled: true,
+          },
+        ],
+        analysisGateIds: { p1: ["a"] },
+      }),
+    );
+    expect(summarizeActiveConstraints(constraints, resolveName)).toBe(
+      "1 lasso gate",
+    );
+  });
+
+  it("falls back to no property name when the path no longer resolves", () => {
+    const constraints = collectActiveConstraints(
+      input({ propertyFilters: [propertyFilter(true, ["p", "Gone"])] }),
+    );
+    expect(summarizeActiveConstraints(constraints, resolveName)).toBe(
+      "1 property filter",
+    );
+  });
+});

--- a/src/utils/__tests__/renderCoverage.test.ts
+++ b/src/utils/__tests__/renderCoverage.test.ts
@@ -93,6 +93,45 @@ describe("computeRenderCoverage", () => {
     expect(c.constraintLabel).toBeNull();
   });
 
+  it("reports how many objects pass the active constraints", () => {
+    const c = computeRenderCoverage({
+      stubMode: true,
+      viewportShown: 826,
+      viewportTotal: 826,
+      loaded: 708983,
+      constraintCount: 1,
+      passingCount: 289469,
+    });
+    expect(c.passingLabel).toBe(
+      `(${(289469).toLocaleString()} passing filters)`,
+    );
+  });
+
+  it("omits the passing count when nothing is narrowing the set", () => {
+    // With no constraint active the passing count equals the total, so saying
+    // it would just repeat the number on the same line.
+    const c = computeRenderCoverage({
+      stubMode: true,
+      viewportShown: 826,
+      viewportTotal: 826,
+      loaded: 708983,
+      passingCount: 708983,
+    });
+    expect(c.passingLabel).toBeNull();
+  });
+
+  it("omits the passing count when the caller has none to report", () => {
+    const c = computeRenderCoverage({
+      stubMode: true,
+      viewportShown: 826,
+      viewportTotal: 826,
+      loaded: 708983,
+      constraintCount: 1,
+    });
+    expect(c.constraintLabel).toBe("(1 filter applied)");
+    expect(c.passingLabel).toBeNull();
+  });
+
   it("announces active constraints, pluralized", () => {
     // The reported case: a restored lasso gate cut 708,983 to 72,925, so a
     // viewport that visibly held thousands read "826 of 826" — data loss.

--- a/src/utils/__tests__/renderCoverage.test.ts
+++ b/src/utils/__tests__/renderCoverage.test.ts
@@ -83,6 +83,55 @@ describe("computeRenderCoverage", () => {
     expect(c.shownLabel).toBe("No annotations in view");
   });
 
+  it("says nothing about constraints when none is active", () => {
+    const c = computeRenderCoverage({
+      stubMode: true,
+      viewportShown: 826,
+      viewportTotal: 826,
+      loaded: 708983,
+    });
+    expect(c.constraintLabel).toBeNull();
+  });
+
+  it("announces active constraints, pluralized", () => {
+    // The reported case: a restored lasso gate cut 708,983 to 72,925, so a
+    // viewport that visibly held thousands read "826 of 826" — data loss.
+    const one = computeRenderCoverage({
+      stubMode: true,
+      viewportShown: 826,
+      viewportTotal: 826,
+      loaded: 708983,
+      constraintCount: 1,
+    });
+    expect(one.constraintLabel).toBe("(1 filter applied)");
+    expect(one.shownLabel).toBe(
+      `Showing ${(826).toLocaleString()} of ${(826).toLocaleString()} in view`,
+    );
+    expect(
+      computeRenderCoverage({
+        stubMode: true,
+        viewportShown: 826,
+        viewportTotal: 826,
+        loaded: 708983,
+        constraintCount: 3,
+      }).constraintLabel,
+    ).toBe("(3 filters applied)");
+  });
+
+  it("announces constraints outside stub mode too", () => {
+    // The counts are filtered in client mode as well, so the cue cannot be
+    // gated on stub mode.
+    const c = computeRenderCoverage({
+      stubMode: false,
+      viewportShown: 100,
+      viewportTotal: 45000,
+      loaded: 45000,
+      constraintCount: 2,
+    });
+    expect(c.show).toBe(true);
+    expect(c.constraintLabel).toBe("(2 filters applied)");
+  });
+
   it("clamps the fraction to [0, 1]", () => {
     const over = computeRenderCoverage({
       stubMode: true,

--- a/src/utils/activeConstraints.ts
+++ b/src/utils/activeConstraints.ts
@@ -21,6 +21,7 @@ import {
   IPropertyAnnotationFilter,
   IROIAnnotationFilter,
   ITagAnnotationFilter,
+  PropertyFilterMode,
   TAnalysisAxis,
 } from "@/store/model";
 import { CATEGORICAL_AXES } from "@/utils/analysisAxes";
@@ -68,6 +69,17 @@ export interface IActiveConstraintsInput {
 
 const isEnabled = (filter: IAnnotationFilter) => filter.enabled;
 
+// An enabled values-mode filter with an empty values list is a deliberate
+// pass-all: emptying the values textarea writes `values: []` meaning "do not
+// filter" (PropertyFilterHistogram), the client filtering path passes
+// everything for it (filters.ts), and the backend drops it
+// (dropNoOpPropertyFilters). Counting it would announce narrowing that the
+// viewer contradicts — the same reason an unresolved gate is not counted.
+// Range mode always narrows: the client shape always carries numeric bounds.
+const narrowsAnything = (filter: IPropertyAnnotationFilter) =>
+  filter.valuesOrRange !== PropertyFilterMode.Values ||
+  (filter.values?.length ?? 0) > 0;
+
 // Every constraint currently narrowing the object set, Filters panel first
 // then Analysis gates in plot order. `emptyROIFilter` (a region still being
 // drawn) filters nothing yet and is deliberately absent.
@@ -90,7 +102,9 @@ export function collectActiveConstraints(
   if (!input.showAnnotationsFromHiddenLayers) {
     pushFilter("hiddenLayers");
   }
-  for (const filter of input.propertyFilters.filter(isEnabled)) {
+  for (const filter of input.propertyFilters
+    .filter(isEnabled)
+    .filter(narrowsAnything)) {
     constraints.push({
       source: "filters",
       kind: "property",

--- a/src/utils/activeConstraints.ts
+++ b/src/utils/activeConstraints.ts
@@ -1,0 +1,218 @@
+// Everything that narrows the visible object set, in ONE place.
+//
+// Three surfaces report this: the app-bar Filters badge, the app-bar Analysis
+// badge, and the render-coverage HUD ("Showing 826 of 826 in view (1 filter
+// applied)"). They used to be counted independently, which is how a saved
+// lasso gate could narrow 708,983 annotations to 72,925 while the HUD read
+// like data loss — the badge was the only cue and it lives far from the count
+// the user is actually reading. Counting here once means the three cannot
+// drift.
+//
+// Pure data: a constraint records WHAT it is, not how to say it. Rendering a
+// phrase needs the properties store (to name a property path), so it lives in
+// `describeConstraint` / `summarizeActiveConstraints` below, which take a
+// resolver — the collectors stay callable from the filters store without
+// pulling a store dependency into a hot getter.
+
+import {
+  IAnalysisPlot,
+  IAnnotationFilter,
+  IIdAnnotationFilter,
+  IPropertyAnnotationFilter,
+  IROIAnnotationFilter,
+  ITagAnnotationFilter,
+  TAnalysisAxis,
+} from "@/store/model";
+import { CATEGORICAL_AXES } from "@/utils/analysisAxes";
+
+// Which panel owns the constraint — the badge that counts it, and the panel
+// the HUD opens when the user clicks the suffix.
+export type TConstraintSource = "filters" | "analysis";
+
+export type TConstraintKind =
+  | "tag"
+  | "currentFrame"
+  | "selection"
+  | "hiddenLayers"
+  | "property"
+  | "roi"
+  | "annotationId"
+  | "gate";
+
+export interface IActiveConstraint {
+  source: TConstraintSource;
+  kind: TConstraintKind;
+  // Property filters: the path being filtered, so the phrase can name it.
+  propertyPath?: string[];
+  // Gates: the plot's axes, so the phrase can name the plane it was drawn on.
+  xAxis?: TAnalysisAxis | null;
+  yAxis?: TAnalysisAxis | null;
+}
+
+export interface IActiveConstraintsInput {
+  tagFilter: ITagAnnotationFilter;
+  onlyCurrentFrame: boolean;
+  selectionFilter: IIdAnnotationFilter;
+  // The permissive default is `true`; only the non-default (objects on hidden
+  // layers hidden) narrows anything.
+  showAnnotationsFromHiddenLayers: boolean;
+  propertyFilters: IPropertyAnnotationFilter[];
+  roiFilters: IROIAnnotationFilter[];
+  annotationIdFilters: IIdAnnotationFilter[];
+  analysisPlots: IAnalysisPlot[];
+  // Resolved gate ids by plot id. A gate that is enabled and drawn but not yet
+  // resolved constrains nothing (see activeAnalysisGateIdLists), so it is not
+  // counted — the same three-way predicate the gate consumers use.
+  analysisGateIds: { [plotId: string]: string[] | undefined };
+}
+
+const isEnabled = (filter: IAnnotationFilter) => filter.enabled;
+
+// Every constraint currently narrowing the object set, Filters panel first
+// then Analysis gates in plot order. `emptyROIFilter` (a region still being
+// drawn) filters nothing yet and is deliberately absent.
+export function collectActiveConstraints(
+  input: IActiveConstraintsInput,
+): IActiveConstraint[] {
+  const constraints: IActiveConstraint[] = [];
+  const pushFilter = (kind: TConstraintKind) =>
+    constraints.push({ source: "filters", kind });
+
+  if (input.tagFilter.enabled) {
+    pushFilter("tag");
+  }
+  if (input.onlyCurrentFrame) {
+    pushFilter("currentFrame");
+  }
+  if (input.selectionFilter.enabled) {
+    pushFilter("selection");
+  }
+  if (!input.showAnnotationsFromHiddenLayers) {
+    pushFilter("hiddenLayers");
+  }
+  for (const filter of input.propertyFilters.filter(isEnabled)) {
+    constraints.push({
+      source: "filters",
+      kind: "property",
+      propertyPath: filter.propertyPath,
+    });
+  }
+  input.roiFilters.filter(isEnabled).forEach(() => pushFilter("roi"));
+  input.annotationIdFilters
+    .filter(isEnabled)
+    .forEach(() => pushFilter("annotationId"));
+  for (const plot of input.analysisPlots) {
+    if (
+      plot.gateEnabled &&
+      plot.gate !== null &&
+      input.analysisGateIds[plot.id] !== undefined
+    ) {
+      constraints.push({
+        source: "analysis",
+        kind: "gate",
+        xAxis: plot.xAxis,
+        yAxis: plot.yAxis,
+      });
+    }
+  }
+  return constraints;
+}
+
+// How many constraints are active, optionally restricted to one panel's own.
+// Each badge counts what its own panel can show: a Filters badge that counted
+// gates pointed at a filter the user could not find or clear.
+export function countActiveConstraints(
+  constraints: IActiveConstraint[],
+  source?: TConstraintSource,
+): number {
+  return source === undefined
+    ? constraints.length
+    : constraints.filter((constraint) => constraint.source === source).length;
+}
+
+// A noun phrase per constraint, split so a group of identical constraints can
+// be pluralized ("2 property filters on Area") without string surgery.
+export interface IConstraintPhrase {
+  noun: string;
+  qualifier: string;
+}
+
+const KIND_NOUNS: Record<TConstraintKind, string> = {
+  tag: "tag filter",
+  currentFrame: "current-frame filter",
+  selection: "selection filter",
+  hiddenLayers: "hidden-layer filter",
+  property: "property filter",
+  roi: "region filter",
+  annotationId: "object-list filter",
+  gate: "lasso gate",
+};
+
+const CATEGORICAL_AXIS_TEXT = new Map(
+  CATEGORICAL_AXES.map(({ key, text }) => [key, text]),
+);
+
+// Display name for one analysis axis. Property paths need the properties
+// store, so the caller supplies the resolver (the HUD has it; the filters
+// store deliberately does not reach for it in a getter).
+export function describeAxis(
+  axis: TAnalysisAxis | null | undefined,
+  resolvePropertyName: (path: string[]) => string | null,
+): string | null {
+  if (!axis) {
+    return null;
+  }
+  return axis.type === "categorical"
+    ? CATEGORICAL_AXIS_TEXT.get(axis.key) ?? axis.key
+    : resolvePropertyName(axis.path);
+}
+
+export function describeConstraint(
+  constraint: IActiveConstraint,
+  resolvePropertyName: (path: string[]) => string | null,
+): IConstraintPhrase {
+  const noun = KIND_NOUNS[constraint.kind];
+  if (constraint.kind === "property") {
+    const name = constraint.propertyPath
+      ? resolvePropertyName(constraint.propertyPath)
+      : null;
+    return { noun, qualifier: name ? `on ${name}` : "" };
+  }
+  if (constraint.kind === "gate") {
+    const x = describeAxis(constraint.xAxis, resolvePropertyName);
+    const y = describeAxis(constraint.yAxis, resolvePropertyName);
+    // Both axes or neither: "on Area" for a half-configured plot would read as
+    // a one-dimensional gate, which is not a thing.
+    return { noun, qualifier: x && y ? `on ${x} × ${y}` : "" };
+  }
+  return { noun, qualifier: "" };
+}
+
+// "1 lasso gate on Area × PECAM1; 2 property filters on Area" — the tooltip
+// body for the HUD suffix. Identical phrases collapse into one counted entry,
+// in the order the constraints were collected.
+export function summarizeActiveConstraints(
+  constraints: IActiveConstraint[],
+  resolvePropertyName: (path: string[]) => string | null,
+): string {
+  const groups: { phrase: IConstraintPhrase; count: number }[] = [];
+  for (const constraint of constraints) {
+    const phrase = describeConstraint(constraint, resolvePropertyName);
+    const existing = groups.find(
+      (group) =>
+        group.phrase.noun === phrase.noun &&
+        group.phrase.qualifier === phrase.qualifier,
+    );
+    if (existing) {
+      existing.count += 1;
+    } else {
+      groups.push({ phrase, count: 1 });
+    }
+  }
+  return groups
+    .map(({ phrase, count }) => {
+      const noun = count === 1 ? phrase.noun : `${phrase.noun}s`;
+      return `${count} ${noun}${phrase.qualifier ? ` ${phrase.qualifier}` : ""}`;
+    })
+    .join("; ");
+}

--- a/src/utils/renderCoverage.ts
+++ b/src/utils/renderCoverage.ts
@@ -22,6 +22,10 @@ export interface IRenderCoverage {
   totalLabel: string;
   // "(1 filter applied)" — null when nothing is narrowing the object set.
   constraintLabel: string | null;
+  // "(289,469 passing filters)" — how many of the total survive the active
+  // constraints. Null when nothing is narrowing the set (it would just repeat
+  // the total) or when the caller has no count to report.
+  passingLabel: string | null;
 }
 
 export function computeRenderCoverage(input: {
@@ -39,6 +43,10 @@ export function computeRenderCoverage(input: {
   // these are applied, so without saying so "Showing 826 of 826 in view" in a
   // viewport that visibly holds thousands reads as data loss.
   constraintCount?: number;
+  // How many annotations in the whole dataset pass the active constraints.
+  // Shown next to the total so the narrowed population is readable without
+  // opening a panel.
+  passingCount?: number;
 }): IRenderCoverage {
   const {
     stubMode,
@@ -46,6 +54,7 @@ export function computeRenderCoverage(input: {
     viewportTotal,
     loaded,
     constraintCount = 0,
+    passingCount,
   } = input;
   const hasAnnotations = viewportTotal > 0;
   // Show whenever the dataset is in stub mode, OR the render is actively
@@ -77,6 +86,12 @@ export function computeRenderCoverage(input: {
     constraintLabel:
       constraintCount > 0
         ? `(${constraintCount} filter${constraintCount === 1 ? "" : "s"} applied)`
+        : null,
+    // Gated on the same condition as constraintLabel: with nothing narrowing
+    // the set the passing count equals the total and saying so is noise.
+    passingLabel:
+      constraintCount > 0 && passingCount != null
+        ? `(${passingCount.toLocaleString()} passing filters)`
         : null,
   };
 }

--- a/src/utils/renderCoverage.ts
+++ b/src/utils/renderCoverage.ts
@@ -20,6 +20,8 @@ export interface IRenderCoverage {
   shownLabel: string;
   // "708,983 total annotations"
   totalLabel: string;
+  // "(1 filter applied)" — null when nothing is narrowing the object set.
+  constraintLabel: string | null;
 }
 
 export function computeRenderCoverage(input: {
@@ -32,8 +34,19 @@ export function computeRenderCoverage(input: {
   viewportShown: number; // rendered annotations within the actual viewport
   viewportTotal: number; // all annotations within the actual viewport (current frame)
   loaded: number; // total stubs held in memory
+  // Filters AND analysis gates currently narrowing the object set
+  // (filters.activeConstraintCount). Both counts above are computed AFTER
+  // these are applied, so without saying so "Showing 826 of 826 in view" in a
+  // viewport that visibly holds thousands reads as data loss.
+  constraintCount?: number;
 }): IRenderCoverage {
-  const { stubMode, viewportShown, viewportTotal, loaded } = input;
+  const {
+    stubMode,
+    viewportShown,
+    viewportTotal,
+    loaded,
+    constraintCount = 0,
+  } = input;
   const hasAnnotations = viewportTotal > 0;
   // Show whenever the dataset is in stub mode, OR the render is actively
   // downsampling (not everything in the current view is drawn):
@@ -57,5 +70,13 @@ export function computeRenderCoverage(input: {
       ? `Showing ${viewportShown.toLocaleString()} of ${viewportTotal.toLocaleString()} in view`
       : "No annotations in view",
     totalLabel: `${loaded.toLocaleString()} total annotations`,
+    // Deliberately NOT gated on stubMode: the counts are filtered in both
+    // stub and client modes, so the cue has to appear wherever the HUD does.
+    // "filter" covers gates too — the reader is being told their numbers are
+    // narrowed, and the tooltip names which panels did the narrowing.
+    constraintLabel:
+      constraintCount > 0
+        ? `(${constraintCount} filter${constraintCount === 1 ? "" : "s"} applied)`
+        : null,
   };
 }


### PR DESCRIPTION
Closes #1328.

## Problem

The render-coverage HUD prints counts computed **after** filters and analysis gates (`viewportAnnotationCount` / `viewportRenderedCount` come from the id set that already survived them), with nothing to say so. A saved lasso gate restored at load (Area × PECAM1, 72,925 of 708,983) made it read "Showing 826 of 826 in view" in a viewport that visibly held thousands — indistinguishable from data loss. The `1` badge on the Analysis palette icon was showing the whole time and did not prevent the report: it lives at the edge of the window, far from the number being read, and says nothing about the count it explains.

## What changed

**The HUD label carries an active-constraint suffix.**

> Showing 826 of 826 in view **(1 filter applied)**

- Warning-tinted, dotted-underlined, on the same line as the counts it explains.
- Tooltip (also its `aria-label`, since the visible text is only a count): *"Objects are narrowed by 1 lasso gate on Area × PECAM1; 1 tag filter. Click to open Analysis and Filters."*
- Clicking opens the panels owning the active constraints — Analysis first, then Filters, because Filters is a companion palette that hosts alongside Analysis and the other order would close what was just opened.
- Not gated on stub mode, since the counts are filtered in client mode too. It does **not** change *when* the HUD appears: the show rule is still stub mode or active downsampling. A small dataset with a filter and no downsampling never showed the misleading denominator, so forcing the HUD open there would be new noise rather than a fix.

**One list behind all three surfaces.** New `src/utils/activeConstraints.ts` decides what counts as narrowing the object set: `collectActiveConstraints` (pure data — each entry carries its `source`, `kind`, and enough detail to name it later), `countActiveConstraints`, and `describeConstraint` / `summarizeActiveConstraints` for phrasing. `activeFilterCount` and `activeAnalysisGateCount` keep their exact semantics (each badge still counts only what its own panel can show) and now just count that one list; the HUD reads both halves via `activeConstraintCount`. A new narrowing filter that skips the collector is now invisible on all three surfaces rather than on two — that trap is written into the doc and the skill.

Phrasing is deliberately separate from collecting: naming a property path needs the properties store, which shouldn't be pulled into a filters-store getter. It degrades rather than invents — a half-configured gate drops the plane instead of implying a one-dimensional gate, and an unresolvable property path drops the name.

**Reaching the palette registry.** The HUD is mounted deep inside `ImageViewer`, with no path to App.vue's palette state, so it asks through the store: `requestPaletteOpen([...])` sets `paletteOpenRequests`, App.vue opens each in order and clears the list. This generalizes the existing `isAnnotationPanelOpen` hatch used by the Timelapse panel. `TRequestablePalette` is a subset of App.vue's `PaletteId`, so a renamed palette is a compile error rather than a click that silently does nothing.

## Tests

`pnpm test` (3649 tests, 204 files), `pnpm lint:ci`, `pnpm tsc` and `pnpm build` all pass. 20 new tests:

- `src/utils/__tests__/activeConstraints.test.ts` — what counts (every filter kind; disabled rows and a region still being drawn excluded; a gate only when enabled **and** drawn **and** resolved), per-panel vs combined counts, and the phrasing edge cases.
- `src/components/RenderCoverageIndicator.test.ts` — suffix presence/absence, the full sentence including the space that template whitespace handling is free to eat, the tooltip mirrored into `aria-label`, both click targets, and the non-stub-mode case.
- `src/utils/__tests__/renderCoverage.test.ts` — the label itself, pluralized, and outside stub mode.
- `src/App.test.ts` — the request watcher opens every palette named then clears the request; an empty request is a no-op.

Two test-harness traps hit during this and are now recorded in `nimbus-frontend`: a `vi.mock` factory captures the spy it closes over (so `mockClear`, never reassign in `beforeEach`), and a plain-object store mock never fires a watcher (so App.vue's store mock is now `reactive` — otherwise both watcher tests would have passed vacuously).

**Not verified in a live browser** — no backend or dataset available in this environment. The visual claims rest on the component test and the CSS, so the tint and hover state are worth a glance when running locally.

## Docs

New `codebaseDocumentation/ACTIVE_CONSTRAINT_CUES.md` (problem, design, regression checklist), cross-referenced from `ANALYSIS_PANEL.md` and `SERVER_GATING.md` where the "each badge counts only what its own panel can show" prose lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0124dCot4gNFX7PYhXwt1Wn3)_