### PR TITLE
Fix annotation overview raster: attach tile failure hook post-cache

### DIFF
--- a/.agents/skills/nimbus-geojs/SKILL.md
+++ b/.agents/skills/nimbus-geojs/SKILL.md
@@ -23,6 +23,7 @@ GeoJS's annotation layer has several asymmetric, mutating APIs. Each trap below 
 | Clicking a list row shows no connection at high zoom | A connection draws only when BOTH endpoints are displayed; recentering on one leaves the other outside the viewport | Frame both endpoints (`frameCameraInfo`) instead of recentering on one |
 | With an axis unrolled, the camera/hit-test lands exactly one tile-width (or a multiple) away from the object | The draw path offsets each annotation by its grid cell; the other path used the raw frame-local centroid | Put both through `@/utils/unroll` — see "Unrolled coordinates are a third space" |
 | Hover/selection highlight works on one layer and does nothing on another | The second layer rebuilds its features from scratch on every draw and bakes the highlight in at build time, so only the state wired to a rebuild is ever reflected | Give the features a base-style option and restyle them in place — see "Layers that bake style at draw time" |
+| A tile layer silently loads nothing: zero network requests, no errors, later draws/toggles no-ops | `tile.catch`/`tile.then` QUEUES the tile's fetch, and the queue's `needed` predicate requires `tile === cache.get(hash)` — a handler attached inside `_getTile` (pre-`cache.add`) rejects every tile at creation; rejected tiles stay cached with `_queued=true` so nothing ever refetches them | Attach tile promise handlers only post-cache: wrap `_getTileCached`, never `_getTile` — see "Tile promise handlers queue the fetch" |
 
 ## Layers that bake style at draw time
 
@@ -128,6 +129,39 @@ selects nothing; clicking the same spot on the first tile selects it. Verified l
 ## Render gating
 
 `_update` (the WebGL feature-data rebuild) only runs when the layer's `modified()` timestamp advanced. `clearOldAnnotations` marks modified only when it *removes* something; a pure add pass with `update=false` marks nothing → invisible features. Debugging tell: run `layer.modified(); layer.draw()` in the console — if features appear instantly, it's this, not missing data. Guard the `modified()` call on "count actually grew" so pure pans keep the incremental-draw optimization.
+
+## Tile promise handlers queue the fetch — attach post-cache only
+
+GeoJS tiles have a promise-like interface, and it is not passive: `tile.catch(cb)`
+calls `tile.then`, and `then` on a pending unfetched tile runs
+`this._queue.add(this, this.fetch)` — **attaching a handler queues the fetch**.
+The fetch queue's `needed` predicate accepts a tile only if it is already the
+cache's entry for its hash (`tile === cache.get(tile.toString())`), and
+`fetchQueue.add` processes synchronously. Inside `_getTileCached`, `_getTile`
+runs BEFORE `cache.add` — so a failure hook attached in a wrapped `_getTile`
+rejects every tile the instant it is created.
+
+The symptom is total silence: zero network requests, no console errors, and the
+failure is sticky — rejected tiles stay in the cache with `_queued=true`, and
+`_update` never re-queues a tile whose queue position is `-1`, so later draws
+and visibility toggles are no-ops until `layer.reset()` or a template change.
+This shipped as a blank annotation raster overview (review R19): the retry
+subsystem's own hook killed every tile, then consumed its retry budget on
+identical deaths.
+
+Rules:
+
+- Wrap `_getTileCached` (returns only after `cache.add`), never `_getTile`,
+  when you need a per-tile failure signal (there is no tile-error event).
+- Cache hits return the same tile — guard so each tile is hooked once
+  (WeakSet).
+- Unit-test the ordering contract with a mock that mimics create-then-cache
+  and records cache membership at `catch`-attach time
+  (`ImageViewer.test.ts`, `installMockTileFactory`); a mock that just exposes
+  `_getTile` cannot fail on this bug.
+- Diagnose live: `layer.cache._cache` sizes vs `read_network_requests`; the
+  counterfactual `layer.queue._needed = () => true` + `layer.reset()` +
+  `layer.draw()` making tiles load proves this mechanism.
 
 ## Tile URL changes already reset the GeoJS cache
 

--- a/.claude/skills/nimbus-geojs/SKILL.md
+++ b/.claude/skills/nimbus-geojs/SKILL.md
@@ -23,6 +23,7 @@ GeoJS's annotation layer has several asymmetric, mutating APIs. Each trap below 
 | Clicking a list row shows no connection at high zoom | A connection draws only when BOTH endpoints are displayed; recentering on one leaves the other outside the viewport | Frame both endpoints (`frameCameraInfo`) instead of recentering on one |
 | With an axis unrolled, the camera/hit-test lands exactly one tile-width (or a multiple) away from the object | The draw path offsets each annotation by its grid cell; the other path used the raw frame-local centroid | Put both through `@/utils/unroll` — see "Unrolled coordinates are a third space" |
 | Hover/selection highlight works on one layer and does nothing on another | The second layer rebuilds its features from scratch on every draw and bakes the highlight in at build time, so only the state wired to a rebuild is ever reflected | Give the features a base-style option and restyle them in place — see "Layers that bake style at draw time" |
+| A tile layer silently loads nothing: zero network requests, no errors, later draws/toggles no-ops | `tile.catch`/`tile.then` QUEUES the tile's fetch, and the queue's `needed` predicate requires `tile === cache.get(hash)` — a handler attached inside `_getTile` (pre-`cache.add`) rejects every tile at creation; rejected tiles stay cached with `_queued=true` so nothing ever refetches them | Attach tile promise handlers only post-cache: wrap `_getTileCached`, never `_getTile` — see "Tile promise handlers queue the fetch" |
 
 ## Layers that bake style at draw time
 
@@ -128,6 +129,39 @@ selects nothing; clicking the same spot on the first tile selects it. Verified l
 ## Render gating
 
 `_update` (the WebGL feature-data rebuild) only runs when the layer's `modified()` timestamp advanced. `clearOldAnnotations` marks modified only when it *removes* something; a pure add pass with `update=false` marks nothing → invisible features. Debugging tell: run `layer.modified(); layer.draw()` in the console — if features appear instantly, it's this, not missing data. Guard the `modified()` call on "count actually grew" so pure pans keep the incremental-draw optimization.
+
+## Tile promise handlers queue the fetch — attach post-cache only
+
+GeoJS tiles have a promise-like interface, and it is not passive: `tile.catch(cb)`
+calls `tile.then`, and `then` on a pending unfetched tile runs
+`this._queue.add(this, this.fetch)` — **attaching a handler queues the fetch**.
+The fetch queue's `needed` predicate accepts a tile only if it is already the
+cache's entry for its hash (`tile === cache.get(tile.toString())`), and
+`fetchQueue.add` processes synchronously. Inside `_getTileCached`, `_getTile`
+runs BEFORE `cache.add` — so a failure hook attached in a wrapped `_getTile`
+rejects every tile the instant it is created.
+
+The symptom is total silence: zero network requests, no console errors, and the
+failure is sticky — rejected tiles stay in the cache with `_queued=true`, and
+`_update` never re-queues a tile whose queue position is `-1`, so later draws
+and visibility toggles are no-ops until `layer.reset()` or a template change.
+This shipped as a blank annotation raster overview (review R19): the retry
+subsystem's own hook killed every tile, then consumed its retry budget on
+identical deaths.
+
+Rules:
+
+- Wrap `_getTileCached` (returns only after `cache.add`), never `_getTile`,
+  when you need a per-tile failure signal (there is no tile-error event).
+- Cache hits return the same tile — guard so each tile is hooked once
+  (WeakSet).
+- Unit-test the ordering contract with a mock that mimics create-then-cache
+  and records cache membership at `catch`-attach time
+  (`ImageViewer.test.ts`, `installMockTileFactory`); a mock that just exposes
+  `_getTile` cannot fail on this bug.
+- Diagnose live: `layer.cache._cache` sizes vs `read_network_requests`; the
+  counterfactual `layer.queue._needed = () => true` + `layer.reset()` +
+  `layer.draw()` making tiles load proves this mechanism.
 
 ## Tile URL changes already reset the GeoJS cache
 

--- a/codebaseDocumentation/ANNOTATION_RASTER_OVERVIEW-REVIEW.md
+++ b/codebaseDocumentation/ANNOTATION_RASTER_OVERVIEW-REVIEW.md
@@ -240,13 +240,42 @@ Review base: `master` (`da7a9e4e`)
   worse than originally reported — keeps the REJECTED tile in its cache, so
   later draws reuse the failure instead of refetching. Vectors stay
   suppressed while the raster shows holes.
-- **Status:** fixed — the overview layer's `_getTile` factory (the seam GeoJS
-  documents for derived classes) is wrapped at creation so every tile's
-  promise interface reports failures; a failure schedules one bounded retry
-  (max 3 per applied template, 1 s delay matching the server's Retry-After)
-  that runs `layer.reset()` (the only way to purge a rejected cached tile) +
-  redraw + reload tracking. Retries are skipped for unmounted, hidden, or
-  retemplated layers; a new template restores the budget. Retry state lives
-  in WeakMaps outside the GeoJS object (R6 rule). Covered by _"retries
-  failed overview tiles with a bounded delayed reset"_ and _"does not retry
-  tiles for a hidden overview layer"_, verified to fail without the fix.
+- **Status:** fixed — the overview layer's cache-aware tile factory
+  (`_getTileCached`; see R19 for why the pre-cache `_getTile` seam is wrong)
+  is wrapped at creation so every tile's promise interface reports failures;
+  a failure schedules one bounded retry (max 3 per applied template, 1 s
+  delay matching the server's Retry-After) that runs `layer.reset()` (the
+  only way to purge a rejected cached tile) + redraw + reload tracking.
+  Retries are skipped for unmounted, hidden, or retemplated layers; a new
+  template restores the budget. Retry state lives in WeakMaps outside the
+  GeoJS object (R6 rule). Covered by _"retries failed overview tiles with a
+  bounded delayed reset"_ and _"does not retry tiles for a hidden overview
+  layer"_, verified to fail without the fix.
+
+## R19 — Tile failure hook rejected every tile at creation (live regression, 2026-08-26)
+
+- **Severity:** Critical (raster permanently blank; the R18 fix itself caused it)
+- **Location:** `src/components/ImageViewer.vue`
+  (`hookAnnotationOverviewTileErrors`)
+- **Summary:** The R18 fix wrapped `_getTile` and attached `tile.catch(...)`
+  there. In GeoJS, attaching any handler to a tile's promise interface
+  (`tile.catch` → `tile.then`) queues the tile's fetch, and the fetch
+  queue's `needed` predicate only accepts a tile that is already the cache's
+  entry for its hash (`tile === cache.get(hash)`). `_getTile` runs BEFORE
+  `cache.add` inside `_getTileCached`, so every tile was rejected on the
+  spot: zero network requests, each rejection scheduled a retry whose
+  reset+redraw died identically, and after the 3-retry budget the raster
+  went permanently silent (rejected tiles stay cached with `_queued=true`,
+  so later draws and toggles are no-ops). Proven live with instrumentation
+  (41 created / 41 needed-false / 41 rejected) and the counterfactual
+  (`needed = () => true` for one pass → 41 requests, all 200, raster loads).
+- **Status:** fixed — the hook wraps `_getTileCached` instead, which returns
+  only after the tile is in the cache, and hooks each tile exactly once
+  (cache hits return the same tile; a WeakSet guards re-attachment). Retry
+  semantics for genuine failures are unchanged. Covered by the ordering
+  assertion in _"retries failed overview tiles with a bounded delayed
+  reset"_ (the test's tile factory mimics GeoJS's create-then-cache order
+  and records cache membership at `catch`-attach time), verified to fail
+  without the fix. Lesson per `CLAUDE.md`: a review-round fix is a change
+  like any other — re-verify the feature in-browser from a fresh load after
+  the LAST fix, not only after the feature landed.

--- a/codebaseDocumentation/ANNOTATION_RASTER_OVERVIEW.md
+++ b/codebaseDocumentation/ANNOTATION_RASTER_OVERVIEW.md
@@ -634,6 +634,13 @@ Per `CLAUDE.md`, every item names its test:
   retemplated layers do not retry — _"retries failed overview tiles with a
   bounded delayed reset"_ and _"does not retry tiles for a hidden overview
   layer"_.
+- **Failure hook attaches only post-cache**: attaching `tile.catch` queues
+  the tile's fetch, which GeoJS's queue drops unless the tile is already the
+  cache's entry for its hash — so the hook must wrap `_getTileCached`, never
+  the pre-cache `_getTile`, or every tile is rejected at creation and the
+  raster is permanently blank (review R19) — ordering assertion in _"retries
+  failed overview tiles with a bounded delayed reset"_
+  (`catchAttachedWhileInCache`).
 - **Invalidation on every mutation verb**: create, updateMultiple,
   delete, deleteMultiple each change the ETag —
   _"testEveryModelMutationPathInvalidatesEtag"_ and

--- a/src/components/ImageViewer.test.ts
+++ b/src/components/ImageViewer.test.ts
@@ -1354,6 +1354,42 @@ describe("ImageViewer", () => {
       expect(mockedProgressStore.complete).toHaveBeenCalledWith("progress1");
     });
 
+    // Mimic GeoJS's real tile factory ordering (tileLayer in geojs/geo.js):
+    // `_getTileCached` creates the tile via `_getTile` and only AFTER that
+    // adds it to the cache; cache hits return the cached tile. In real GeoJS,
+    // attaching a promise handler (tile.catch → tile.then) queues the tile's
+    // fetch, and the fetch queue's `needed` predicate only accepts a tile
+    // that is already the cache's entry for its hash — a handler attached
+    // pre-cache rejects the tile on the spot and the raster never loads. Each
+    // tile records cache membership at the moment `catch` is attached so the
+    // tests can hold that ordering contract.
+    const installMockTileFactory = (overviewLayer: any) => {
+      const cache = new Map<string, any>();
+      const tileErrorCallbacks: Array<() => void> = [];
+      const catchAttachedWhileInCache: boolean[] = [];
+      overviewLayer._getTile = vi.fn((index: any) => {
+        const hash = `${index.level}_${index.y}_${index.x}`;
+        const tile: any = {
+          toString: () => hash,
+          catch: (callback: () => void) => {
+            catchAttachedWhileInCache.push(cache.get(hash) === tile);
+            tileErrorCallbacks.push(callback);
+          },
+        };
+        return tile;
+      });
+      overviewLayer._getTileCached = vi.fn((index: any) => {
+        const hash = `${index.level}_${index.y}_${index.x}`;
+        let tile = cache.get(hash);
+        if (!tile) {
+          tile = overviewLayer._getTile(index);
+          cache.set(hash, tile);
+        }
+        return tile;
+      });
+      return { tileErrorCallbacks, catchAttachedWhileInCache };
+    };
+
     // A raster tile can 503 while another geometry key is still cold-building
     // (the backend sends Retry-After: 1). GeoJS has no tile-error event, drops
     // the failed tile, and keeps the rejected entry in its tile cache — so
@@ -1361,13 +1397,8 @@ describe("ImageViewer", () => {
     it("retries failed overview tiles with a bounded delayed reset", async () => {
       const map = mockMap();
       const overviewLayer = mockLayer();
-      const tileErrorCallbacks: Array<() => void> = [];
-      const innerGetTile = vi.fn(() => ({
-        catch: (callback: () => void) => {
-          tileErrorCallbacks.push(callback);
-        },
-      }));
-      (overviewLayer as any)._getTile = innerGetTile;
+      const { tileErrorCallbacks, catchAttachedWhileInCache } =
+        installMockTileFactory(overviewLayer);
       map.createLayer.mockReturnValue(overviewLayer);
       const mapentry = {
         map,
@@ -1418,9 +1449,16 @@ describe("ImageViewer", () => {
 
       // Creation wrapped the tile factory: fetching a tile registers a
       // failure hook on the tile's promise interface.
-      (overviewLayer as any)._getTile({ x: 0, y: 0, level: 0 });
-      (overviewLayer as any)._getTile({ x: 1, y: 0, level: 0 });
-      expect(innerGetTile).toHaveBeenCalledTimes(2);
+      (overviewLayer as any)._getTileCached({ x: 0, y: 0, level: 0 });
+      (overviewLayer as any)._getTileCached({ x: 1, y: 0, level: 0 });
+      expect((overviewLayer as any)._getTile).toHaveBeenCalledTimes(2);
+      expect(tileErrorCallbacks).toHaveLength(2);
+      // Ordering contract: the failure hook must attach only once the tile
+      // is the cache's entry for its hash — attaching pre-cache makes the
+      // real fetch queue reject every tile at creation (blank raster).
+      expect(catchAttachedWhileInCache).toEqual([true, true]);
+      // A cache hit returns the same tile; the hook must not re-attach.
+      (overviewLayer as any)._getTileCached({ x: 0, y: 0, level: 0 });
       expect(tileErrorCallbacks).toHaveLength(2);
 
       // Two failures in one batch coalesce into a single delayed retry.
@@ -1459,12 +1497,7 @@ describe("ImageViewer", () => {
     it("does not retry tiles for a hidden overview layer", async () => {
       const map = mockMap();
       const overviewLayer = mockLayer();
-      const tileErrorCallbacks: Array<() => void> = [];
-      (overviewLayer as any)._getTile = vi.fn(() => ({
-        catch: (callback: () => void) => {
-          tileErrorCallbacks.push(callback);
-        },
-      }));
+      const { tileErrorCallbacks } = installMockTileFactory(overviewLayer);
       map.createLayer.mockReturnValue(overviewLayer);
       const mapentry = {
         map,
@@ -1511,7 +1544,7 @@ describe("ImageViewer", () => {
         opacity: 0.6,
       });
 
-      (overviewLayer as any)._getTile({ x: 0, y: 0, level: 0 });
+      (overviewLayer as any)._getTileCached({ x: 0, y: 0, level: 0 });
       tileErrorCallbacks[0]();
       (wrapper.vm as any)._setAnnotationOverviewVisibility(mountedMapentry, {
         visible: false,

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -572,18 +572,28 @@ const annotationOverviewRetryStates = new WeakMap<
 // GeoJS exposes no tile-error event: a failed fetch logs a console warning,
 // removes the tile, and leaves the REJECTED tile in the layer's cache, so
 // later draws reuse the failure instead of refetching. The tile's documented
-// promise interface (`tile.catch`) is the only failure signal, and `_getTile`
-// is the factory GeoJS documents for derived classes to override — wrap it so
-// every tile carries a failure hook. Retry state itself stays out of the
-// GeoJS object (WeakMaps above).
+// promise interface (`tile.catch`) is the only failure signal. Attaching any
+// handler (tile.catch → tile.then) queues the tile's fetch, and the fetch
+// queue's `needed` predicate only accepts a tile that is already the cache's
+// entry for its hash — `_getTile` runs BEFORE `cache.add` inside
+// `_getTileCached`, so hooking `_getTile` rejects every tile at creation
+// (zero requests, permanently blank raster). Wrap `_getTileCached` instead:
+// it returns only after the tile is cached. Cache hits return the same tile,
+// so hook each tile exactly once. Retry state itself stays out of the GeoJS
+// object (WeakMaps above).
+const hookedAnnotationOverviewTiles = new WeakSet<IGeoJSTile>();
+
 function hookAnnotationOverviewTileErrors(layer: AnnotationOverviewLayer) {
-  const originalGetTile = layer._getTile;
-  if (typeof originalGetTile !== "function") {
+  const originalGetTileCached = layer._getTileCached;
+  if (typeof originalGetTileCached !== "function") {
     return;
   }
-  layer._getTile = (...args: unknown[]) => {
-    const tile = originalGetTile.apply(layer, args);
-    tile.catch(() => scheduleAnnotationOverviewRetry(layer));
+  layer._getTileCached = (...args: unknown[]) => {
+    const tile = originalGetTileCached.apply(layer, args);
+    if (!hookedAnnotationOverviewTiles.has(tile)) {
+      hookedAnnotationOverviewTiles.add(tile);
+      tile.catch(() => scheduleAnnotationOverviewRetry(layer));
+    }
     return tile;
   };
 }

--- a/src/store/model.ts
+++ b/src/store/model.ts
@@ -1184,10 +1184,13 @@ export interface IGeoJSOsmLayer extends IGeoJSLayer {
 
   _imageUrls?: (string | undefined)[];
   _tileBounds: (tile: IGeoJSTile) => IGeoJSBounds;
-  // The tile factory GeoJS documents for derived classes to override. Tiles
-  // have a promise-like interface; `catch` is the only failure signal the
-  // library exposes (there is no tile-error event).
-  _getTile?: (
+  // The cache-aware tile factory: creates a tile via `_getTile` and returns
+  // it only after it is the cache's entry for its hash. Tiles have a
+  // promise-like interface; `catch` is the only failure signal the library
+  // exposes (there is no tile-error event). Attaching any handler queues the
+  // tile's fetch, which the fetch queue drops unless the tile is already
+  // cached — so failure hooks must wrap this, never the pre-cache `_getTile`.
+  _getTileCached?: (
     ...args: unknown[]
   ) => IGeoJSTile & { catch: (callback: (reason?: unknown) => void) => void };
   _options?: {


### PR DESCRIPTION
## Problem

The annotation overview raster silently showed nothing on dataset load — no tile requests, no progress bar, no errors. Diagnosed live 2026-08-26 with instrumentation: 41 tiles created, 41 rejected by the fetch queue's `needed` predicate, zero network requests.

The regression came from `6fd11615` (the busy-tile retry fix, last code commit of PR #1312): `hookAnnotationOverviewTileErrors` wrapped `layer._getTile` and called `tile.catch()` on each new tile. In GeoJS, attaching any handler to a tile's promise interface (`tile.catch` → `tile.then`) **queues the tile's fetch**, and the queue's `needed` predicate only accepts a tile that is already the cache's entry for its hash (`tile === cache.get(hash)`). `_getTile` runs *before* `cache.add` inside `_getTileCached`, so every tile was rejected the instant it was created. Each rejection consumed a retry whose reset+redraw died identically; after the 3-retry budget the raster went permanently blank (rejected tiles stay cached with `_queued=true`, so later draws and visibility toggles were no-ops).

## Fix

Wrap `_getTileCached` instead — it returns only after the tile is in the cache — and hook each tile exactly once via a `WeakSet` (cache hits return the same tile object). The retry subsystem is untouched; genuine tile failures still schedule the bounded reset+redraw retry.

Also:
- `IGeoJSOsmLayer` type updated (`_getTile` → `_getTileCached`, with the ordering constraint documented).
- The retry tests' tile-factory mock now mimics GeoJS's real create-then-cache ordering and asserts cache membership at `catch`-attach time (`catchAttachedWhileInCache`), plus an idempotence assertion for cache hits — the old mock structurally could not catch this bug.
- `ANNOTATION_RASTER_OVERVIEW-REVIEW.md` gains R19 documenting the regression; R18's stale `_getTile` wording corrected; regression checklist gains the ordering invariant.
- nimbus-geojs skill gains the "tile promise handlers queue the fetch" trap (both skill trees synced).

## Verification

- `pnpm tsc`, `pnpm lint:ci`, `pnpm test` (3744/3744) all green.
- **In-browser on the 708K-annotation dataset, fresh page load**: 13/13 raster tiles fetch (`/upenn_annotation/raster/` all HTTP 200, two rounds across the `v` mutation bump), layer goes idle with all tiles active, and pixels confirmed via GeoJS compositing (max channel 171).
- **Counterfactual**: with the fix stashed, the same fresh load produces 13 cached tiles, 0 fetched, zero network requests — the exact bug.
- **Real-failure retry path**: pointing the layer at a 404 URL live triggers the bounded retry cadence (repeated reset+refetch, then stops at the budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmrBdRzToNt9nACPFMiSDW