### PR TITLE
Fix [object Object] in image switcher metadata subtitle

### DIFF
--- a/src/components/LargeImageDropdown.test.ts
+++ b/src/components/LargeImageDropdown.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { shallowMount } from "@vue/test-utils";
+
+vi.mock("@/utils/log", () => ({
+  logError: vi.fn(),
+  logWarning: vi.fn(),
+}));
 
 vi.mock("@/store", () => ({
   default: {
@@ -19,10 +24,16 @@ vi.mock("@/girder/index", () => ({
 
 import LargeImageDropdown from "./LargeImageDropdown.vue";
 import store from "@/store";
+import { logError } from "@/utils/log";
 
 function mountComponent() {
   return shallowMount(LargeImageDropdown, {});
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
 
 describe("LargeImageDropdown", () => {
   it("shouldShow is true when largeImages.length > 1", () => {
@@ -103,6 +114,35 @@ describe("LargeImageDropdown", () => {
   it("formatMeta returns an empty string for empty meta, hiding the subtitle", () => {
     const wrapper = mountComponent();
     expect(wrapper.vm.formatMeta({})).toBe("");
+  });
+
+  it("formattedLargeImages precomputes metaText per image", () => {
+    const wrapper = mountComponent();
+    const [original, output] = wrapper.vm.formattedLargeImages;
+    expect(original.metaText).toBe("");
+    expect(output.metaText).toBe("tool: SAM");
+  });
+
+  it("copyMetaText copies the full text and shows transient feedback", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const wrapper = mountComponent();
+    await wrapper.vm.copyMetaText({ _id: "img2", metaText: "tool: SAM" });
+    expect(writeText).toHaveBeenCalledWith("tool: SAM");
+    expect(wrapper.vm.copiedImageId).toBe("img2");
+    vi.advanceTimersByTime(2000);
+    expect(wrapper.vm.copiedImageId).toBe(null);
+  });
+
+  it("copyMetaText logs and shows no feedback when the clipboard fails", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    const wrapper = mountComponent();
+    await wrapper.vm.copyMetaText({ _id: "img2", metaText: "tool: SAM" });
+    expect(logError).toHaveBeenCalled();
+    expect(wrapper.vm.copiedImageId).toBe(null);
   });
 
   it("mounted sets previousNumberOfImages", () => {

--- a/src/components/LargeImageDropdown.test.ts
+++ b/src/components/LargeImageDropdown.test.ts
@@ -68,6 +68,31 @@ describe("LargeImageDropdown", () => {
     );
   });
 
+  it("formatMeta renders nested objects instead of [object Object]", () => {
+    const wrapper = mountComponent();
+    expect(
+      wrapper.vm.formatMeta({
+        tool: "Stitch Refinement",
+        worker_version: "1.0.0",
+        refinement: { method: "cross-correlation", overlap: 0.1 },
+      }),
+    ).toBe(
+      "tool: Stitch Refinement; " +
+        "refinement: {method: cross-correlation, overlap: 0.1}; " +
+        "worker_version: 1.0.0",
+    );
+  });
+
+  it("formatMeta renders arrays and deep nesting", () => {
+    const wrapper = mountComponent();
+    expect(
+      wrapper.vm.formatMeta({
+        channels: [0, 1],
+        source: { item: { name: "Well_2" } },
+      }),
+    ).toBe("channels: [0, 1]; source: {item: {name: Well_2}}");
+  });
+
   it("mounted sets previousNumberOfImages", () => {
     const wrapper = mountComponent();
     expect(wrapper.vm.previousNumberOfImages).toBe(store.allLargeImages.length);

--- a/src/components/LargeImageDropdown.test.ts
+++ b/src/components/LargeImageDropdown.test.ts
@@ -83,6 +83,13 @@ describe("LargeImageDropdown", () => {
     );
   });
 
+  it("formatMeta renders an object-valued tool key without [object Object]", () => {
+    const wrapper = mountComponent();
+    expect(wrapper.vm.formatMeta({ tool: { name: "SAM", version: 2 } })).toBe(
+      "tool: {name: SAM, version: 2}",
+    );
+  });
+
   it("formatMeta renders arrays and deep nesting", () => {
     const wrapper = mountComponent();
     expect(
@@ -91,6 +98,11 @@ describe("LargeImageDropdown", () => {
         source: { item: { name: "Well_2" } },
       }),
     ).toBe("channels: [0, 1]; source: {item: {name: Well_2}}");
+  });
+
+  it("formatMeta returns an empty string for empty meta, hiding the subtitle", () => {
+    const wrapper = mountComponent();
+    expect(wrapper.vm.formatMeta({})).toBe("");
   });
 
   it("mounted sets previousNumberOfImages", () => {

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -7,6 +7,7 @@
       item-title="displayName"
       item-value="_id"
       label="Select Image"
+      :menu-props="{ maxWidth: 560 }"
       density="compact"
       style="width: auto; padding: 4px 0"
       hide-details

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -104,6 +104,19 @@ function formatName(name: string): string {
   return name.replace(/^(.+)\.[^.\s(]+(.*)$/, "$1$2");
 }
 
+function formatMetaValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(formatMetaValue).join(", ")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, nested]) => `${key}: ${formatMetaValue(nested)}`)
+      .join(", ")}}`;
+  }
+  return String(value);
+}
+
 function formatMeta(meta: Record<string, any>): string {
   const pairs: string[] = [];
   if (meta.tool) {
@@ -113,7 +126,7 @@ function formatMeta(meta: Record<string, any>): string {
     .filter(([key]) => key !== "tool")
     .sort(([a], [b]) => a.localeCompare(b))
     .forEach(([key, value]) => {
-      pairs.push(`${key}: ${value}`);
+      pairs.push(`${key}: ${formatMetaValue(value)}`);
     });
   return pairs.join("; ");
 }

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -14,9 +14,9 @@
       <template v-slot:item="{ item: listItem, props: itemProps }">
         <v-list-item v-bind="itemProps">
           <template #title>{{ listItem.displayName }}</template>
-          <template #subtitle v-if="listItem.meta">
+          <template #subtitle v-if="listItem.metaText">
             <span style="font-size: 0.875rem; opacity: 0.7">{{
-              formatMeta(listItem.meta)
+              listItem.metaText
             }}</span>
           </template>
           <template #append v-if="listItem.name !== DEFAULT_LARGE_IMAGE_SOURCE">
@@ -38,10 +38,10 @@
         <div style="flex: 1 1 auto; min-width: 0; white-space: normal">
           <v-list-item-title>{{ listItem.displayName }}</v-list-item-title>
           <v-list-item-subtitle
-            v-if="listItem.meta"
+            v-if="listItem.metaText"
             class="text-medium-emphasis"
             style="white-space: normal; font-size: 0.875rem; opacity: 0.7"
-            >{{ formatMeta(listItem.meta) }}</v-list-item-subtitle
+            >{{ listItem.metaText }}</v-list-item-subtitle
           >
         </div>
       </template>
@@ -94,6 +94,7 @@ const formattedLargeImages = computed(() =>
   largeImages.value.map((img: IGirderLargeImage) => ({
     ...img,
     displayName: formatName(img.name),
+    metaText: img.meta ? formatMeta(img.meta) : "",
   })),
 );
 
@@ -120,7 +121,7 @@ function formatMetaValue(value: unknown): string {
 function formatMeta(meta: Record<string, any>): string {
   const pairs: string[] = [];
   if (meta.tool) {
-    pairs.push(`tool: ${meta.tool}`);
+    pairs.push(`tool: ${formatMetaValue(meta.tool)}`);
   }
   Object.entries(meta)
     .filter(([key]) => key !== "tool")

--- a/src/components/LargeImageDropdown.vue
+++ b/src/components/LargeImageDropdown.vue
@@ -12,15 +12,31 @@
       hide-details
     >
       <template v-slot:item="{ item: listItem, props: itemProps }">
-        <v-list-item v-bind="itemProps">
+        <v-list-item
+          v-bind="itemProps"
+          :lines="listItem.metaText ? 'two' : 'one'"
+        >
           <template #title>{{ listItem.displayName }}</template>
           <template #subtitle v-if="listItem.metaText">
-            <span style="font-size: 0.875rem; opacity: 0.7">{{
-              listItem.metaText
-            }}</span>
+            <span class="meta-text">{{ listItem.metaText }}</span>
           </template>
-          <template #append v-if="listItem.name !== DEFAULT_LARGE_IMAGE_SOURCE">
+          <template #append>
             <v-btn
+              v-if="listItem.metaText"
+              variant="text"
+              icon
+              size="small"
+              class="ml-2"
+              @click.stop="copyMetaText(listItem)"
+            >
+              <v-icon size="small">{{
+                copiedImageId === listItem._id
+                  ? "mdi-check"
+                  : "mdi-content-copy"
+              }}</v-icon>
+            </v-btn>
+            <v-btn
+              v-if="listItem.name !== DEFAULT_LARGE_IMAGE_SOURCE"
               variant="text"
               icon
               size="small"
@@ -37,12 +53,25 @@
       <template v-slot:selection="{ item: listItem }">
         <div style="flex: 1 1 auto; min-width: 0; white-space: normal">
           <v-list-item-title>{{ listItem.displayName }}</v-list-item-title>
-          <v-list-item-subtitle
-            v-if="listItem.metaText"
-            class="text-medium-emphasis"
-            style="white-space: normal; font-size: 0.875rem; opacity: 0.7"
-            >{{ listItem.metaText }}</v-list-item-subtitle
-          >
+          <div v-if="listItem.metaText" class="d-flex align-start">
+            <v-list-item-subtitle class="text-medium-emphasis meta-text">{{
+              listItem.metaText
+            }}</v-list-item-subtitle>
+            <v-btn
+              variant="text"
+              icon
+              size="x-small"
+              class="ml-1 flex-shrink-0"
+              @mousedown.stop
+              @click.stop="copyMetaText(listItem)"
+            >
+              <v-icon size="small">{{
+                copiedImageId === listItem._id
+                  ? "mdi-check"
+                  : "mdi-content-copy"
+              }}</v-icon>
+            </v-btn>
+          </div>
         </div>
       </template>
     </v-select>
@@ -60,7 +89,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from "vue";
+import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import store from "@/store";
 import { IGirderLargeImage } from "@/girder";
 import { DEFAULT_LARGE_IMAGE_SOURCE } from "@/girder/index";
@@ -132,6 +161,31 @@ function formatMeta(meta: Record<string, any>): string {
   return pairs.join("; ");
 }
 
+const copiedImageId = ref<string | null>(null);
+let copyResetTimeout: ReturnType<typeof setTimeout> | null = null;
+
+async function copyMetaText(image: { _id: string; metaText: string }) {
+  try {
+    await navigator.clipboard.writeText(image.metaText);
+  } catch {
+    logError("LargeImageDropdown", "Failed to copy metadata to clipboard");
+    return;
+  }
+  copiedImageId.value = image._id;
+  if (copyResetTimeout !== null) {
+    clearTimeout(copyResetTimeout);
+  }
+  copyResetTimeout = setTimeout(() => {
+    copiedImageId.value = null;
+  }, 1500);
+}
+
+onBeforeUnmount(() => {
+  if (copyResetTimeout !== null) {
+    clearTimeout(copyResetTimeout);
+  }
+});
+
 async function deleteImage(image: IGirderLargeImage) {
   deletingImageId.value = image._id;
   try {
@@ -164,6 +218,24 @@ defineExpose({
   formatName,
   currentLargeImage,
   formatMeta,
+  formattedLargeImages,
+  copyMetaText,
+  copiedImageId,
   previousNumberOfImages,
 });
 </script>
+
+<style lang="scss" scoped>
+// Worker metadata can be arbitrarily long — clamp it to two lines with an
+// ellipsis; the copy button next to it provides the full text.
+.meta-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  white-space: normal;
+  font-size: 0.875rem;
+  opacity: 0.7;
+}
+</style>


### PR DESCRIPTION
## Problem

The image switcher dropdown (`LargeImageDropdown.vue`) shows each image's metadata as a subtitle, but `formatMeta` built the string with plain template interpolation (`` `${key}: ${value}` ``). Worker outputs write nested objects into item metadata — e.g. the Stitch Refinement + Illumination Correction worker writes `illumination`, `parameters`, `refinement`, and `source` as objects — so those rendered as `[object Object]`. Additionally, workers with many parameters produced metadata strings dozens of lines long, stretching the switcher's selected-image display absurdly tall.

## Fix

Added a recursive `formatMetaValue` helper: objects render as `{key: value, ...}` (keys sorted, matching the existing top-level sort), arrays as `[a, b]`, and primitives as before. Both the dropdown list items and the selected-item display go through the same formatting, so one fix covers both.

Follow-up commits:
- **Branch-review fixes:** the special-cased `tool` key (pinned first in the subtitle) also goes through `formatMetaValue`, so an object-valued `tool` can't reintroduce `[object Object]`; and the subtitle is gated on the formatted text being non-empty instead of on the truthy meta object, so images with empty `{}` meta no longer render an empty subtitle. The formatted string is computed once per image in the `formattedLargeImages` computed rather than on every slot render.
- **Length clamp + copy button:** metadata text is clamped to two lines with an ellipsis in both the dropdown items and the selected display, and a small copy button (with transient check-icon feedback) copies the full metadata string to the clipboard for anyone who needs it.

## Tests

Seven regression tests in `LargeImageDropdown.test.ts`: nested objects, arrays and deep nesting, an object-valued `tool` key, empty meta producing an empty string (hiding the subtitle), the precomputed `metaText` mapping, clipboard copy with transient feedback and its timed reset, and clipboard failure logging without feedback. Verified with `pnpm tsc`, `pnpm lint:ci`, and `pnpm vitest run src/components/LargeImageDropdown.test.ts` (15/15 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ysafiAXksH6i1Ep7BcbDt